### PR TITLE
Only internal redirect when urlPattern is path

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -48,7 +48,7 @@ public class WovnServletFilter implements Filter {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse((HttpServletResponse)response);
 
-        if (headers.getPathLang().length() > 0) {
+        if (settings.urlPattern.equals("path") && headers.getPathLang().length() > 0) {
             wovnRequest.getRequestDispatcher(headers.pathNameKeepTrailingSlash).forward(wovnRequest, wovnResponse);
         } else {
             chain.doFilter(wovnRequest, wovnResponse);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -15,13 +15,13 @@ import org.easymock.EasyMock;
 
 
 public class TestUtil {
-    private static final HashMap<String, String> emptySettings = new HashMap<String, String>();
+    private static final HashMap<String, String> emptyOption = new HashMap<String, String>();
 
-    public static Settings makeSettings() {
-        return makeSettings(emptySettings);
+    public static FilterConfig makeConfig() {
+        return makeConfig(emptyOption);
     }
 
-    public static Settings makeSettings(HashMap<String, String> option) {
+    public static FilterConfig makeConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
         String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout"};
         for (int i=0; i<keys.length; ++i) {
@@ -31,7 +31,15 @@ public class TestUtil {
             EasyMock.expect(mock.getInitParameter(key)).andReturn(val);
         }
         EasyMock.replay(mock);
-        return new Settings(mock);
+        return mock;
+    }
+
+    public static Settings makeSettings() {
+        return makeSettings(emptyOption);
+    }
+
+    public static Settings makeSettings(HashMap<String, String> option) {
+        return new Settings(makeConfig(option));
     }
 
     public static HttpServletRequest mockRequestPath(String path) {
@@ -93,14 +101,22 @@ public class TestUtil {
     }
 
     public static FilterChainMock doServletFilter(String contentType, String path) throws ServletException, IOException {
-        return doServletFilter(contentType, path, path);
+        return doServletFilter(contentType, path, path, emptyOption);
+    }
+
+    public static FilterChainMock doServletFilter(String contentType, String path, HashMap<String, String> option) throws ServletException, IOException {
+        return doServletFilter(contentType, path, path, option);
     }
 
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath) throws ServletException, IOException {
+        return doServletFilter(contentType, path, forwardPath, emptyOption);
+    }
+
+    public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
         ServletResponse res = TestUtil.mockResponse(contentType, "");
-        FilterConfig filterConfig = mockFilterConfig();
+        FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();
         filter.init(filterConfig);

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -1,6 +1,7 @@
 package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
+import java.util.HashMap;
 import javax.servlet.FilterConfig;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -15,7 +16,6 @@ import org.easymock.EasyMock;
 
 
 public class WovnServletFilterTest extends TestCase {
-
     public void testHtml() throws ServletException, IOException {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/");
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
@@ -24,6 +24,18 @@ public class WovnServletFilterTest extends TestCase {
 
     public void testHtmlWithLang() throws ServletException, IOException {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/");
+        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
+        assertEquals("/", mock.req.getRequestURI());
+    }
+
+    public void testHtmlWithQueryLang() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/?wovn=ja", queryOption);
+        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
+        assertEquals("/", mock.req.getRequestURI());
+    }
+
+    public void testHtmlWithSubdomain() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", subdomainOption("ja.wovn.io"));
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("/", mock.req.getRequestURI());
     }
@@ -51,4 +63,16 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals("image/png", mock.res.getContentType());
         assertEquals("/image.png", mock.req.getRequestURI());
     }
+
+    private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
+        put("urlPattern", "query");
+    }};
+
+    private HashMap<String, String> subdomainOption(String host) {
+        return new HashMap<String, String>() {{
+            put("urlPattern", "subdomain");
+            put("host", host);
+        }};
+    }
+
 }


### PR DESCRIPTION
If the browser access with language code by query, wovnjava do internal redirect to other path but it's illegal.
So I fixed it.
This issue reported by our user.