### PR TITLE
Fix current lang to use target lang on handling timeout error

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -29,12 +29,12 @@ class Interceptor {
             return converter.restore(translatedBody);
         } catch (ApiException e) {
             Logger.log.error("ApiException", e);
-            return apiTranslateFail(body, e.getMessage());
+            return apiTranslateFail(body, lang, e.getMessage());
         }
     }
 
-    private String apiTranslateFail(String body, String reason) {
-        return new HtmlConverter(settings, body).convert(headers, settings.defaultLang, reason);
+    private String apiTranslateFail(String body, String lang, String reason) {
+        return new HtmlConverter(settings, body).convert(headers, lang, reason);
     }
 
     private String localTranslate(String lang, String body) {

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -37,7 +37,7 @@ public class InterceptorTest extends TestCase {
         }});
         String html = translate("/ja/", originalHtml, settings, mockApi("timeout"));
         String expect = "<!doctype html><html><head><title>test</title>" +
-                        "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"timeout\" async></script>" +
+                        "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"timeout\" async></script>" +
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
                         "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +


### PR DESCRIPTION
Fix for https://github.com/WOVNio/equalizer/issues/11688

This is the change to set target lang to target lang instead of default lang after ApiException happened.
Because currentLang make widgets swap even if  ApiException happened,