### PR TITLE
Add xercesImpl 2.11.0 to dependencies.

### DIFF
--- a/.idea/libraries/Maven__xerces_xercesImpl_2_11_0.xml
+++ b/.idea/libraries/Maven__xerces_xercesImpl_2_11_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: xerces:xercesImpl:2.11.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/xerces/xercesImpl/2.11.0/xercesImpl-2.11.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/xerces/xercesImpl/2.11.0/xercesImpl-2.11.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/xerces/xercesImpl/2.11.0/xercesImpl-2.11.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__xml_apis_xml_apis_1_4_01.xml
+++ b/.idea/libraries/Maven__xml_apis_xml_apis_1_4_01.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: xml-apis:xml-apis:1.4.01">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.4.01/xml-apis-1.4.01-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
 
         <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>

--- a/wovn-servlet-filter.iml
+++ b/wovn-servlet-filter.iml
@@ -14,6 +14,8 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
     <orderEntry type="library" name="Maven: net.arnx:jsonic:1.3.10" level="project" />
     <orderEntry type="library" name="Maven: nu.validator:htmlparser:1.4.1" level="project" />
+    <orderEntry type="library" name="Maven: xerces:xercesImpl:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.4.01" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations-java5:15.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />


### PR DESCRIPTION
htmlparser does not work with old xercesImpl. It is not written in its pom.xml. So I wrote the dependency to wovnjava's pom.xml.