### PR TITLE
Hotfix/feature site prefix path

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -245,7 +245,8 @@ class Headers {
             return Pattern.compile("(^|(//))" + lang + "\\.", Pattern.CASE_INSENSITIVE)
                     .matcher(uri).replaceFirst("$1");
         } else {
-            return uri.replaceFirst("/" + lang + "(/|$)", "/");
+            String prefix = this.settings.sitePrefixPathWithSlash;
+            return uri.replaceFirst(prefix + lang + "(/|$)", prefix);
         }
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -18,6 +18,7 @@ class Headers {
     String host;
     private String pathLang;
     String pathName;
+    String pathNameKeepTrailingSlash;
     String protocol;
     String pageUrl;
     String query;
@@ -138,6 +139,7 @@ class Headers {
             this.query = "";
         }
         this.query = this.removeLang(this.query, this.langCode());
+        this.pathNameKeepTrailingSlash = this.pathName;
         this.pathName = Pattern.compile("/$").matcher(this.pathName).replaceAll("");
         this.pageUrl = this.host + this.pathName + this.query;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -517,11 +517,16 @@ class Interceptor {
         insertNode.setAttribute("src", "//j.wovn.io/1");
         insertNode.setAttribute("async", "true");
         String version = WovnServletFilter.VERSION;
+        String sitePrefixPath = "";
+        if (this.store.settings.hasSitePrefixPath) {
+            sitePrefixPath = "&site_prefix_path=" + this.store.settings.sitePrefixPathWithSlash;
+        }
         insertNode.setAttribute(
                 "data-wovnio",
                 "key=" + this.store.settings.projectToken + "&backend=true&currentLang=" + lang
                         + "&defaultLang=" + this.store.settings.defaultLang
                         + "&urlPattern=" + this.store.settings.urlPattern + "&version=" + version
+                        + sitePrefixPath
         );
         insertNode.setTextContent(" ");
         parentNode.insertBefore(insertNode, parentNode.getFirstChild());

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -498,7 +498,7 @@ class Interceptor {
         String version = WovnServletFilter.VERSION;
         String sitePrefixPath = "";
         if (this.store.settings.hasSitePrefixPath) {
-            sitePrefixPath = "&site_prefix_path=" + this.store.settings.sitePrefixPathWithSlash;
+            sitePrefixPath = "&site_prefix_path=" + this.store.settings.sitePrefixPathWithoutSlash;
         }
         insertNode.setAttribute(
                 "data-wovnio",

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -239,7 +239,7 @@ class Interceptor {
                         newHref = href + "?wovn=" + lang;
                     }
                 } else {
-                    newHref = href.replaceFirst("([^\\.]*\\.[^/]*)(/|$)", "$1/" + lang + "/");
+					newHref = addLangToPath(href, lang, headers.getPathLang());
                 }
             }
         } else if (href != null && href.length() > 0) {
@@ -264,16 +264,43 @@ class Interceptor {
                 }
             } else {
                 if (Pattern.compile("^/").matcher(href).find()) {
-                    newHref = "/" + lang + href;
+					newHref = addLangToPath(href, lang, headers.getPathLang());
                 } else {
-                    currentDir = headers.pathName.replaceFirst("[^/]*\\.[^\\.]{2,6}$", "");
-                    newHref = "/" + lang + currentDir + href;
+                    //currentDir = headers.pathName.replaceFirst("[^/]*\\.[^\\.]{2,6}$", "");
+                    currentDir = headers.pathNameKeepTrailingSlash.replaceFirst("[^/]+$", "");
+					newHref = addLangToPath(currentDir + href, lang, headers.getPathLang());
                 }
             }
         }
 
         return newHref;
     }
+
+	private String addLangToPath(String path, String lang, String pathLang) {
+		if (lang == pathLang) {
+			return path;
+		}
+		String prefix = this.store.settings.sitePrefixPathWithSlash;
+		String newPath = prefix + lang + "/";
+		boolean hasPathLang = pathLang.length() > 0;
+		boolean hasPrefix = path.contains(prefix);
+		if (path.length() ==0) {
+			return newPath;
+		}
+		if (hasPrefix) {
+			if(hasPathLang) {
+				return path.replaceFirst(prefix + pathLang + "(/|$)", newPath);
+			} else {
+				return path.replaceFirst(prefix, newPath);
+			}
+		} else {
+			if(hasPathLang) {
+				return path.replaceFirst("/" + pathLang + "(/|$)", newPath);
+			} else {
+				return "/" + lang + "/" + path;
+			}
+		}
+	}
 
     private boolean checkWovnIgnore(Node node) {
         if (node.getAttributes() != null && node.getAttributes().getNamedItem("wovn-ignore") != null) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -239,7 +239,7 @@ class Interceptor {
                         newHref = href + "?wovn=" + lang;
                     }
                 } else {
-					newHref = addLangToPath(href, lang, headers.getPathLang());
+                    newHref = addLangToPath(href, lang, headers.getPathLang());
                 }
             }
         } else if (href != null && href.length() > 0) {
@@ -264,11 +264,11 @@ class Interceptor {
                 }
             } else {
                 if (Pattern.compile("^/").matcher(href).find()) {
-					newHref = addLangToPath(href, lang, headers.getPathLang());
+                    newHref = addLangToPath(href, lang, headers.getPathLang());
                 } else {
                     //currentDir = headers.pathName.replaceFirst("[^/]*\\.[^\\.]{2,6}$", "");
                     currentDir = headers.pathNameKeepTrailingSlash.replaceFirst("[^/]+$", "");
-					newHref = addLangToPath(currentDir + href, lang, headers.getPathLang());
+                    newHref = addLangToPath(currentDir + href, lang, headers.getPathLang());
                 }
             }
         }
@@ -276,31 +276,31 @@ class Interceptor {
         return newHref;
     }
 
-	private String addLangToPath(String path, String lang, String pathLang) {
-		if (lang == pathLang) {
-			return path;
-		}
-		String prefix = this.store.settings.sitePrefixPathWithSlash;
-		String newPath = prefix + lang + "/";
-		boolean hasPathLang = pathLang.length() > 0;
-		boolean hasPrefix = path.contains(prefix);
-		if (path.length() ==0) {
-			return newPath;
-		}
-		if (hasPrefix) {
-			if(hasPathLang) {
-				return path.replaceFirst(prefix + pathLang + "(/|$)", newPath);
-			} else {
-				return path.replaceFirst(prefix, newPath);
-			}
-		} else {
-			if(hasPathLang) {
-				return path.replaceFirst("/" + pathLang + "(/|$)", newPath);
-			} else {
-				return "/" + lang + "/" + path;
-			}
-		}
-	}
+    private String addLangToPath(String path, String lang, String pathLang) {
+        if (lang == pathLang) {
+            return path;
+        }
+        String prefix = this.store.settings.sitePrefixPathWithSlash;
+        String newPath = prefix + lang + "/";
+        boolean hasPathLang = pathLang.length() > 0;
+        boolean hasPrefix = path.contains(prefix);
+        if (path.length() ==0) {
+            return newPath;
+        }
+        if (hasPrefix) {
+            if(hasPathLang) {
+                return path.replaceFirst(prefix + pathLang + "(/|$)", newPath);
+            } else {
+                return path.replaceFirst(prefix, newPath);
+            }
+        } else {
+            if(hasPathLang) {
+                return path.replaceFirst("/" + pathLang + "(/|$)", newPath);
+            } else {
+                return "/" + lang + "/" + path;
+            }
+        }
+    }
 
     private boolean checkWovnIgnore(Node node) {
         if (node.getAttributes() != null && node.getAttributes().getNamedItem("wovn-ignore") != null) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -276,29 +276,9 @@ class Interceptor {
     }
 
     private String addLangToPath(String path, String lang, String pathLang) {
-        if (lang == pathLang) {
-            return path;
-        }
         String prefix = this.store.settings.sitePrefixPathWithSlash;
         String newPath = prefix + lang + "/";
-        boolean hasPathLang = pathLang.length() > 0;
-        boolean hasPrefix = path.contains(prefix);
-        if (path.length() ==0) {
-            return newPath;
-        }
-        if (hasPrefix) {
-            if(hasPathLang) {
-                return path.replaceFirst(prefix + pathLang + "(/|$)", newPath);
-            } else {
-                return path.replaceFirst(prefix, newPath);
-            }
-        } else {
-            if(hasPathLang) {
-                return path.replaceFirst("/" + pathLang + "(/|$)", newPath);
-            } else {
-                return "/" + lang + "/" + path;
-            }
-        }
+        return path.replaceFirst("^" + prefix, newPath);
     }
 
     private boolean checkWovnIgnore(Node node) {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -266,7 +266,6 @@ class Interceptor {
                 if (Pattern.compile("^/").matcher(href).find()) {
                     newHref = addLangToPath(href, lang, headers.getPathLang());
                 } else {
-                    //currentDir = headers.pathName.replaceFirst("[^/]*\\.[^\\.]{2,6}$", "");
                     currentDir = headers.pathNameKeepTrailingSlash.replaceFirst("[^/]+$", "");
                     newHref = addLangToPath(currentDir + href, lang, headers.getPathLang());
                 }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -13,7 +13,8 @@ class Settings {
     static final String UrlPatternRegSubdomain = "^([^.]+)\\.";
 
     String projectToken = "";
-    String sitePrefixPathWithSlash = "";
+    boolean hasSitePrefixPath = false;
+    String sitePrefixPathWithSlash = "/";
     String sitePrefixPathWithoutSlash = "";
     String secretKey = "";
     String urlPattern = "path";
@@ -50,7 +51,8 @@ class Settings {
         }
 
         p = config.getInitParameter("sitePrefixPath");
-        if (p != null && p.length() > 0) {
+        this.hasSitePrefixPath = p != null && p.length() > 0;
+        if (this.hasSitePrefixPath) {
             if (p.endsWith("/")) {
                 this.sitePrefixPathWithSlash = p;
                 this.sitePrefixPathWithoutSlash = p.substring(0, p.length() - 1);
@@ -178,6 +180,10 @@ class Settings {
 
         if (this.urlPattern.equals("path")) {
             this.urlPatternReg = UrlPatternRegPath;
+            String prefix = this.sitePrefixPathWithoutSlash;
+            if (prefix.length() > 0 && !this.urlPatternReg.contains(prefix)) {
+                this.urlPatternReg = prefix +  UrlPatternRegPath;
+            }
         } else if (this.urlPattern.equals("query")) {
             this.urlPatternReg = UrlPatternRegQuery;
         } else if (this.urlPattern.equals("subdomain")) {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -13,6 +13,7 @@ class Settings {
     static final String UrlPatternRegSubdomain = "^([^.]+)\\.";
 
     String projectToken = "";
+    String sitePrefixPath = "";
     String secretKey = "";
     String urlPattern = "path";
     String urlPatternReg = UrlPatternRegPath;
@@ -45,6 +46,11 @@ class Settings {
         p = config.getInitParameter("projectToken");
         if (p != null && p.length() > 0) {
             this.projectToken = p;
+        }
+
+        p = config.getInitParameter("sitePrefixPath");
+        if (p != null && p.length() > 0) {
+            this.sitePrefixPath = p;
         }
 
         p = config.getInitParameter("secretKey");

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -13,7 +13,8 @@ class Settings {
     static final String UrlPatternRegSubdomain = "^([^.]+)\\.";
 
     String projectToken = "";
-    String sitePrefixPath = "";
+    String sitePrefixPathWithSlash = "";
+    String sitePrefixPathWithoutSlash = "";
     String secretKey = "";
     String urlPattern = "path";
     String urlPatternReg = UrlPatternRegPath;
@@ -50,7 +51,13 @@ class Settings {
 
         p = config.getInitParameter("sitePrefixPath");
         if (p != null && p.length() > 0) {
-            this.sitePrefixPath = p;
+            if (p.endsWith("/")) {
+                this.sitePrefixPathWithSlash = p;
+                this.sitePrefixPathWithoutSlash = p.substring(0, p.length() - 1);
+            } else {
+                this.sitePrefixPathWithSlash = p + "/";
+                this.sitePrefixPathWithoutSlash = p;
+            }
         }
 
         p = config.getInitParameter("secretKey");

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -182,7 +182,7 @@ class Settings {
             this.urlPatternReg = UrlPatternRegPath;
             String prefix = this.sitePrefixPathWithoutSlash;
             if (prefix.length() > 0 && !this.urlPatternReg.contains(prefix)) {
-                this.urlPatternReg = prefix +  UrlPatternRegPath;
+                this.urlPatternReg = prefix + UrlPatternRegPath;
             }
         } else if (this.urlPattern.equals("query")) {
             this.urlPatternReg = UrlPatternRegQuery;

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -13,6 +13,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -35,6 +36,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -57,6 +59,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -80,6 +83,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -103,6 +107,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -126,6 +131,7 @@ public class HeadersTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -390,4 +390,16 @@ public class HeadersTest extends TestCase {
         Settings s = makeSettings(option);
         return new Headers(mockRequest, s);
     }
+
+    public void testOriginalHeaders() {
+        HttpServletRequest mockRequest = mockRequestOriginalHeaders();
+        FilterConfig mockConfig = mockConfigOriginalHeaders();
+
+        Settings s = new Settings(mockConfig);
+        Headers h = new Headers(mockRequest, s);
+
+        assertEquals("/foo/bar", h.pathName);
+        assertEquals("?baz=123", h.query);
+        assertEquals("example.com/foo/bar?baz=123", h.pageUrl);
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -4,6 +4,7 @@ import junit.framework.TestCase;
 
 import org.easymock.EasyMock;
 
+import java.util.HashMap;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 
@@ -152,10 +153,13 @@ public class HeadersTest extends TestCase {
     }
 
     private static HttpServletRequest mockRequestPath() {
+        return mockRequestPath("/ja/test");
+    }
+    private static HttpServletRequest mockRequestPath(String path) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(mock.getScheme()).andReturn("https");
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
+        EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
@@ -228,6 +232,24 @@ public class HeadersTest extends TestCase {
 
         return mock;
 
+    }
+
+    private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
+        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck"};
+        for (int i=0; i<keys.length; ++i) {
+            String key = keys[i];
+            String val = option.get(key);
+            val = val == null ? "" : val;
+            EasyMock.expect(mock.getInitParameter(key)).andReturn(val);
+        }
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private static Settings makeSettings(HashMap<String, String> option) {
+        FilterConfig mock = mockSpecificConfig(option);
+        return new Settings(mock);
     }
 
     public void testHeaders() {
@@ -356,15 +378,16 @@ public class HeadersTest extends TestCase {
         assertEquals("example.com:8080/test", h.pageUrl);
     }
 
-    public void testOriginalHeaders() {
-        HttpServletRequest mockRequest = mockRequestOriginalHeaders();
-        FilterConfig mockConfig = mockConfigOriginalHeaders();
+    public void testSitePrefixPath() {
+        Headers h = makeHeader("/global/en/foo", "/global/");
+        assertEquals("/global/", h.removeLang("/global/en/", null));
+        assertEquals("/en/global/", h.removeLang("/en/global/", null));
+    }
 
-        Settings s = new Settings(mockConfig);
-        Headers h = new Headers(mockRequest, s);
-
-        assertEquals("/foo/bar", h.pathName);
-        assertEquals("?baz=123", h.query);
-        assertEquals("example.com/foo/bar?baz=123", h.pageUrl);
+    private Headers makeHeader(String requestPath, String sitePrefix) {
+        HttpServletRequest mockRequest = mockRequestPath(requestPath);
+        HashMap<String, String> option = new HashMap<String, String>(){ { put("sitePrefixPath", "/global/"); } };
+        Settings s = makeSettings(option);
+        return new Headers(mockRequest, s);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -16,6 +16,7 @@ public class InterceptorTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -38,6 +39,7 @@ public class InterceptorTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -60,6 +62,7 @@ public class InterceptorTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -4,6 +4,7 @@ import junit.framework.TestCase;
 
 import org.easymock.EasyMock;
 
+import java.util.HashMap;
 import java.util.ArrayList;
 
 import javax.servlet.FilterConfig;
@@ -104,6 +105,24 @@ public class SettingsTest extends TestCase {
         EasyMock.replay(mock);
 
         return mock;
+    }
+
+    private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
+        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck"};
+        for (int i=0; i<keys.length; ++i) {
+            String key = keys[i];
+            String val = option.get(key);
+            val = val == null ? "" : val;
+            EasyMock.expect(mock.getInitParameter(key)).andReturn(val);
+        }
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private static Settings newSettings(HashMap<String, String> option) {
+        FilterConfig mock = mockSpecificConfig(option);
+        return new Settings(mock);
     }
 
     // urlPattern is "path".
@@ -240,5 +259,21 @@ public class SettingsTest extends TestCase {
 
         assertEquals("REDIRECT_URL", s.originalUrlHeader);
         assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
+    }
+
+    public void testSettingsWithSitePrefixWithTailingSlash() {
+        HashMap<String, String> option = new HashMap<String, String>();
+        option.put("sitePrefixPath", "/global/");
+        Settings s = newSettings(option);
+        assertEquals("/global/", s.sitePrefixPathWithSlash);
+        assertEquals("/global", s.sitePrefixPathWithoutSlash);
+    }
+
+    public void testSettingsWithSitePrefixWithoutTailingSlash() {
+        HashMap<String, String> option = new HashMap<String, String>();
+        option.put("sitePrefixPath", "/global");
+        Settings s = newSettings(option);
+        assertEquals("/global/", s.sitePrefixPathWithSlash);
+        assertEquals("/global", s.sitePrefixPathWithoutSlash);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -14,6 +14,7 @@ public class SettingsTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -37,6 +38,7 @@ public class SettingsTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
@@ -60,6 +62,7 @@ public class SettingsTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("3elW2");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
@@ -83,6 +86,7 @@ public class SettingsTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -261,18 +261,19 @@ public class SettingsTest extends TestCase {
         assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
     }
 
-    public void testSettingsWithSitePrefixWithTailingSlash() {
+    public void testSettingsWithoutSitePrefix() {
+        HashMap<String, String> option = new HashMap<String, String>();
+        Settings s = newSettings(option);
+        assertFalse(s.hasSitePrefixPath);
+        assertEquals("/", s.sitePrefixPathWithSlash);
+        assertEquals("", s.sitePrefixPathWithoutSlash);
+    }
+
+    public void testSettingsWithSitePrefix() {
         HashMap<String, String> option = new HashMap<String, String>();
         option.put("sitePrefixPath", "/global/");
         Settings s = newSettings(option);
-        assertEquals("/global/", s.sitePrefixPathWithSlash);
-        assertEquals("/global", s.sitePrefixPathWithoutSlash);
-    }
-
-    public void testSettingsWithSitePrefixWithoutTailingSlash() {
-        HashMap<String, String> option = new HashMap<String, String>();
-        option.put("sitePrefixPath", "/global");
-        Settings s = newSettings(option);
+        assertTrue(s.hasSitePrefixPath);
         assertEquals("/global/", s.sitePrefixPathWithSlash);
         assertEquals("/global", s.sitePrefixPathWithoutSlash);
     }

--- a/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
@@ -135,6 +135,7 @@ public class TranslateTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -55,6 +55,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -77,6 +78,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
@@ -99,6 +101,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
         EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
         EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
         EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
         EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");


### PR DESCRIPTION
Create `site_prefix_path` feature.

I explain this feature.
Normally, WOVN change URL `/global/index.html`  to `/fr/global/index.html`.
If user put `sitePrefixPath` and `/global` to settings, WOVN change URL `/global/index.html`  to `/global/fr/index.html`.
