### PR TITLE
Support rewriting URL case.

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -113,7 +113,14 @@ class Settings {
         if (param == null || param.isEmpty()) {
             return 0;
         }
-        return Integer.parseInt(param);
+        int n;
+        try {
+            n = Integer.parseInt(param);
+        } catch (NumberFormatException e) {
+            Logger.log.error("NumberFormatException while parsing int parameter", e);
+            n = 0;
+        }
+        return n;
     }
 
     @Contract("null -> null")

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -24,6 +24,8 @@ class Settings {
     String testUrl = "";
     boolean useProxy = false;
     int debugMode = 0;
+    String originalUrlHeader = "";
+    String originalQueryStringHeader = "";
 
     Settings(FilterConfig config) {
         super();
@@ -89,9 +91,19 @@ class Settings {
             this.useProxy = getBoolParameter(p);
         }
 
-        p  = config.getInitParameter("debugMode");
+        p = config.getInitParameter("debugMode");
         if (p != null && !p.isEmpty()) {
             this.debugMode = getIntParameter(p);
+        }
+
+        p = config.getInitParameter("originalUrlHeader");
+        if (p != null && !p.isEmpty()) {
+            this.originalUrlHeader = p;
+        }
+
+        p = config.getInitParameter("originalQueryStringHeader");
+        if (p != null && !p.isEmpty()) {
+            this.originalQueryStringHeader = p;
         }
 
         this.initialize();

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -112,6 +112,27 @@ public class HeadersTest extends TestCase {
         return mock;
     }
 
+    private static FilterConfig mockConfigOriginalHeaders() {
+        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
+        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("query")).andReturn("baz");
+        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
+        EasyMock.replay(mock);
+
+        return mock;
+    }
+
     private static HttpServletRequest mockRequestPath() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(mock.getScheme()).andReturn("https");
@@ -173,6 +194,22 @@ public class HeadersTest extends TestCase {
         EasyMock.replay(mock);
 
         return mock;
+    }
+
+    private static HttpServletRequest mockRequestOriginalHeaders() {
+        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
+        EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
+        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getHeader("REDIRECT_URL")).andReturn("/foo/bar").atLeastOnce();
+        EasyMock.expect(mock.getHeader("REDIRECT_QUERY_STRING")).andReturn("baz=123").atLeastOnce();
+        EasyMock.replay(mock);
+
+        return mock;
+
     }
 
     public void testHeaders() {
@@ -299,5 +336,17 @@ public class HeadersTest extends TestCase {
         Headers h = new Headers(mockRequest, s);
 
         assertEquals("example.com:8080/test", h.pageUrl);
+    }
+
+    public void testOriginalHeaders() {
+        HttpServletRequest mockRequest = mockRequestOriginalHeaders();
+        FilterConfig mockConfig = mockConfigOriginalHeaders();
+
+        Settings s = new Settings(mockConfig);
+        Headers h = new Headers(mockRequest, s);
+
+        assertEquals("/foo/bar", h.pathName);
+        assertEquals("?baz=123", h.query);
+        assertEquals("example.com/foo/bar?baz=123", h.pageUrl);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -23,6 +23,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -41,6 +43,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -59,6 +63,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -78,6 +84,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -97,6 +105,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -22,6 +22,8 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -40,6 +42,8 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -58,6 +62,8 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -24,6 +24,8 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -43,6 +45,8 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("https://example.com");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -62,6 +66,8 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -45,8 +45,8 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("https://example.com");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.replay(mock);
 
         return mock;
@@ -91,6 +91,9 @@ public class SettingsTest extends TestCase {
         assertEquals(supportedLangs, s.supportedLangs);
         assertFalse(s.testMode);
         assertEquals("", s.testUrl);
+
+        assertEquals("", s.originalUrlHeader);
+        assertEquals("", s.originalQueryStringHeader);
     }
     // urlPattern is "subdomain".
     public void testSettingsWithValidConfig() {
@@ -114,6 +117,9 @@ public class SettingsTest extends TestCase {
         assertEquals(supportedLangs, s.supportedLangs);
         assertTrue(s.testMode);
         assertEquals("https://example.com", s.testUrl);
+
+        assertEquals("REDIRECT_URL", s.originalUrlHeader);
+        assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
     }
     public void testSettingsWithQueryConfig() {
         FilterConfig mock = mockQueryConfig();
@@ -162,5 +168,18 @@ public class SettingsTest extends TestCase {
     }
     public void testGetArrayParameterWithEmptyString() {
         assertNull(Settings.getArrayParameter(""));
+    }
+
+    public void testGetIntParamterWithInvalidString() {
+        assertEquals(0, Settings.getIntParameter(null));
+        assertEquals(0, Settings.getIntParameter(""));
+        assertEquals(0, Settings.getIntParameter("a"));
+        assertEquals(0, Settings.getIntParameter("3.14"));
+    }
+    public void testGetIntParameter() {
+        assertEquals(0, Settings.getIntParameter("0"));
+        assertEquals(1, Settings.getIntParameter("1"));
+        assertEquals(2, Settings.getIntParameter("2"));
+        assertEquals(13, Settings.getIntParameter("13"));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -65,6 +65,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -83,6 +85,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -101,6 +105,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
         EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }


### PR DESCRIPTION
There is some case that Apache HTTP Server with mod_rewrite is running in front of Java application. If wovnjava cannot get original URL, wovnjava cannot get translation data from API server. For resolving this problem, I have added "originalUrlHeader" and "originalQueryStringHeader" settings.

You use "REDIRECT_URL" and "REDIRECT_QUERY_STRING" headers or original headers you configured in Apache setting. I will write documentation with some examples.