### PR TITLE
Hotfix/include url schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>0.3.6</version>
+    <version>0.3.7</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -126,7 +126,7 @@ class Api {
 
     private String getApiBody(String lang, String body) throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder();
-        appendKeyValue(sb, "url=", headers.url);
+        appendKeyValue(sb, "url=", headers.getUrlWithoutLanguageCode());
         appendKeyValue(sb, "&token=", settings.projectToken);
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -183,6 +183,9 @@ class Headers {
         return this.pathLang;
     }
 
+    /**
+     * @return String Returns request URL with new language code added
+     */
     String redirectLocation(String lang) {
         if (lang.equals(this.settings.defaultLang)) {
             return this.protocol + "://" + this.url;
@@ -206,6 +209,13 @@ class Headers {
             }
             return protocol + "://" + location;
         }
+    }
+
+    /**
+     * @return String Returns request URL without any language code
+     */
+    String getUrlWithoutLanguageCode() {
+        return this.protocol + "://" + this.url;
     }
 
     String removeLang(String uri, String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -11,7 +11,7 @@ import javax.servlet.FilterConfig;
 import javax.xml.bind.DatatypeConverter;
 
 class Settings {
-    public static final String VERSION = "0.3.6";
+    public static final String VERSION = "0.3.7";
     static final String UrlPatternRegPath = "/([^/.?]+)";
     static final String UrlPatternRegQuery = "(?:(?:\\?.*&)|\\?)wovn=([^&]+)(?:&|$)";
     static final String UrlPatternRegSubdomain = "^([^.]+)\\.";

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -2,6 +2,7 @@ package com.github.wovnio.wovnjava;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
@@ -13,6 +14,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
+import java.net.URLDecoder;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,35 +26,54 @@ import org.easymock.EasyMock;
 
 public class ApiTest extends TestCase {
 
-    public void testNormal() throws ApiException, IOException, ProtocolException {
+    public void testTranslateWithGzipResponse() throws ApiException, IOException, ProtocolException {
+        byte[] apiServerResponse = gzip("{\"body\": \"<html><body>response html</body></html>\"}".getBytes());
+        String encoding = "gzip";
+        String resultingHtml = testTranslate(apiServerResponse, encoding);
+        String expectedHtml = "<html><body>response html</body></html>";
+        assertEquals(expectedHtml, resultingHtml);
+    }
+
+    public void testTranslateWithPlainTextResponse() throws ApiException, IOException, ProtocolException {
+        byte[] apiServerResponse = "{\"body\": \"<html><body>response html</body></html>\"}".getBytes();
+        String encoding = "";
+        String resultingHtml = testTranslate(apiServerResponse, encoding);
+        String expectedHtml = "<html><body>response html</body></html>";
+        assertEquals(expectedHtml, resultingHtml);
+    }
+
+    private String testTranslate(byte[] apiServerResponse, String encoding) throws ApiException, IOException, ProtocolException {
+        String html = "<html>much content</html>";
+
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("projectToken", "token0");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        HttpServletRequest request = TestUtil.mockRequestPath("/ja/");
-        String html = translate(request, settings, "<html></html>", 200, "gzip", gzip("{\"body\": \"response html\"}".getBytes()));
-        String expect = "response html";
-        assertEquals(expect, html);
-    }
 
-    public void testWithPlainTextResponse() throws ApiException, IOException, ProtocolException {
-        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
-            put("projectToken", "token0");
-            put("defaultLang", "en");
-            put("supportedLangs", "en,ja,fr");
-        }});
-        HttpServletRequest request = TestUtil.mockRequestPath("/ja/");
-        String html = translate(request, settings, "<html></html>", 200, "", "{\"body\": \"response html\"}".getBytes());
-        String expect = "response html";
-        assertEquals(expect, html);
-    }
+        HttpServletRequest request = TestUtil.mockRequestPath("/ja/somepage/"); // mocks "https://example.com"
 
-    private String translate(HttpServletRequest request, Settings settings, String html, int code, String encoding, byte[] response) throws ApiException, IOException, ProtocolException {
         Headers headers = new Headers(request, settings);
-        HttpURLConnection con = mockHttpURLConnection(gzip(html.getBytes()).length, code, encoding, response);
+
         Api api = new Api(settings, headers);
-        return api.translate("ja", html, con);
+
+        ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
+        ByteArrayInputStream responseStream = new ByteArrayInputStream(apiServerResponse);
+        int returnCode = 200;
+        HttpURLConnection con = mockHttpURLConnection(requestStream, responseStream, returnCode, encoding);
+
+        String result = api.translate("ja", html, con);
+
+        String encodedApiRequestBody = decompress(requestStream.toByteArray());
+        String apiRequestBody = URLDecoder.decode(encodedApiRequestBody, "UTF-8");
+        String expectedRequestBody = "url=https://example.com/somepage/" +
+                                     "&token=token0" +
+                                     "&lang_code=ja" +
+                                     "&url_pattern=path" +
+                                     "&body=" + html;
+        assertEquals(expectedRequestBody, apiRequestBody);
+
+        return result;
     }
 
     private byte[] gzip(byte[] input) throws IOException, ProtocolException {
@@ -66,8 +87,7 @@ public class ApiTest extends TestCase {
         return buffer.toByteArray();
     }
 
-    private HttpURLConnection mockHttpURLConnection( int sendLength, int code, String encoding, byte[] response) throws IOException, ProtocolException {
-        InputStream responseStream = new ByteArrayInputStream(response);
+    private HttpURLConnection mockHttpURLConnection(ByteArrayOutputStream requestStream, ByteArrayInputStream responseStream, int code, String encoding) throws IOException, ProtocolException {
         HttpURLConnection mock = EasyMock.createMock(HttpURLConnection.class);
         mock.setDoOutput(true);
         mock.setRequestProperty(EasyMock.anyString(), EasyMock.anyString());
@@ -75,9 +95,24 @@ public class ApiTest extends TestCase {
         mock.setRequestMethod("POST");
         EasyMock.expect(mock.getResponseCode()).andReturn(code);
         EasyMock.expect(mock.getContentEncoding()).andReturn(encoding);
-        EasyMock.expect(mock.getOutputStream()).andReturn(new ByteArrayOutputStream());
+        EasyMock.expect(mock.getOutputStream()).andReturn(requestStream);
         EasyMock.expect(mock.getInputStream()).andReturn(responseStream);
         EasyMock.replay(mock);
         return mock;
+    }
+
+    private static String decompress(byte[] compressed) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+        GZIPInputStream gis = new GZIPInputStream(bis);
+        BufferedReader br = new BufferedReader(new InputStreamReader(gis, "UTF-8"));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while((line = br.readLine()) != null) {
+            sb.append(line);
+        }
+        br.close();
+        gis.close();
+        bis.close();
+        return sb.toString();
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -102,17 +102,23 @@ public class ApiTest extends TestCase {
     }
 
     private static String decompress(byte[] compressed) throws IOException {
-        ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
-        GZIPInputStream gis = new GZIPInputStream(bis);
-        BufferedReader br = new BufferedReader(new InputStreamReader(gis, "UTF-8"));
         StringBuilder sb = new StringBuilder();
-        String line;
-        while((line = br.readLine()) != null) {
-            sb.append(line);
+        ByteArrayInputStream bis = null;
+        GZIPInputStream gis = null;
+        BufferedReader br = null;
+        try {
+            bis = new ByteArrayInputStream(compressed);
+            gis = new GZIPInputStream(bis);
+            br = new BufferedReader(new InputStreamReader(gis, "UTF-8"));
+            String line;
+            while((line = br.readLine()) != null) {
+                sb.append(line);
+            }
+        } finally {
+            gis.close();
+            bis.close();
+            br.close();
         }
-        br.close();
-        gis.close();
-        bis.close();
         return sb.toString();
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -19,7 +19,7 @@ public class HtmlConverterTest extends TestCase {
     }
 
     public void testRemoveWovnSnippet() {
-        String original = "<html><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.3.6\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
+        String original = "<html><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
         String removedHtml = "<html><head></head><body></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = new HtmlConverter(settings, original);
@@ -82,7 +82,7 @@ public class HtmlConverterTest extends TestCase {
 
     public void testMixAllCase() {
         String original = "<html><head>" +
-            "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.3.6\" data-wovnio-type=\"backend_without_api\" async></script>" +
+            "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script>" +
             "<script>alert(1)</script>" +
             "<link ref=\"altername\" hreflang=\"en\" href=\"http://localhost:8080/\"><link ref=\"altername\" hreflang=\"ja\" href=\"http://localhost:8080/ja/\"><link ref=\"altername\" hreflang=\"ar\" href=\"http://localhost:8080/ar/\">" +
             "</head><body>" +


### PR DESCRIPTION
Include schema("http://") in request to API server.

#### Problem
Related to https://github.com/WOVNio/equalizer/issues/9799

wovnjava would send `url=example.com` to html-swapper, and html-swapper then changed it to `://example.com`, causing the error.

#### Solution
Now we make sure to always send `url=http[s]://example.com`.

This change includes some reorganization in the relevant tests in order to properly test the request that gets sent to the API server.

It also includes a version bump to 0.3.7