### PR TITLE
Centralize testing initialization for FilterConfig mock class.

### DIFF
--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -11,169 +11,64 @@ import javax.servlet.http.HttpServletRequest;
 public class HeadersTest extends TestCase {
 
     private static FilterConfig mockConfigPath() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
     private static FilterConfig mockConfigSubdomain() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "subdomain");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
     private static FilterConfig mockConfigQuery() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockConfigQueryParameter() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("abc");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("query", "abc");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockConfigQueryParameterAAA() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("AAA");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("query", "AAA");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockConfigOriginalHeaders() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("baz");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("query", "baz");
+            put("originalUrlHeader", "REDIRECT_URL");
+            put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static HttpServletRequest mockRequestPath() {
@@ -256,24 +151,6 @@ public class HeadersTest extends TestCase {
 
         return mock;
 
-    }
-
-    private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout"};
-        for (int i=0; i<keys.length; ++i) {
-            String key = keys[i];
-            String val = option.get(key);
-            val = val == null ? "" : val;
-            EasyMock.expect(mock.getInitParameter(key)).andReturn(val);
-        }
-        EasyMock.replay(mock);
-        return mock;
-    }
-
-    private static Settings makeSettings(HashMap<String, String> option) {
-        FilterConfig mock = mockSpecificConfig(option);
-        return new Settings(mock);
     }
 
     public void testHeaders() {
@@ -432,7 +309,7 @@ public class HeadersTest extends TestCase {
     private Headers makeHeader(String requestPath, String sitePrefix) {
         HttpServletRequest mockRequest = mockRequestPath(requestPath);
         HashMap<String, String> option = new HashMap<String, String>(){ { put("sitePrefixPath", "/global/"); } };
-        Settings s = makeSettings(option);
+        Settings s = TestUtil.makeSettings(option);
         return new Headers(mockRequest, s);
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -12,113 +12,51 @@ import javax.servlet.FilterConfig;
 public class SettingsTest extends TestCase {
 
     private static FilterConfig mockEmptyConfig() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        return TestUtil.makeConfig();
     }
 
     private static FilterConfig mockValidConfig() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("foo,bar");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("https://example.com/v0/values");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("ja");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("en,ja");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("urlPatternReg", "aaa");
+            put("query", "foo,bar");
+            put("apiUrl", "https://example.com/v0/values");
+            put("defaultLang", "ja");
+            put("supportedLangs", "en,ja");
+            put("originalUrlHeader", "REDIRECT_URL");
+            put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockValidConfigMultipleToken() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("3elW2");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("aaa");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("foo,bar");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("https://example.com/v0/values");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("ja");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("en,ja");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("REDIRECT_URL");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("REDIRECT_QUERY_STRING");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "3elW2");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("urlPatternReg", "aaa");
+            put("query", "foo,bar");
+            put("apiUrl", "https://example.com/v0/values");
+            put("defaultLang", "ja");
+            put("supportedLangs", "en,ja");
+            put("originalUrlHeader", "REDIRECT_URL");
+            put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockQueryConfig() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-
-    private static FilterConfig mockSpecificConfig(HashMap<String, String> option) {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "useProxy", "originalUrlHeader", "originalQueryStringHeader", "connectTimeout", "readTimeout", "strictHtmlCheck"};
-        for (int i=0; i<keys.length; ++i) {
-            String key = keys[i];
-            String val = option.get(key);
-            val = val == null ? "" : val;
-            EasyMock.expect(mock.getInitParameter(key)).andReturn(val);
-        }
-        EasyMock.replay(mock);
-        return mock;
-    }
-
-    private static Settings newSettings(HashMap<String, String> option) {
-        FilterConfig mock = mockSpecificConfig(option);
-        return new Settings(mock);
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     // urlPattern is "path".
@@ -252,8 +190,7 @@ public class SettingsTest extends TestCase {
     }
 
     public void testSettingsWithoutSitePrefix() {
-        HashMap<String, String> option = new HashMap<String, String>();
-        Settings s = newSettings(option);
+        Settings s = TestUtil.makeSettings();
         assertFalse(s.hasSitePrefixPath);
         assertEquals("/", s.sitePrefixPathWithSlash);
         assertEquals("", s.sitePrefixPathWithoutSlash);
@@ -262,7 +199,7 @@ public class SettingsTest extends TestCase {
     public void testSettingsWithSitePrefix() {
         HashMap<String, String> option = new HashMap<String, String>();
         option.put("sitePrefixPath", "/global/");
-        Settings s = newSettings(option);
+        Settings s = TestUtil.makeSettings(option);
         assertTrue(s.hasSitePrefixPath);
         assertEquals("/global/", s.sitePrefixPathWithSlash);
         assertEquals("/global", s.sitePrefixPathWithoutSlash);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -73,33 +73,6 @@ public class TestUtil {
         return mock;
     }
 
-    public static FilterConfig mockFilterConfig() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-        return mock;
-    }
-
     public static FilterChainMock doServletFilter(String contentType, String path) throws ServletException, IOException {
         return doServletFilter(contentType, path, path, emptyOption);
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -2,6 +2,7 @@ package com.github.wovnio.wovnjava;
 
 import junit.framework.TestCase;
 
+import java.util.HashMap;
 import org.easymock.EasyMock;
 
 import javax.servlet.FilterConfig;
@@ -52,84 +53,32 @@ public class WovnHttpServletRequestTest extends TestCase {
     }
 
     private static FilterConfig mockConfigPath() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockConfigSubDomain() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("subdomain");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "subdomain");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     private static FilterConfig mockConfigQuery() {
-        FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        EasyMock.expect(mock.getInitParameter("userToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("projectToken")).andReturn("2Wle3");
-        EasyMock.expect(mock.getInitParameter("sitePrefixPath")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("secretKey")).andReturn("secret");
-        EasyMock.expect(mock.getInitParameter("urlPattern")).andReturn("query");
-        EasyMock.expect(mock.getInitParameter("urlPatternReg")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("query")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("apiUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("defaultLang")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("supportedLangs")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("testUrl")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("useProxy")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("debugMode")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalUrlHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("originalQueryStringHeader")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("strictHtmlCheck")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidClosingTag")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("deleteInvalidUTF8")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("connectTimeout")).andReturn("");
-        EasyMock.expect(mock.getInitParameter("readTimeout")).andReturn("");
-        EasyMock.replay(mock);
-        return mock;
+        HashMap<String, String> parameters = new HashMap<String, String>() {{
+            put("userToken", "2Wle3");
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+        }};
+        return TestUtil.makeConfig(parameters);
     }
 
     public void testWovnHttpServletRequest() {


### PR DESCRIPTION
### Purpose

The testing code has a `TestUtil.java` file but it was not being used much. This change will take advantage of TestUtil to centralize configuration initializations in all the tests, and it cleans up some related redundant code.

This will make it easier to manage the test when the code changes.