### PR TITLE
Keep doctype when translate html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
-  - openjdk6
-

--- a/src/main/java/com/github/wovnio/wovnjava/Doctype.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Doctype.java
@@ -1,62 +1,37 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
 class DoctypeDetectation {
+    private static Pattern pattern = Pattern.compile("<!doctype\\s+html[^>]*>", Pattern.CASE_INSENSITIVE);
+
     public static String addDoctypeIfNotExists(String input, String output)
     {
-        if (normalize(output).contains("<!doctype html")) {
+        if (match(output).matches()) {
             return output;
         }
 
-        String head = normalize(input);
-        for (int i=0; i<htmlDocTypes.length; i++) {
-            String doctypeLowerCase = htmlDocTypesLowerCase[i];
-            if (head.contains(doctypeLowerCase)) {
-                String doctype = htmlDocTypes[i];
-                return doctype + output.replaceFirst(" xmlns=\"http://www.w3.org/1999/xhtml\"", "");
-            }
-        }
-        for (int i=0; i<xhtmlDocTypes.length; i++) {
-            String doctypeLowerCase = xhtmlDocTypesLowerCase[i];
-            if (head.contains(doctypeLowerCase)) {
-                String doctype = xhtmlDocTypes[i];
-                return doctype + output;
-            }
+        Matcher m = match(input);
+        if (!m.find()) {
+            return output;
         }
 
-        return output;
+        String doctype = m.group(0);
+        if (doctype.toLowerCase().contains("xhtml")) {
+            return doctype + output;
+        } else {
+            return doctype + output.replaceFirst(" xmlns=\"http://www.w3.org/1999/xhtml\"", "");
+        }
+    }
+
+    private static Matcher match(String s) {
+        return pattern.matcher(normalize(s));
     }
 
     private static String normalize(String s) {
-        return s.substring(0, Math.min(s.length(), bufferSize)).trim().replaceAll("\\s+", " ").toLowerCase();
+        return s.substring(0, Math.min(s.length(), bufferSize));
     }
-
-    private static String[] htmlDocTypes = {
-        "<!DOCTYPE html>",
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">",
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">",
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\" \"http://www.w3.org/TR/html4/frameset.dtd\">"
-    };
-
-    private static String[] htmlDocTypesLowerCase = {
-        "<!doctype html>",
-        "<!doctype html public \"-//w3c//dtd html 4.01//en\" \"http://www.w3.org/tr/html4/strict.dtd\">",
-        "<!doctype html public \"-//w3c//dtd html 4.01 transitional//en\" \"http://www.w3.org/tr/html4/loose.dtd\">",
-        "<!doctype html public \"-//w3c//dtd html 4.01 frameset//en\" \"http://www.w3.org/tr/html4/frameset.dtd\">"
-    };
-
-    private static String[] xhtmlDocTypes = {
-        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">",
-        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",
-        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">",
-        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">"
-    };
-
-    private static String[] xhtmlDocTypesLowerCase = {
-        "<!doctype html public \"-//w3c//dtd xhtml 1.1//en\" \"http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd\">",
-        "<!doctype html public \"-//w3c//dtd xhtml 1.0 transitional//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-transitional.dtd\">",
-        "<!doctype html public \"-//w3c//dtd xhtml 1.0 strict//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-strict.dtd\">",
-        "<!doctype html public \"-//w3c//dtd xhtml 1.0 frameset//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-frameset.dtd\">"
-    };
 
     private static int bufferSize = 256;
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Doctype.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Doctype.java
@@ -1,0 +1,62 @@
+package com.github.wovnio.wovnjava;
+
+class DoctypeDetectation {
+    public static String addDoctypeIfNotExists(String input, String output)
+    {
+        if (normalize(output).contains("<!doctype html")) {
+            return output;
+        }
+
+        String head = normalize(input);
+        for (int i=0; i<htmlDocTypes.length; i++) {
+            String doctypeLowerCase = htmlDocTypesLowerCase[i];
+            if (head.contains(doctypeLowerCase)) {
+                String doctype = htmlDocTypes[i];
+                return doctype + output.replaceFirst(" xmlns=\"http://www.w3.org/1999/xhtml\"", "");
+            }
+        }
+        for (int i=0; i<xhtmlDocTypes.length; i++) {
+            String doctypeLowerCase = xhtmlDocTypesLowerCase[i];
+            if (head.contains(doctypeLowerCase)) {
+                String doctype = xhtmlDocTypes[i];
+                return doctype + output;
+            }
+        }
+
+        return output;
+    }
+
+    private static String normalize(String s) {
+        return s.substring(0, Math.min(s.length(), bufferSize)).trim().replaceAll("\\s+", " ").toLowerCase();
+    }
+
+    private static String[] htmlDocTypes = {
+        "<!DOCTYPE html>",
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">",
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">",
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\" \"http://www.w3.org/TR/html4/frameset.dtd\">"
+    };
+
+    private static String[] htmlDocTypesLowerCase = {
+        "<!doctype html>",
+        "<!doctype html public \"-//w3c//dtd html 4.01//en\" \"http://www.w3.org/tr/html4/strict.dtd\">",
+        "<!doctype html public \"-//w3c//dtd html 4.01 transitional//en\" \"http://www.w3.org/tr/html4/loose.dtd\">",
+        "<!doctype html public \"-//w3c//dtd html 4.01 frameset//en\" \"http://www.w3.org/tr/html4/frameset.dtd\">"
+    };
+
+    private static String[] xhtmlDocTypes = {
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">",
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">",
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">"
+    };
+
+    private static String[] xhtmlDocTypesLowerCase = {
+        "<!doctype html public \"-//w3c//dtd xhtml 1.1//en\" \"http://www.w3.org/tr/xhtml11/dtd/xhtml11.dtd\">",
+        "<!doctype html public \"-//w3c//dtd xhtml 1.0 transitional//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-transitional.dtd\">",
+        "<!doctype html public \"-//w3c//dtd xhtml 1.0 strict//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-strict.dtd\">",
+        "<!doctype html public \"-//w3c//dtd xhtml 1.0 frameset//en\" \"http://www.w3.org/tr/xhtml1/dtd/xhtml1-frameset.dtd\">"
+    };
+
+    private static int bufferSize = 256;
+}

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -282,7 +282,7 @@ class Interceptor {
         return this.checkWovnIgnore(node.getParentNode());
     }
 
-    private static String getStringFromDocument(Document doc)
+    private static String getStringFromDocument(String body, Document doc)
     {
         try
         {
@@ -293,7 +293,8 @@ class Interceptor {
             Transformer transformer = tf.newTransformer();
             transformer.setOutputProperty(OutputKeys.METHOD, "html");
             transformer.transform(domSource, result);
-            return writer.toString();
+            String html = writer.toString();
+            return DoctypeDetectation.addDoctypeIfNotExists(body, html);
         }
         catch(TransformerException ex)
         {
@@ -301,6 +302,7 @@ class Interceptor {
             return null;
         }
     }
+
     private String switchLang(String body, Values values, HashMap<String, String> url, String lang, Headers headers) {
 
         lang = Lang.getCode(lang);
@@ -321,9 +323,8 @@ class Interceptor {
 
         XPathFactory factory = XPathFactory.newInstance();
         XPath xpath = factory.newXPath();
-
         if (doc.getDocumentElement().hasAttribute("wovn-ignore")) {
-            return getStringFromDocument(doc);
+            return getStringFromDocument(body, doc);
         }
 
         if (!lang.equals(this.store.settings.defaultLang)) {
@@ -504,6 +505,6 @@ class Interceptor {
 
         doc.getDocumentElement().setAttribute("lang", lang);
 
-        return getStringFromDocument(doc);
+        return getStringFromDocument(body, doc);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -168,12 +168,16 @@ public class InterceptorTest extends TestCase {
     }
 
     private void assertDocType(String doctype, String input, String expect) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        assertDocTypeWithCase(doctype, input, expect);
+        assertDocTypeWithCase(doctype.replace(" ", "\n"), input, expect);
+        assertDocTypeWithCase(doctype.replace(" ", "  "), input, expect);
+        assertDocTypeWithCase(doctype.replace(" ", "\n  "), input, expect);
+    }
+
+    private void assertDocTypeWithCase(String doctype, String input, String expect) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         assertEquals(doctype + expect, switchLang(doctype + input));
-        assertEquals(doctype + expect, switchLang(doctype.toUpperCase() + input));
-        assertEquals(doctype + expect, switchLang(doctype.toLowerCase() + input));
-        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "\n") + input));
-        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "  ") + input));
-        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "\n  ") + input));
+        assertEquals(doctype.toUpperCase() + expect, switchLang(doctype.toUpperCase() + input));
+        assertEquals(doctype.toLowerCase() + expect, switchLang(doctype.toLowerCase() + input));
     }
 
     private String switchLang(String html) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -4,7 +4,11 @@ import junit.framework.TestCase;
 
 import org.easymock.EasyMock;
 
+import java.util.HashMap;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
 
 public class InterceptorTest extends TestCase {
 
@@ -148,4 +152,51 @@ public class InterceptorTest extends TestCase {
         assertEquals(true, Interceptor.isHtml("<!-- -->\n\r<!DOCTYPE html><html></html>"));
     }
 
+    public void testDoctype() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        String input = "<html></html>";
+        String html = "<html lang=\"en\"><head><META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script async=\"true\" data-wovnio=\"key=2Wle3&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.1.9\" src=\"//j.wovn.io/1\"> </script></head><body></body></html>";
+        String xhtml = "<html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><head><META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><script async=\"true\" data-wovnio=\"key=2Wle3&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.1.9\" src=\"//j.wovn.io/1\"> </script></head><body></body></html>";
+
+        assertDocType("<!DOCTYPE html>", input, html);
+        assertDocType("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">", input, html);
+        assertDocType("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">", input, html);
+        assertDocType("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\" \"http://www.w3.org/TR/html4/frameset.dtd\">", input, html);
+        assertDocType("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", input, xhtml);
+        assertDocType("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">", input, xhtml);
+        assertDocType("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">", input, xhtml);
+        assertDocType("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">", input, xhtml);
+    }
+
+    private void assertDocType(String doctype, String input, String expect) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        assertEquals(doctype + expect, switchLang(doctype + input));
+        assertEquals(doctype + expect, switchLang(doctype.toUpperCase() + input));
+        assertEquals(doctype + expect, switchLang(doctype.toLowerCase() + input));
+        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "\n") + input));
+        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "  ") + input));
+        assertEquals(doctype + expect, switchLang(doctype.replace(" ", "\n  ") + input));
+    }
+
+    private String switchLang(String html) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Interceptor interceptor = new Interceptor(mockConfigPath());
+        Method method = interceptor.getClass().getDeclaredMethod("switchLang", String.class, Values.class, HashMap.class, String.class, Headers.class);
+        method.setAccessible(true);
+        Values values = new Values("");
+        HashMap<String, String> url = new HashMap<String, String>();
+        String lang = "en";
+        HttpServletRequest mockRequest = mockRequestPath();
+        Headers headers = new Headers(mockRequest, new Settings(mockConfigPath()));
+        return (String)method.invoke(interceptor, html, values, url, lang, headers);
+    }
+
+    private static HttpServletRequest mockRequestPath() {
+        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
+        EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
+        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.replay(mock);
+        return mock;
+    }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #6792)
Relate: https://github.com/WOVNio/equalizer/issues/6792

Keep doctype when translate html.

Because `HtmlDocumentBuilder` that library remove doctype when create DOM tree.

### Comments
Update JDK version in .travis.yml

- Add Open JDK 8  
  Because Oracle JDK 8 is supported.
- Remove Oracle JDK 7  
  Because [that version of the JDK is no longer current ](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html)
- Remove Open JDK 6  
  Because [Sun/Oracle JDK 6 is not provided because it reached End of Life in fall 2012.](https://docs.travis-ci.com/user/reference/precise/)

I confirmed jeff about remove JDK6.

### Release comments (new feature, migrations, indexes)
