### PR TITLE
Implment strictHtmlCheck setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ useProxy                  |          | 'false'
 debugMode                 |          | '0'
 originalUrlHeader         |          | ''
 originalQueryStringHeader |          | ''
+strictHtmlCheck           |          | 'false'
 
 ### 2.1. userToken
 
@@ -168,3 +169,15 @@ wovnjava uses URL before rewriting with following setting, and can get correct t
 ※ Above sample of request header setting is referred from following site.
 
 https://coderwall.com/p/jhkw7w/passing-request-uri-into-request-header
+
+### 2.9. strictHtmlCheck
+
+(This is an experimental setting. So it is possible to remove this setting in the future.)
+
+wovnjava with default settings translates only HTML requests and wovnjava determines data type of response body by only Content-Type. When you set true to srictHtmlCheck setting, wovnjava determines data type of response body not only by Content-Type but also by the content of response body. This setting is used when you want to eliminate HTML responses that has wrong Content-Type.
+
+wovnjava determines reponse body as HTML when the response body starts any following strings. wovnjava ignores first comment tags and blanks in response body.
+
+* <?xml
+* <!DOCTYPE
+* <html

--- a/README_ja.md
+++ b/README_ja.md
@@ -89,6 +89,7 @@ useProxy                  |              | 'false'
 debugMode                 |              | '0'
 originalUrlHeader         |              | ''
 originalQueryStringHeader |              | ''
+strictHtmlCheck           |              | 'false'
 
 ※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（userToken と secretKey だけ指定すればライブラリを動作させることができます）
 
@@ -188,3 +189,16 @@ wovnjava は下記の設定で書き換え前の URL を使って、正しい翻
 ※ 上記のリクエストヘッダ設定のサンプルは、下記ページから引用しています。
 
 https://coderwall.com/p/jhkw7w/passing-request-uri-into-request-header
+
+### 2.9. strictHtmlCheck
+
+（これは実験的な機能です。将来的に廃止される可能性があります。）
+
+wovnjava は HTML に対してのみ翻訳処理を行い、その判定は Content-Type ヘッダのチェックによって行っています。strictHtmlCheck の設定を true にすると、Content-Type ヘッダのチェックに加えて、レスポンスボディの内容も翻訳するかどうかのチェックに利用します。本機能は例えば Content-Type は text/html であるけれども、内容は HTML ではないものを翻訳処理から除外したい場合に有効です。
+
+レスポンスボディの最初のコメントタグと空白を除いて、レスポンスボディが下記いずれかで開始している場合に HTML だと判定します。大文字小文字は区別しません。
+
+* <?xml
+* <!DOCTYPE
+* <html
+

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -114,7 +114,7 @@ class Interceptor {
 
                 body = wovnResponse.toString();
 
-                if (isHtml(body)) {
+                if (!this.store.settings.strictHtmlCheck || isHtml(body)) {
 
                     if (Logger.isDebug()) {
                         if (wovnRequest.getQueryString() == null || wovnRequest.getQueryString().isEmpty()) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -163,7 +163,7 @@ class Interceptor {
     }
 
     static boolean isHtml(String body) {
-        return Pattern.compile("(?m)\\A\\s*(<!DOCTYPE|<html)\\b", Pattern.CASE_INSENSITIVE).matcher(body).find();
+        return Pattern.compile("(?m)\\A\\s*(<\\?xml|<!DOCTYPE|<html)\\b", Pattern.CASE_INSENSITIVE).matcher(body).find();
     }
 
     private String addLangCode(String href, String pattern, String lang, Headers headers) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -112,24 +112,28 @@ class Interceptor {
 
             if (!Pattern.compile("^1|302").matcher(status).find()) {
 
-                if (Logger.isDebug()) {
-                    if (wovnRequest.getQueryString() == null || wovnRequest.getQueryString().isEmpty()) {
-                        Logger.log.info("Translating HTML: " + wovnRequest.getRequestURL());
-                    } else {
-                        Logger.log.info("Translating HTML: " + wovnRequest.getRequestURL() + "?" + wovnRequest.getQueryString());
-                    }
-                }
-
-                Values values = store.getValues(h.pageUrl);
-
-                String lang = h.langCode();
-                HashMap<String,String> url = new HashMap<String,String>();
-                url.put("protocol", h.protocol);
-                url.put("host", h.host);
-                url.put("pathname", h.pathName);
-
                 body = wovnResponse.toString();
-                body = this.switchLang(body, values, url, lang, h);
+
+                if (isHtml(body)) {
+
+                    if (Logger.isDebug()) {
+                        if (wovnRequest.getQueryString() == null || wovnRequest.getQueryString().isEmpty()) {
+                            Logger.log.info("Translating HTML: " + wovnRequest.getRequestURL());
+                        } else {
+                            Logger.log.info("Translating HTML: " + wovnRequest.getRequestURL() + "?" + wovnRequest.getQueryString());
+                        }
+                    }
+
+                    String lang = h.langCode();
+                    HashMap<String,String> url = new HashMap<String,String>();
+                    url.put("protocol", h.protocol);
+                    url.put("host", h.host);
+                    url.put("pathname", h.pathName);
+
+                    Values values = store.getValues(h.pageUrl);
+
+                    body = this.switchLang(body, values, url, lang, h);
+                }
                 wovnResponse.setContentLength(body.getBytes().length);
             }
         }
@@ -156,6 +160,10 @@ class Interceptor {
         }
 
         h.out(request, wovnResponse);
+    }
+
+    static boolean isHtml(String body) {
+        return Pattern.compile("(?m)\\A\\s*(<!DOCTYPE\\s+html|<html)", Pattern.CASE_INSENSITIVE).matcher(body).find();
     }
 
     private String addLangCode(String href, String pattern, String lang, Headers headers) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -163,7 +163,7 @@ class Interceptor {
     }
 
     static boolean isHtml(String body) {
-        return Pattern.compile("(?m)\\A\\s*(<!DOCTYPE\\s+html|<html)", Pattern.CASE_INSENSITIVE).matcher(body).find();
+        return Pattern.compile("(?m)\\A\\s*(<!DOCTYPE|<html)\\b", Pattern.CASE_INSENSITIVE).matcher(body).find();
     }
 
     private String addLangCode(String href, String pattern, String lang, Headers headers) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -163,7 +163,38 @@ class Interceptor {
     }
 
     static boolean isHtml(String body) {
-        return Pattern.compile("(?m)\\A\\s*(<\\?xml|<!DOCTYPE|<html)\\b", Pattern.CASE_INSENSITIVE).matcher(body).find();
+        if (Logger.isDebug()) {
+            Logger.log.info("Checking HTML strictly.");
+
+            if (Logger.debugMode > 1) {
+                Logger.log.info("original HTML:\n" + body);
+            }
+        }
+
+        // Remove comments.
+        body = Pattern.compile("(?m)\\A(\\s*<!--[\\s\\S]*?-->\\s*)+").matcher(body).replaceAll("");
+
+        // Remove spaces.
+        body = Pattern.compile("(?m)\\A\\s+").matcher(body).replaceAll("");
+
+        if (Logger.debugMode > 1) {
+            Logger.log.info("HTML after removing comment tags and spaces:\n" + body);
+        }
+
+        if (Pattern.compile("(?m)\\A<\\?xml\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()             // <?xml
+                || Pattern.compile("(?m)\\A<!DOCTYPE\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()    // <!DOCTYPE
+                || Pattern.compile("(?m)\\A<html\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()        // <html
+                ) {
+            if (Logger.isDebug()) {
+                Logger.log.info("This data is HTML.");
+            }
+            return true;
+        } else {
+            if (Logger.isDebug()) {
+                Logger.log.info("This data is not HTML.");
+            }
+            return false;
+        }
     }
 
     private String addLangCode(String href, String pattern, String lang, Headers headers) {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -26,6 +26,7 @@ class Settings {
     int debugMode = 0;
     String originalUrlHeader = "";
     String originalQueryStringHeader = "";
+    boolean strictHtmlCheck = false;
 
     Settings(FilterConfig config) {
         super();
@@ -104,6 +105,11 @@ class Settings {
         p = config.getInitParameter("originalQueryStringHeader");
         if (p != null && !p.isEmpty()) {
             this.originalQueryStringHeader = p;
+        }
+
+        p = config.getInitParameter("strictHtmlCheck");
+        if (p != null && !p.isEmpty()) {
+            this.strictHtmlCheck = getBoolParameter(p);
         }
 
         this.initialize();

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -25,6 +25,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -45,6 +46,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -65,6 +67,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -86,6 +89,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -107,6 +111,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -128,6 +133,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -75,4 +75,40 @@ public class InterceptorTest extends TestCase {
         assertNotNull(interceptor);
     }
 
+    public void testIsHtml() {
+        assertEquals(false, Interceptor.isHtml(""));
+        assertEquals(false, Interceptor.isHtml("html"));
+        assertEquals(false, Interceptor.isHtml("doctype"));
+        assertEquals(false, Interceptor.isHtml("doctype html"));
+
+        assertEquals(true, Interceptor.isHtml("<html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa<html></html>"));
+        assertEquals(true, Interceptor.isHtml("<HTML></HTML>"));
+        assertEquals(true, Interceptor.isHtml(" <html></html>"));
+        assertEquals(true, Interceptor.isHtml("\n<html></html>"));
+        assertEquals(true, Interceptor.isHtml("\r\n<html></html>"));
+        assertEquals(true, Interceptor.isHtml("\n\r<html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \n  <html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \r\n  <html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \n\r  <html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n<html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\r\n<html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n\r<html></html>"));
+
+        assertEquals(true, Interceptor.isHtml("<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!DOCTYPE   html><html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!doctype html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("  <!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("\n<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("\r\n<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("\n\r<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \n  <!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \r\n  <!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("  \n\r  <!DOCTYPE html><html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n<!DOCTYPE html><html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\r\n<!DOCTYPE html><html></html>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n\r<!DOCTYPE html><html></html>"));
+    }
+
 }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -24,6 +24,7 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -44,6 +45,7 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -64,6 +66,7 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -84,6 +84,7 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("html"));
         assertEquals(false, Interceptor.isHtml("doctype"));
         assertEquals(false, Interceptor.isHtml("doctype html"));
+        assertEquals(false, Interceptor.isHtml("<!-- -->"));
 
         assertEquals(true, Interceptor.isHtml("<?xml version=\"1.0\"?>"));
         assertEquals(false, Interceptor.isHtml("<?xmlversion=\"1.0\"?>"));
@@ -98,6 +99,10 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("aaa\n<?xml version=\"1.0\"?>"));
         assertEquals(false, Interceptor.isHtml("aaa\r\n<?xml version=\"1.0\"?>"));
         assertEquals(false, Interceptor.isHtml("aaa\n\r<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("<!-- --><?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\r\n<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n\r<?xml version=\"1.0\"?>"));
 
         assertEquals(true, Interceptor.isHtml("<html></html>"));
         assertEquals(true, Interceptor.isHtml("<html ></html>"));
@@ -114,6 +119,10 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("aaa\n<html></html>"));
         assertEquals(false, Interceptor.isHtml("aaa\r\n<html></html>"));
         assertEquals(false, Interceptor.isHtml("aaa\n\r<html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- --><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n<html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\r\n<html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n\r<html></html>"));
 
         assertEquals(true, Interceptor.isHtml("<!DOCTYPE html><html></html>"));
         assertEquals(false, Interceptor.isHtml("<!DOCTYPEhtml><html></html>"));
@@ -130,6 +139,10 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("aaa\n<!DOCTYPE html><html></html>"));
         assertEquals(false, Interceptor.isHtml("aaa\r\n<!DOCTYPE html><html></html>"));
         assertEquals(false, Interceptor.isHtml("aaa\n\r<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- --><!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\r\n<!DOCTYPE html><html></html>"));
+        assertEquals(true, Interceptor.isHtml("<!-- -->\n\r<!DOCTYPE html><html></html>"));
     }
 
 }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -82,6 +82,8 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("doctype html"));
 
         assertEquals(true, Interceptor.isHtml("<html></html>"));
+        assertEquals(true, Interceptor.isHtml("<html ></html>"));
+        assertEquals(false, Interceptor.isHtml("<html1></html>"));
         assertEquals(false, Interceptor.isHtml("aaa<html></html>"));
         assertEquals(true, Interceptor.isHtml("<HTML></HTML>"));
         assertEquals(true, Interceptor.isHtml(" <html></html>"));
@@ -96,6 +98,7 @@ public class InterceptorTest extends TestCase {
         assertEquals(false, Interceptor.isHtml("aaa\n\r<html></html>"));
 
         assertEquals(true, Interceptor.isHtml("<!DOCTYPE html><html></html>"));
+        assertEquals(false, Interceptor.isHtml("<!DOCTYPEhtml><html></html>"));
         assertEquals(true, Interceptor.isHtml("<!DOCTYPE   html><html></html>"));
         assertEquals(false, Interceptor.isHtml("aaa<!DOCTYPE html><html></html>"));
         assertEquals(true, Interceptor.isHtml("<!doctype html><html></html>"));

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -77,9 +77,24 @@ public class InterceptorTest extends TestCase {
 
     public void testIsHtml() {
         assertEquals(false, Interceptor.isHtml(""));
+        assertEquals(false, Interceptor.isHtml("xml"));
         assertEquals(false, Interceptor.isHtml("html"));
         assertEquals(false, Interceptor.isHtml("doctype"));
         assertEquals(false, Interceptor.isHtml("doctype html"));
+
+        assertEquals(true, Interceptor.isHtml("<?xml version=\"1.0\"?>"));
+        assertEquals(false, Interceptor.isHtml("<?xmlversion=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("<?XML version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("   <?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("\n<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("\r\n<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml("\n\r<?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml(" \n <?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml(" \r\n <?xml version=\"1.0\"?>"));
+        assertEquals(true, Interceptor.isHtml(" \n\r <?xml version=\"1.0\"?>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n<?xml version=\"1.0\"?>"));
+        assertEquals(false, Interceptor.isHtml("aaa\r\n<?xml version=\"1.0\"?>"));
+        assertEquals(false, Interceptor.isHtml("aaa\n\r<?xml version=\"1.0\"?>"));
 
         assertEquals(true, Interceptor.isHtml("<html></html>"));
         assertEquals(true, Interceptor.isHtml("<html ></html>"));

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -26,6 +26,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -47,6 +48,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -68,6 +70,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -67,6 +67,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -87,6 +88,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -107,6 +109,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }


### PR DESCRIPTION
from documentation.

> (This is an experimental setting. So it is possible to remove this setting in the future.)
> 
> wovnjava with default settings translates only HTML requests and wovnjava determines data type of response body by only Content-Type. When you set true to srictHtmlCheck setting, wovnjava determines data type of response body not only by Content-Type but also by the content of response body. This setting is used when you want to eliminate HTML responses that has wrong Content-Type.