### PR TITLE
Hotfix/delete invalid utf8

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -10,11 +10,6 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.net.IDN;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
-import java.nio.charset.CharacterCodingException;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -322,11 +317,7 @@ class Interceptor {
 
     private String switchLang(String body, Values values, HashMap<String, String> url, String lang, Headers headers) {
         if (this.store.settings.deleteInvalidUTF8) {
-            try {
-                body = deleteInvalidUTF8(body);
-            } catch (CharacterCodingException e) {
-                Logger.log.error("Failed delete invalid UTF8 ", e);
-            }
+            body = deleteInvalidUTF8(body);
         }
         if (this.store.settings.deleteInvalidClosingTag) {
             FixJavaScript fjs = new FixJavaScript(body);
@@ -337,7 +328,7 @@ class Interceptor {
         }
     }
 
-    private String deleteInvalidUTF8(String src) throws CharacterCodingException {
+    private String deleteInvalidUTF8(String src) {
         return src.replaceAll("[^\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A0-\\uD7FF\\uE000-\\uFFFC\\x{10000}-\\x{10FFFF}]", "");
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -31,6 +31,7 @@ class Settings {
     String originalUrlHeader = "";
     String originalQueryStringHeader = "";
     boolean strictHtmlCheck = false;
+    boolean deleteInvalidUTF8 = false;
 
     Settings(FilterConfig config) {
         super();
@@ -131,6 +132,11 @@ class Settings {
         p = config.getInitParameter("strictHtmlCheck");
         if (p != null && !p.isEmpty()) {
             this.strictHtmlCheck = getBoolParameter(p);
+        }
+
+        p = config.getInitParameter("deleteInvalidUTF8");
+        if (p != null && !p.isEmpty()) {
+            this.deleteInvalidUTF8 = getBoolParameter(p);
         }
 
         p = config.getInitParameter("deleteInvalidClosingTag");

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -30,6 +30,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -54,6 +55,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -78,6 +80,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -103,6 +106,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -128,6 +132,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -153,6 +158,7 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -242,7 +248,7 @@ public class HeadersTest extends TestCase {
 
     private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -31,6 +31,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -56,6 +57,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -81,6 +83,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -106,6 +109,7 @@ public class SettingsTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
 
         return mock;
@@ -113,7 +117,7 @@ public class SettingsTest extends TestCase {
 
     private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);

--- a/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TranslateTest.java
@@ -151,6 +151,7 @@ public class TranslateTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -71,6 +71,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -95,6 +96,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }
@@ -119,6 +121,7 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
         EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
         EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
         EasyMock.replay(mock);
         return mock;
     }


### PR DESCRIPTION
Related https://github.com/WOVNio/wovnjava/pull/63

When to use saxon, throw `net.sf.saxon.trans.XPathException: Illegal HTML character: decimal` if response html include specific UTF character such as some controll code.

For example
Exception
```
Recoverable error 
  SERE0014: Illegal HTML character: decimal 129
net.sf.saxon.trans.XPathException: Illegal HTML character: decimal 129
	at net.sf.saxon.serialize.HTMLEmitter.writeEscape(HTMLEmitter.java:373)
	at net.sf.saxon.serialize.XMLEmitter.characters(XMLEmitter.java:655)
	at net.sf.saxon.serialize.HTMLEmitter.characters(HTMLEmitter.java:435)
	at net.sf.saxon.serialize.HTMLIndenter.characters(HTMLIndenter.java:246)
	at net.sf.saxon.event.ProxyReceiver.characters(ProxyReceiver.java:190)
	at net.sf.saxon.event.ProxyReceiver.characters(ProxyReceiver.java:190)
	at net.sf.saxon.event.ProxyReceiver.characters(ProxyReceiver.java:190)
	at net.sf.saxon.event.ComplexContentOutputter.characters(ComplexContentOutputter.java:278)
	at net.sf.saxon.event.ProxyReceiver.characters(ProxyReceiver.java:190)
	at net.sf.saxon.dom.DOMSender.walkNode(DOMSender.java:269)
```

HTML
```
359 00001660: 6e65 7220 6169 726c 696e 6573 c281 6620  ner airlines..f 
                                            ~~~~ A `c281` is valid UTF character (control code) but saxon doesn't understand.
```

So added option `deleteInvalidUTF8` for avoide this problem.
If the option is enable, delete un-acceptable UTF characters by saxon.

Setting example
```
<init-param>
  <param-name>deleteInvalidUTF8</param-name>
  <param-value>1</param-value>
</init-param>
```