### PR TITLE
Hotfix/support amp

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ useProxy                  |          | 'false'
 debugMode                 |          | '0'
 originalUrlHeader         |          | ''
 originalQueryStringHeader |          | ''
-strictHtmlCheck           |          | 'false'
 
 * A required parameter with a default setting does not need to be set within the web.xml. (Only the projectToken and secretKey parameters must be set in order for the library to work)
 
@@ -183,15 +182,3 @@ wovnjava will use the following settings along with the correct URL (prior to re
 * The sample request header shown above was referenced from the following site.
 
 https://coderwall.com/p/jhkw7w/passing-request-uri-into-request-header
-
-### 2.9. strictHtmlCheck
-
-(This is an experimental setting. As such, there is a possibility it will be removed in the future.)
-
-wovnjava uses the Content-Type header to determine the data type of the response body; by default, it translates only HTML requests. If you set strictHtmlCheck to true, wovnJava determines the data type of the response body, not only by the Content-Type, but also by checking the contents of the response body. This feature is used for example when the Content-type is text/html, however the actual content is not HTML. We can then prevent unnecessary translations of the page.
-
-wovnjava determines the response body as HTML if it starts with any of the following strings. wovnjava ignores comment tags and blanks during this process and is not case sensitive.
-
-* &lt;?xml
-* &lt;!DOCTYPE
-* &lt;html

--- a/README_ja.md
+++ b/README_ja.md
@@ -89,7 +89,6 @@ useProxy                  |              | 'false'
 debugMode                 |              | '0'
 originalUrlHeader         |              | ''
 originalQueryStringHeader |              | ''
-strictHtmlCheck           |              | 'false'
 
 ※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（projectToken と secretKey だけ指定すればライブラリを動作させることができます）
 
@@ -173,16 +172,3 @@ wovnjava は下記の設定で書き換え前の URL を使って、正しい翻
 ※ 上記のリクエストヘッダ設定のサンプルは、下記ページから引用しています。
 
 https://coderwall.com/p/jhkw7w/passing-request-uri-into-request-header
-
-### 2.8. strictHtmlCheck
-
-（これは実験的な機能です。将来的に廃止される可能性があります。）
-
-wovnjava は HTML に対してのみ翻訳処理を行い、その判定は Content-Type ヘッダのチェックによって行っています。strictHtmlCheck の設定を true にすると、Content-Type ヘッダのチェックに加えて、レスポンスボディの内容も翻訳するかどうかのチェックに利用します。本機能は例えば Content-Type は text/html であるけれども、内容は HTML ではないものを翻訳処理から除外したい場合に有効です。
-
-レスポンスボディの最初のコメントタグと空白を除いて、レスポンスボディが下記いずれかで開始している場合に HTML だと判定します。大文字小文字は区別しません。
-
-* <?xml
-* <!DOCTYPE
-* <html
-

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -34,8 +34,15 @@ class HtmlChecker {
     }
 
     private boolean isAmp(String head) {
-        return head.contains("<html ⚡")
-            || head.contains("<html amp");
+        head = REMOVE_QUOTED_ATTRIBUTES.matcher(head).replaceAll("");
+        Matcher m = HTML_TAG_ATTRIBUTE_PATTERN.matcher(head);
+        if (!m.find()) {
+            return false;
+        }
+        String attributes = m.group();
+        System.out.println(attributes);
+        return attributes.contains(" ⚡")
+            || attributes.contains(" amp");
     }
 
     private boolean isHtml(String head) {
@@ -50,6 +57,9 @@ class HtmlChecker {
     }
 
     private final int BUFFER_SIZE = 256;
+
+    private final Pattern HTML_TAG_ATTRIBUTE_PATTERN = Pattern.compile("<html([^>]+)>");
+    private final Pattern REMOVE_QUOTED_ATTRIBUTES = Pattern.compile("(?:\"[^\"]*\")|(?:'[^']*')");
 
     // The pattern come from WOVN.php/src/wovnio/wovnphp/Utils.php
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -18,7 +18,8 @@ class HtmlChecker {
         path = path.replaceFirst("[?#].*$", ""); // strip query or/and hash
         path = path.toLowerCase();
 
-        return !IMAGE_FILE_PATTERN.matcher(path).find()
+        return !TEXT_FILE_PATTERN.matcher(path).find()
+            && !IMAGE_FILE_PATTERN.matcher(path).find()
             && !AUDIO_FILE_PATTERN.matcher(path).find()
             && !VIDEO_FILE_PATTERN.matcher(path).find()
             && !DOC_FILE_PATTERN.matcher(path).find();
@@ -40,8 +41,9 @@ class HtmlChecker {
             return false;
         }
         String attributes = m.group();
-        return attributes.contains(" ⚡")
-            || attributes.contains(" amp");
+        attributes = attributes.replace(">", " ").replaceAll("[\r\n\t]", " ");
+        return attributes.contains(" ⚡ ")
+            || attributes.contains(" amp ");
     }
 
     private boolean isHtml(String head) {
@@ -59,6 +61,8 @@ class HtmlChecker {
 
     private final Pattern HTML_TAG_ATTRIBUTE_PATTERN = Pattern.compile("<html([^>]+)>");
     private final Pattern REMOVE_QUOTED_ATTRIBUTES = Pattern.compile("(?:\"[^\"]*\")|(?:'[^']*')");
+
+    private final Pattern TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
 
     // The pattern come from WOVN.php/src/wovnio/wovnphp/Utils.php
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -1,0 +1,47 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class HtmlChecker {
+    public boolean canTranslatePath(String path) {
+        // Reduce strings for performance and keep a simple case
+        path = path.replaceFirst("^.*/", "/"); // strip directries
+        path = path.replaceFirst("[?#].*$", ""); // strip query or/and hash
+        path = path.toLowerCase();
+
+        return !IMAGE_FILE_PATTERN.matcher(path).find()
+            && !AUDIO_FILE_PATTERN.matcher(path).find()
+            && !VIDEO_FILE_PATTERN.matcher(path).find()
+            && !DOC_FILE_PATTERN.matcher(path).find();
+    }
+
+    public boolean canTranslateContent(String html) {
+        String head = getHead(html).toLowerCase();
+        return isHtml(head) && !isAmp(head);
+    }
+
+    private boolean isAmp(String head) {
+        return head.contains("<html ⚡")
+            || head.contains("<html amp");
+    }
+
+    private boolean isHtml(String head) {
+        return head.contains("<?xml")
+            || head.contains("<!doctype")
+            || head.contains("<html")
+            || head.contains("<xhtml");
+    }
+
+    private String getHead(String html) {
+        return html.substring(0, Math.min(html.length(), BUFFER_SIZE));
+    }
+
+    private final int BUFFER_SIZE = 256;
+
+    // The pattern come from WOVN.php/src/wovnio/wovnphp/Utils.php
+    private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
+    private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
+    private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
+    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.(zip|tar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+}

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -4,7 +4,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class HtmlChecker {
+    public boolean canTranslateContentType(String type) {
+        return type == null || type.toLowerCase().contains("html");
+    }
+
     public boolean canTranslatePath(String path) {
+        if (path == null) {
+            return true;
+        }
+
         // Reduce strings for performance and keep a simple case
         path = path.replaceFirst("^.*/", "/"); // strip directries
         path = path.replaceFirst("[?#].*$", ""); // strip query or/and hash
@@ -17,6 +25,10 @@ class HtmlChecker {
     }
 
     public boolean canTranslateContent(String html) {
+        if (html == null) {
+            return false;
+        }
+
         String head = getHead(html).toLowerCase();
         return isHtml(head) && !isAmp(head);
     }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -40,7 +40,6 @@ class HtmlChecker {
             return false;
         }
         String attributes = m.group();
-        System.out.println(attributes);
         return attributes.contains(" ⚡")
             || attributes.contains(" amp");
     }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -1,5 +1,7 @@
 package com.github.wovnio.wovnjava;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,15 +37,8 @@ class HtmlChecker {
     }
 
     private boolean isAmp(String head) {
-        head = REMOVE_QUOTED_ATTRIBUTES.matcher(head).replaceAll("");
-        Matcher m = HTML_TAG_ATTRIBUTE_PATTERN.matcher(head);
-        if (!m.find()) {
-            return false;
-        }
-        String attributes = m.group();
-        attributes = attributes.replace(">", " ").replaceAll("[\r\n\t]", " ");
-        return attributes.contains(" ⚡ ")
-            || attributes.contains(" amp ");
+        Element element = Jsoup.parse(head).getElementsByTag("html").first();
+        return element != null && (element.hasAttr("amp") || element.hasAttr("⚡"));
     }
 
     private boolean isHtml(String head) {
@@ -58,9 +53,6 @@ class HtmlChecker {
     }
 
     private final int BUFFER_SIZE = 256;
-
-    private final Pattern HTML_TAG_ATTRIBUTE_PATTERN = Pattern.compile("<html([^>]+)>");
-    private final Pattern REMOVE_QUOTED_ATTRIBUTES = Pattern.compile("(?:\"[^\"]*\")|(?:'[^']*')");
 
     private final Pattern TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
 

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -54,14 +54,16 @@ public class WovnServletFilter implements Filter {
             // text
             String body = null;
             if (htmlChecker.canTranslateContent(originalBody)) {
+                // html
                 Api api = new Api(settings, headers);
                 Interceptor interceptor = new Interceptor(headers, settings, api);
                 body = interceptor.translate(originalBody);
             } else {
+                // css, javascript or others
                 body = originalBody;
             }
             wovnResponse.setContentLength(body.getBytes().length);
-            wovnResponse.setContentType("text/html; charset=utf-8");
+            wovnResponse.setCharacterEncoding("utf-8");
             PrintWriter out = response.getWriter();
             out.write(body);
             out.close();

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -2,8 +2,6 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -20,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 
 public class WovnServletFilter implements Filter {
     private Settings settings;
+    private final HtmlChecker htmlChecker = new HtmlChecker();
 
     public static final String VERSION = Settings.VERSION;  // for backword compatibility
 
@@ -33,7 +32,7 @@ public class WovnServletFilter implements Filter {
         String lang = headers.getPathLang();
         boolean hasShorterPath = lang.length() > 0 && lang.equals(settings.defaultLang);
 
-        if (!isHtml(headers.pathName)) {
+        if (!htmlChecker.canTranslatePath(headers.pathName)) {
             chain.doFilter(request, response);
         } else if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
@@ -45,17 +44,12 @@ public class WovnServletFilter implements Filter {
     public void destroy() {
     }
 
-    boolean isHtml(String path) {
-        // TODO: implement
-        return true;
-    }
-
     private void tryTranslate(Headers headers, HttpServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse((HttpServletResponse)response);
         chain.doFilter(wovnRequest, wovnResponse);
         String originalBody = wovnResponse.toString();
-        if (originalBody != null && (!settings.strictHtmlCheck || isHtmlContent(originalBody))) {
+        if (originalBody != null && htmlChecker.canTranslateContent(originalBody)) {
             // text
             Api api = new Api(settings, headers);
             Interceptor interceptor = new Interceptor(headers, settings, api);
@@ -72,40 +66,5 @@ public class WovnServletFilter implements Filter {
             out.close();
         }
         headers.out(wovnRequest, wovnResponse);
-    }
-
-    private boolean isHtmlContent(String body) {
-        if (Logger.isDebug()) {
-            Logger.log.info("Checking HTML strictly.");
-
-            if (Logger.debugMode > 1) {
-                Logger.log.info("original HTML:\n" + body);
-            }
-        }
-
-        // Remove comments.
-        body = Pattern.compile("(?m)\\A(\\s*<!--[\\s\\S]*?-->\\s*)+").matcher(body).replaceAll("");
-
-        // Remove spaces.
-        body = Pattern.compile("(?m)\\A\\s+").matcher(body).replaceAll("");
-
-        if (Logger.debugMode > 1) {
-            Logger.log.info("HTML after removing comment tags and spaces:\n" + body);
-        }
-
-        if (Pattern.compile("(?m)\\A<\\?xml\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()             // <?xml
-                || Pattern.compile("(?m)\\A<!DOCTYPE\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()    // <!DOCTYPE
-                || Pattern.compile("(?m)\\A<html\\b", Pattern.CASE_INSENSITIVE).matcher(body).find()        // <html
-                ) {
-            if (Logger.isDebug()) {
-                Logger.log.info("This data is HTML.");
-            }
-            return true;
-        } else {
-            if (Logger.isDebug()) {
-                Logger.log.info("This data is not HTML.");
-            }
-            return false;
-        }
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -50,11 +50,16 @@ public class WovnServletFilter implements Filter {
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse((HttpServletResponse)response);
         chain.doFilter(wovnRequest, wovnResponse);
         String originalBody = wovnResponse.toString();
-        if (originalBody != null && htmlChecker.canTranslateContent(originalBody)) {
+        if (originalBody != null) {
             // text
-            Api api = new Api(settings, headers);
-            Interceptor interceptor = new Interceptor(headers, settings, api);
-            String body = interceptor.translate(originalBody);
+            String body = null;
+            if (htmlChecker.canTranslateContent(originalBody)) {
+                Api api = new Api(settings, headers);
+                Interceptor interceptor = new Interceptor(headers, settings, api);
+                body = interceptor.translate(originalBody);
+            } else {
+                body = originalBody;
+            }
             wovnResponse.setContentLength(body.getBytes().length);
             wovnResponse.setContentType("text/html; charset=utf-8");
             PrintWriter out = response.getWriter();

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -31,8 +31,9 @@ public class WovnServletFilter implements Filter {
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
         boolean hasShorterPath = lang.length() > 0 && lang.equals(settings.defaultLang);
-
-        if (!htmlChecker.canTranslatePath(headers.pathName)) {
+        boolean canNotTranslate = !htmlChecker.canTranslatePath(headers.pathName)
+                               || !htmlChecker.canTranslateContentType(response.getContentType());
+        if (canNotTranslate) {
             chain.doFilter(request, response);
         } else if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -35,6 +35,11 @@ public class HtmlCheckerTest extends TestCase {
         assertEquals(false, htmlChecker.canTranslateContent("hello world"));
         assertCanTranslate(false, "<!doctype html><html ⚡>");
         assertCanTranslate(false, "<!doctype html><html amp>");
+        assertCanTranslate(false, "<!doctype html><html lang=\"en\" amp>");
+        assertCanTranslate(false, "<!doctype html><html lang='en' amp>");
+        assertCanTranslate(false, "<!doctype html><html lang=en amp>");
+        assertCanTranslate(false, "<!doctype html><html amp lang=\"en\">");
+        assertCanTranslate(false, "<!doctype html><html onload=\"console.log(1 > 2 && 3 < 4)\" amp lang=en>");
         assertCanTranslate(true, "<!doctype html>");
         assertCanTranslate(true, "<!DOCTYPE html>");
         assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -26,6 +26,8 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslatePath(false, "mp4");
         assertCanTranslatePath(false, "zip");
         assertCanTranslatePath(false, "pdf");
+        assertCanTranslatePath(false, "js");
+        assertCanTranslatePath(false, "css");
         assertCanTranslatePath(true, "unknown");
     }
 
@@ -35,11 +37,17 @@ public class HtmlCheckerTest extends TestCase {
         assertEquals(false, htmlChecker.canTranslateContent("hello world"));
         assertCanTranslate(false, "<!doctype html><html ⚡>");
         assertCanTranslate(false, "<!doctype html><html amp>");
+        assertCanTranslate(false, "<!doctype html><html\namp>");
+        assertCanTranslate(false, "<!doctype html><html\ramp>");
+        assertCanTranslate(false, "<!doctype html><html\tamp>");
+        assertCanTranslate(false, "<!doctype html><html\r\t\namp>");
         assertCanTranslate(false, "<!doctype html><html lang=\"en\" amp>");
         assertCanTranslate(false, "<!doctype html><html lang='en' amp>");
         assertCanTranslate(false, "<!doctype html><html lang=en amp>");
         assertCanTranslate(false, "<!doctype html><html amp lang=\"en\">");
         assertCanTranslate(false, "<!doctype html><html onload=\"console.log(1 > 2 && 3 < 4)\" amp lang=en>");
+        assertCanTranslate(true, "<!doctype html><html ampute>");
+        assertCanTranslate(true, "<!doctype html><html lamp>");
         assertCanTranslate(true, "<!doctype html>");
         assertCanTranslate(true, "<!DOCTYPE html>");
         assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -45,6 +45,10 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslate(false, "<!doctype html><html amp=1>");
         assertCanTranslate(false, "<!doctype html><html amp=\"\">");
         assertCanTranslate(false, "<!doctype html><html amp=''>");
+        assertCanTranslate(false, "<!doctype html><html ⚡=amp>");
+        assertCanTranslate(false, "<!doctype html><html ⚡=1>");
+        assertCanTranslate(false, "<!doctype html><html ⚡=\"\">");
+        assertCanTranslate(false, "<!doctype html><html ⚡=''>");
         assertCanTranslate(false, "<!doctype html><html lang=\"en\" amp>");
         assertCanTranslate(false, "<!doctype html><html lang='en' amp>");
         assertCanTranslate(false, "<!doctype html><html lang=en amp>");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -1,0 +1,64 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+
+
+public class HtmlCheckerTest extends TestCase {
+    private final HtmlChecker htmlChecker = new HtmlChecker();
+
+    public void testCanTranslatePath() {
+        assertCanTranslatePath(true, "");
+        assertCanTranslatePath(true, "/");
+        assertCanTranslatePath(true, "html");
+        assertCanTranslatePath(false, "png");
+        assertCanTranslatePath(false, "jpg");
+        assertCanTranslatePath(false, "gif");
+        assertCanTranslatePath(false, "mp3");
+        assertCanTranslatePath(false, "mp4");
+        assertCanTranslatePath(false, "zip");
+        assertCanTranslatePath(false, "pdf");
+        assertCanTranslatePath(true, "unknown");
+    }
+
+    public void testCanTranslate() {
+        assertEquals(false, htmlChecker.canTranslateContent(""));
+        assertCanTranslate(false, "<!doctype html><html ⚡>");
+        assertCanTranslate(false, "<!doctype html><html amp>");
+        assertCanTranslate(true, "<!doctype html>");
+        assertCanTranslate(true, "<!DOCTYPE html>");
+        assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\" \"http://www.w3.org/TR/html4/frameset.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">");
+        assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">");
+    }
+
+    private void assertCanTranslatePath(boolean expect, String ext) {
+        assertEquals(expect, htmlChecker.canTranslatePath("foo." + ext));
+        assertEquals(expect, htmlChecker.canTranslatePath("/foo." + ext));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=1"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=file.html"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=file.png"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.html"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.png"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.png?query=file.png&upload=file.html"));
+        assertEquals(true, htmlChecker.canTranslatePath("foo" + ext));
+        assertEquals(true, htmlChecker.canTranslatePath("/foo." + ext + "unknown"));
+        assertEquals(true, htmlChecker.canTranslatePath("/foo." + ext + "/"));
+        assertEquals(expect, htmlChecker.canTranslatePath("/foo.html/bar." + ext));
+        assertEquals(expect, htmlChecker.canTranslatePath("/foo.png/bar." + ext));
+    }
+
+    private void assertCanTranslate(boolean expect, String prefix) {
+        String template = "<head> <meta charset=\"utf-8\"></head><body>hello</body></html>";
+        assertEquals(expect, htmlChecker.canTranslateContent(prefix + template));
+        assertEquals(expect, htmlChecker.canTranslateContent("  " + prefix + template));
+        assertEquals(expect, htmlChecker.canTranslateContent("\n" + prefix + template));
+        assertEquals(expect, htmlChecker.canTranslateContent("<!-- comment -->" + prefix + template));
+        assertEquals(expect, htmlChecker.canTranslateContent("<!-- comment -->\n " + prefix + template));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -6,7 +6,16 @@ import junit.framework.TestCase;
 public class HtmlCheckerTest extends TestCase {
     private final HtmlChecker htmlChecker = new HtmlChecker();
 
+    public void testCanTranslateContentType() {
+        assertEquals(true, htmlChecker.canTranslateContentType(null));
+        assertEquals(true, htmlChecker.canTranslateContentType("html"));
+        assertEquals(true, htmlChecker.canTranslateContentType("text/html"));
+        assertEquals(true, htmlChecker.canTranslateContentType("text/xhtml"));
+        assertEquals(false, htmlChecker.canTranslateContentType("text/plain"));
+    }
+
     public void testCanTranslatePath() {
+        assertCanTranslatePath(true, null);
         assertCanTranslatePath(true, "");
         assertCanTranslatePath(true, "/");
         assertCanTranslatePath(true, "html");
@@ -21,7 +30,9 @@ public class HtmlCheckerTest extends TestCase {
     }
 
     public void testCanTranslate() {
+        assertEquals(false, htmlChecker.canTranslateContent(null));
         assertEquals(false, htmlChecker.canTranslateContent(""));
+        assertEquals(false, htmlChecker.canTranslateContent("hello world"));
         assertCanTranslate(false, "<!doctype html><html ⚡>");
         assertCanTranslate(false, "<!doctype html><html amp>");
         assertCanTranslate(true, "<!doctype html>");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -43,6 +43,8 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslate(false, "<!doctype html><html\r\t\namp>");
         assertCanTranslate(false, "<!doctype html><html amp=amp>");
         assertCanTranslate(false, "<!doctype html><html amp=1>");
+        assertCanTranslate(false, "<!doctype html><html amp=\"\">");
+        assertCanTranslate(false, "<!doctype html><html amp=''>");
         assertCanTranslate(false, "<!doctype html><html lang=\"en\" amp>");
         assertCanTranslate(false, "<!doctype html><html lang='en' amp>");
         assertCanTranslate(false, "<!doctype html><html lang=en amp>");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -41,6 +41,8 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslate(false, "<!doctype html><html\ramp>");
         assertCanTranslate(false, "<!doctype html><html\tamp>");
         assertCanTranslate(false, "<!doctype html><html\r\t\namp>");
+        assertCanTranslate(false, "<!doctype html><html amp=amp>");
+        assertCanTranslate(false, "<!doctype html><html amp=1>");
         assertCanTranslate(false, "<!doctype html><html lang=\"en\" amp>");
         assertCanTranslate(false, "<!doctype html><html lang='en' amp>");
         assertCanTranslate(false, "<!doctype html><html lang=en amp>");
@@ -48,6 +50,8 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslate(false, "<!doctype html><html onload=\"console.log(1 > 2 && 3 < 4)\" amp lang=en>");
         assertCanTranslate(true, "<!doctype html><html ampute>");
         assertCanTranslate(true, "<!doctype html><html lamp>");
+        assertCanTranslate(true, "<!doctype html><html lang=amp>");
+        assertCanTranslate(true, "<!doctype html><html lang = amp>");
         assertCanTranslate(true, "<!doctype html>");
         assertCanTranslate(true, "<!DOCTYPE html>");
         assertCanTranslate(true, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">");


### PR DESCRIPTION
No translation and no adding snipet when response is amp content or not translatable content.

The feature always check html content, so I removed `strictHtmlCheck` option.
Because it's need always enabled for detect amp.
