### PR TITLE
Implement deleteInvalidClosingTag option

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/FixHtml.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FixHtml.java
@@ -1,0 +1,19 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+class FixHtml {
+    private static Pattern selfClosingPattern = Pattern.compile("</(?:area|base|br|col|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)>", Pattern.CASE_INSENSITIVE);
+
+    public static String deleteClosingTagIfNeed(String html)
+    {
+        if (html.substring(0, Math.min(html.length(), bufferSize)).contains("-//W3C//DTD XHTML")) {
+            return html;
+        }
+        Matcher m = selfClosingPattern.matcher(html);
+        return m.replaceAll("");
+    }
+
+    private static int bufferSize = 256;
+}

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -290,7 +290,7 @@ class Interceptor {
         return this.checkWovnIgnore(node.getParentNode());
     }
 
-    private static String getStringFromDocument(String body, Document doc)
+    private static String getStringFromDocument(String body, Document doc, Settings settings)
     {
         try
         {
@@ -302,7 +302,11 @@ class Interceptor {
             transformer.setOutputProperty(OutputKeys.METHOD, "html");
             transformer.transform(domSource, result);
             String html = writer.toString();
-            return DoctypeDetectation.addDoctypeIfNotExists(body, html);
+            html = DoctypeDetectation.addDoctypeIfNotExists(body, html);
+            if (settings.deleteInvalidClosingTag) {
+                html = FixHtml.deleteClosingTagIfNeed(html);
+            }
+            return html;
         }
         catch(TransformerException ex)
         {
@@ -332,7 +336,7 @@ class Interceptor {
         XPathFactory factory = XPathFactory.newInstance();
         XPath xpath = factory.newXPath();
         if (doc.getDocumentElement().hasAttribute("wovn-ignore")) {
-            return getStringFromDocument(body, doc);
+            return getStringFromDocument(body, doc, this.store.settings);
         }
 
         changeUrlToPunyCode(doc);
@@ -520,7 +524,7 @@ class Interceptor {
 
         doc.getDocumentElement().setAttribute("lang", lang);
 
-        return getStringFromDocument(body, doc);
+        return getStringFromDocument(body, doc, this.store.settings);
     }
 
     private final Pattern extractDomain = Pattern.compile("(?:https?:)?//([^/]+)");

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -26,6 +26,7 @@ class Settings {
     boolean testMode = false;
     String testUrl = "";
     boolean useProxy = false;
+    boolean deleteInvalidClosingTag = false;
     int debugMode = 0;
     String originalUrlHeader = "";
     String originalQueryStringHeader = "";
@@ -130,6 +131,11 @@ class Settings {
         p = config.getInitParameter("strictHtmlCheck");
         if (p != null && !p.isEmpty()) {
             this.strictHtmlCheck = getBoolParameter(p);
+        }
+
+        p = config.getInitParameter("deleteInvalidClosingTag");
+        if (p != null && !p.isEmpty()) {
+            this.deleteInvalidClosingTag = getBoolParameter(p);
         }
 
         this.initialize();

--- a/src/test/java/com/github/wovnio/wovnjava/FixHtmlTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FixHtmlTest.java
@@ -1,0 +1,49 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+
+
+public class FixHtmlTest extends TestCase {
+	public void testDeleteInvalidClosingTag() {
+		String html = "<!DOCTYPE html>"
+			+ "<html>"
+			+ "<head>"
+			+ "<meta content=\"b\" name=\"a\"></meta>"
+			+ "</head>"
+			+ "<body>"
+			+ "</area>"
+			+ "</base>"
+			+ "</br>"
+			+ "</col>"
+			+ "</embed>"
+			+ "</hr>"
+			+ "</img>"
+			+ "</input>"
+			+ "</keygen>"
+			+ "</link>"
+			+ "</param>"
+			+ "</source>"
+			+ "</track>"
+			+ "</wbr>"
+			+ "<area></area>"
+			+ "<base></base>"
+			+ "<br></br>"
+			+ "<col></col>"
+			+ "<embed></embed>"
+			+ "<hr></hr>"
+			+ "<img></img>"
+			+ "<input></input>"
+			+ "<keygen></keygen>"
+			+ "<link></link>"
+			+ "<meta></meta>"
+			+ "<param></param>"
+			+ "<source></source>"
+			+ "<track></track>"
+			+ "<wbr></wbr>"
+			+ "</body>"
+			+ "</html>";
+        String result = FixHtml.deleteClosingTagIfNeed(html);
+        String expect = "<!DOCTYPE html><html><head><meta content=\"b\" name=\"a\"></head><body><area><base><br><col><embed><hr><img><input><keygen><link><meta><param><source><track><wbr></body></html>";
+        assertEquals(expect, result);
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -29,6 +29,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -52,6 +53,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -75,6 +77,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -99,6 +102,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -123,6 +127,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -147,6 +152,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -236,7 +242,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -12,32 +12,9 @@ import javax.servlet.http.HttpServletRequest;
 
 public class InterceptorTest extends TestCase {
 
-    private static FilterConfig mockConfigPath() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.replay(mock);
-        return mock;
-    }
-
     private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);
@@ -46,6 +23,15 @@ public class InterceptorTest extends TestCase {
         }
         EasyMock.replay(mock);
         return mock;
+    }
+
+    private static FilterConfig mockConfigPath() {
+        HashMap<String, String> option = new HashMap<String, String>(){ {
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+        } };
+        return mockSpecificConfig(option);
     }
 
     public void testInterceptor() {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -30,6 +30,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -54,6 +55,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -78,6 +80,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -102,6 +105,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -109,7 +113,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);

--- a/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
@@ -150,6 +150,7 @@ public class TranslateTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -70,6 +70,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -93,6 +94,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -116,6 +118,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }


### PR DESCRIPTION
I found problem that appear extra invalid closing tag if to use [saxon](http://saxon.sourceforge.net/).
For example.

```
# normal
<!doctype html><html lang="ja">
<head>
<title>Link changing test</title>
<meta content="test" name="author">
</head>
 
<body>
hello
<br>
</body>
</html>
```


```
# `</meta>` and `</br>` are extra
<!doctype html><html lang="ja">
<head>
<title>Link changing test</title>
<meta content="test" name="author"></meta>
</head>
 
<body>
hello
<br></br>
</body>
</html>
```

I guess it is take times to investigate, so I added `deleteInvalidClosingTag` option for temporary solution.