### PR TITLE
Hotfix/fix image problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk8
-  - openjdk7

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk7
+    version: openjdk8
 
 test:
   post:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -33,8 +33,11 @@ public class WovnServletFilter implements Filter {
         boolean hasShorterPath = lang.length() > 0 && lang.equals(settings.defaultLang);
         if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
-        } else {
+        } else if (htmlChecker.canTranslatePath(headers.pathName)) {
             tryTranslate(headers, (HttpServletRequest)request, response, chain);
+        } else {
+            WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
+            chain.doFilter(wovnRequest, response);
         }
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
@@ -1,0 +1,16 @@
+package com.github.wovnio.wovnjava;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+public class FilterChainMock implements FilterChain {
+    public HttpServletRequest req;
+    public ServletResponse res;
+
+    public void doFilter(ServletRequest req, ServletResponse res) {
+        this.req = (HttpServletRequest)req;
+        this.res = res;
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
@@ -1,0 +1,22 @@
+package com.github.wovnio.wovnjava;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class RequestDispatcherMock implements RequestDispatcher {
+    public HttpServletRequest req;
+    public HttpServletResponse res;
+
+    public void forward(ServletRequest req, ServletResponse res) {
+        this.req = (HttpServletRequest)req;
+        this.res = (HttpServletResponse)res;
+    }
+
+    public void include(ServletRequest req, ServletResponse res) {
+        this.req = (HttpServletRequest)req;
+        this.res = (HttpServletResponse)res;
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -98,10 +98,10 @@ public class TestUtil {
 
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
-		HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
-		ServletResponse res = TestUtil.mockResponse(contentType, "");
-		FilterConfig filterConfig = mockFilterConfig();
-		FilterChainMock filterChain = new FilterChainMock();
+        HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
+        ServletResponse res = TestUtil.mockResponse(contentType, "");
+        FilterConfig filterConfig = mockFilterConfig();
+        FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();
         filter.init(filterConfig);
         filter.doFilter(req, res, filterChain);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -1,8 +1,16 @@
 package com.github.wovnio.wovnjava;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.FilterConfig;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
 import org.easymock.EasyMock;
 
 
@@ -27,6 +35,10 @@ public class TestUtil {
     }
 
     public static HttpServletRequest mockRequestPath(String path) {
+        return mockRequestPath(path, null, new RequestDispatcherMock());
+    }
+
+    public static HttpServletRequest mockRequestPath(String path, String replacedPath, RequestDispatcherMock dispatcher) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(mock.getScheme()).andReturn("https");
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
@@ -35,7 +47,66 @@ public class TestUtil {
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getHeader("Location")).andReturn(path).atLeastOnce();
+        EasyMock.expect(mock.getRequestDispatcher(replacedPath == null ? EasyMock.anyString() : replacedPath)).andReturn(dispatcher);
         EasyMock.replay(mock);
         return mock;
+    }
+
+    public static ServletResponse mockResponse(String contentType, String encoding) throws IOException {
+        HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
+        mock.setContentLength(EasyMock.anyInt());
+        EasyMock.expectLastCall();
+        mock.setCharacterEncoding("utf-8");
+        EasyMock.expectLastCall();
+        EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));
+        EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();
+        EasyMock.expect(mock.getCharacterEncoding()).andReturn(encoding);
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    public static FilterConfig mockFilterConfig() {
+        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
+        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
+        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
+        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
+        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    public static FilterChainMock doServletFilter(String contentType, String path) throws ServletException, IOException {
+        return doServletFilter(contentType, path, path);
+    }
+
+    public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath) throws ServletException, IOException {
+        RequestDispatcherMock dispatcher = new RequestDispatcherMock();
+		HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
+		ServletResponse res = TestUtil.mockResponse(contentType, "");
+		FilterConfig filterConfig = mockFilterConfig();
+		FilterChainMock filterChain = new FilterChainMock();
+        WovnServletFilter filter = new WovnServletFilter();
+        filter.init(filterConfig);
+        filter.doFilter(req, res, filterChain);
+        filterChain.req = filterChain.req == null ? dispatcher.req : filterChain.req;
+        filterChain.res = filterChain.res == null ? dispatcher.res : filterChain.res;
+        return filterChain;
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -1,0 +1,54 @@
+package com.github.wovnio.wovnjava;
+
+import java.io.IOException;
+import javax.servlet.FilterConfig;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.easymock.EasyMock;
+
+
+public class WovnServletFilterTest extends TestCase {
+
+    public void testHtml() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/");
+        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
+        assertEquals("/", mock.req.getRequestURI());
+    }
+
+    public void testHtmlWithLang() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/");
+        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
+        assertEquals("/", mock.req.getRequestURI());
+    }
+
+    public void testCss() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/dir/style.css");
+        assertEquals("text/css", mock.res.getContentType());
+        assertEquals("/dir/style.css", mock.req.getRequestURI());
+    }
+
+    public void testCssWithLang() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css");
+        assertEquals("text/css", mock.res.getContentType());
+        assertEquals("/style.css", mock.req.getRequestURI());
+    }
+
+    public void testImage() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/image.png");
+        assertEquals("image/png", mock.res.getContentType());
+        assertEquals("/image.png", mock.req.getRequestURI());
+    }
+
+    public void testImageWithLang() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "image.png");
+        assertEquals("image/png", mock.res.getContentType());
+        assertEquals("/image.png", mock.req.getRequestURI());
+    }
+}


### PR DESCRIPTION
# This PR include JDK upgrading
Fix add character encoding problem when content type is image.

Now, there is compiling success when jdk8 on jitpack.io, but jdk7 is not.

This is failing logs.
https://jitpack.io/com/github/wovnio/wovnjava/0.3.1/build.log
https://jitpack.io/com/github/wovnio/wovnjava/0.3.2/build.log
https://jitpack.io/com/github/wovnio/wovnjava/0.3.3/build.log

I'm not sure reason of compile failing, but I guess that it's related that jdk7 got end of life at April 2015.
And jdk8 will be end of life at January 2019.
So I think jdk upgrading is reasonable.
