### PR TITLE
replacing user_token with project_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ You can see all available versions of wovnjava [here](https://jitpack.io/#wovnio
   <filter-name>wovn</filter-name>
   <filter-class>com.github.wovnio.wovnjava.WovnServletFilter</filter-class>
   <init-param>
-    <param-name>userToken</param-name>
-    <param-value>2Wle3</param-value><!-- set your user token -->
+    <param-name>projectToken</param-name>
+    <param-value>2Wle3</param-value><!-- set your project token -->
   </init-param>
   <init-param>
     <param-name>secretKey</param-name>
@@ -81,7 +81,7 @@ The following parameters can be set within the WOVN.io Java Library.
 
 Parameter Name            | Required | Default Setting
 ------------------------- | -------- | ------------
-userToken                 | yes      | ''
+projectToken                 | yes      | ''
 secretKey                 | yes      | ''
 urlPattern                | yes      | 'path'
 query                     |          | ''
@@ -92,11 +92,11 @@ originalUrlHeader         |          | ''
 originalQueryStringHeader |          | ''
 strictHtmlCheck           |          | 'false'
 
-* A required parameter with a default setting does not need to be set within the web.xml. (Only the userToken and secretKey parameters must be set in order for the library to work)
+* A required parameter with a default setting does not need to be set within the web.xml. (Only the projectToken and secretKey parameters must be set in order for the library to work)
 
-### 2.1. userToken
+### 2.1. projectToken
 
-Set your WOVN.io Account's user token. This parameter is required.
+Set your WOVN.io Account's project token. This parameter is required.
 
 ### 2.2. secretKey
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,7 +59,7 @@ WOVN.io Java ライブラリを使用するためには、WOVN.io のアカウ�
   <filter-name>wovn</filter-name>
   <filter-class>com.github.wovnio.wovnjava.WovnServletFilter</filter-class>
   <init-param>
-    <param-name>userToken</param-name>
+    <param-name>projectToken</param-name>
     <param-value>2Wle3</param-value><!-- ユーザートークンを設定してください。 -->
   </init-param>
   <init-param>
@@ -80,7 +80,7 @@ WOVN.io Java ライブラリに設定可能なパラメータは以下の通り�
 
 パラメータ名              | 必須かどうか | 初期値
 ------------------------- | ------------ | ------------
-userToken                 | yes          | ''
+projectToken                 | yes          | ''
 secretKey                 | yes          | ''
 urlPattern                | yes          | 'path'
 query                     |              | ''
@@ -91,9 +91,9 @@ originalUrlHeader         |              | ''
 originalQueryStringHeader |              | ''
 strictHtmlCheck           |              | 'false'
 
-※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（userToken と secretKey だけ指定すればライブラリを動作させることができます）
+※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（projectToken と secretKey だけ指定すればライブラリを動作させることができます）
 
-### 2.1. userToken
+### 2.1. projectToken
 
 あなたの WOVN.io アカウントのユーザートークンを設定してください。このパラメータは必須です。
 

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -487,7 +487,7 @@ class Interceptor {
         String version = WovnServletFilter.VERSION;
         insertNode.setAttribute(
                 "data-wovnio",
-                "key=" + this.store.settings.userToken + "&backend=true&currentLang=" + lang
+                "key=" + this.store.settings.projectToken + "&backend=true&currentLang=" + lang
                         + "&defaultLang=" + this.store.settings.defaultLang
                         + "&urlPattern=" + this.store.settings.urlPattern + "&version=" + version
         );

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -12,7 +12,7 @@ class Settings {
     static final String UrlPatternRegQuery = "(?:(?:\\?.*&)|\\?)wovn=([^&]+)(?:&|$)";
     static final String UrlPatternRegSubdomain = "^([^.]+)\\.";
 
-    String userToken = "";
+    String projectToken = "";
     String secretKey = "";
     String urlPattern = "path";
     String urlPatternReg = UrlPatternRegPath;
@@ -37,9 +37,9 @@ class Settings {
 
         String p;
 
-        p = config.getInitParameter("userToken");
+        p = config.getInitParameter("projectToken");
         if (p != null && p.length() > 0) {
-            this.userToken = p;
+            this.projectToken = p;
         }
 
         p = config.getInitParameter("secretKey");
@@ -171,9 +171,9 @@ class Settings {
         boolean valid = true;
         ArrayList<String> errors = new ArrayList<String>();
 
-        if (userToken == null || userToken.length() < 5 || userToken.length() > 6) {
+        if (projectToken == null || projectToken.length() < 5 || projectToken.length() > 6) {
             valid = false;
-            errors.add("User token is not valid: " + userToken);
+            errors.add("Project token is not valid: " + projectToken);
         }
         if (secretKey == null || secretKey.length() == 0) {
             valid = false;

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -37,6 +37,11 @@ class Settings {
 
         String p;
 
+        p = config.getInitParameter("userToken");
+        if (p != null && p.length() > 0) {
+            this.projectToken = p;
+        }
+
         p = config.getInitParameter("projectToken");
         if (p != null && p.length() > 0) {
             this.projectToken = p;

--- a/src/main/java/com/github/wovnio/wovnjava/Store.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Store.java
@@ -27,10 +27,10 @@ class Store {
 
         String encodedToken, encodedUrl;
         try {
-            encodedToken = URLEncoder.encode(settings.userToken, "UTF-8");
+            encodedToken = URLEncoder.encode(settings.projectToken, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             Logger.log.error("UnsupportedEncodingException while encoding token", e);
-            encodedToken = settings.userToken;
+            encodedToken = settings.projectToken;
         }
         try {
             encodedUrl = URLEncoder.encode(url, "UTF-8");

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -11,7 +11,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -32,7 +32,7 @@ public class HeadersTest extends TestCase {
     }
     private static FilterConfig mockConfigSubdomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -53,7 +53,7 @@ public class HeadersTest extends TestCase {
     }
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -75,7 +75,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigQueryParameter() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -97,7 +97,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigQueryParameterAAA() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -119,7 +119,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigOriginalHeaders() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -11,6 +11,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
@@ -32,6 +33,7 @@ public class HeadersTest extends TestCase {
     }
     private static FilterConfig mockConfigSubdomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
@@ -53,6 +55,7 @@ public class HeadersTest extends TestCase {
     }
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
@@ -75,6 +78,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigQueryParameter() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
@@ -97,6 +101,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigQueryParameterAAA() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
@@ -119,6 +124,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigOriginalHeaders() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -10,6 +10,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
@@ -31,6 +32,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigSubDomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
@@ -52,6 +54,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -10,7 +10,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -31,7 +31,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigSubDomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -52,7 +52,7 @@ public class InterceptorTest extends TestCase {
 
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -56,6 +56,29 @@ public class SettingsTest extends TestCase {
         return mock;
     }
 
+    private static FilterConfig mockValidConfigMultipleToken() {
+        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("3elW2");
+        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
+        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
+        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
+        EasyMock.expect(mock.getInitParameter("query")).andReturn("foo,bar");
+        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("https://example.com/v0/values");
+        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("ja");
+        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("en,ja");
+        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("true");
+        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("https://example.com");
+        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.replay(mock);
+
+        return mock;
+    }
+
     private static FilterConfig mockQueryConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
@@ -187,5 +210,31 @@ public class SettingsTest extends TestCase {
         assertEquals(1, Settings.getIntParameter("1"));
         assertEquals(2, Settings.getIntParameter("2"));
         assertEquals(13, Settings.getIntParameter("13"));
+    }
+
+    public void testSettingsWithValidConfigMultipleToken() {
+        FilterConfig mock = mockValidConfigMultipleToken();
+        Settings s = new Settings(mock);
+
+        assertNotNull(s);
+        assertEquals("3elW2", s.projectToken);
+        assertEquals("secret", s.secretKey);
+        assertEquals("query", s.urlPattern);
+        assertEquals(Settings.UrlPatternRegQuery, s.urlPatternReg);
+        ArrayList<String> query = new ArrayList<String>();
+        query.add("foo");
+        query.add("bar");
+        assertEquals(query, s.query);
+        assertEquals("https://example.com/v0/values", s.apiUrl);
+        assertEquals("ja", s.defaultLang);
+        ArrayList<String> supportedLangs = new ArrayList<String>();
+        supportedLangs.add("en");
+        supportedLangs.add("ja");
+        assertEquals(supportedLangs, s.supportedLangs);
+        assertTrue(s.testMode);
+        assertEquals("https://example.com", s.testUrl);
+
+        assertEquals("REDIRECT_URL", s.originalUrlHeader);
+        assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -12,7 +12,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockEmptyConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -34,7 +34,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockValidConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
@@ -56,7 +56,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockQueryConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -82,7 +82,7 @@ public class SettingsTest extends TestCase {
         Settings s = new Settings(mock);
 
         assertNotNull(s);
-        assertEquals("", s.userToken);
+        assertEquals("", s.projectToken);
         assertEquals("", s.secretKey);
         assertEquals("path", s.urlPattern);
         assertEquals(Settings.UrlPatternRegPath, s.urlPatternReg);
@@ -104,7 +104,7 @@ public class SettingsTest extends TestCase {
         Settings s = new Settings(mock);
 
         assertNotNull(s);
-        assertEquals("2Wle3", s.userToken);
+        assertEquals("2Wle3", s.projectToken);
         assertEquals("secret", s.secretKey);
         assertEquals("query", s.urlPattern);
         assertEquals(Settings.UrlPatternRegQuery, s.urlPatternReg);

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -12,6 +12,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockEmptyConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
@@ -34,6 +35,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockValidConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
@@ -56,6 +58,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockQueryConfig() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -53,6 +53,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
@@ -74,6 +75,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigSubDomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
@@ -95,6 +97,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -53,7 +53,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -74,7 +74,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigSubDomain() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -95,7 +95,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
     private static FilterConfig mockConfigQuery() {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
For clarity in the communication with user, we need to use the name project token everywhere instead of user token
Related to: https://github.com/WOVNio/equalizer/issues/4057


### Acceptance tests

### Comments

### Release comments (new feature, migrations, indexes)
