### PR TITLE
remove unnecessary redirect.

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -30,7 +30,7 @@ public class WovnServletFilter implements Filter {
     {
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
-        boolean hasShorterPath = lang.length() > 0 && lang.equals(settings.defaultLang);
+        boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
         if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
         } else if (htmlChecker.canTranslatePath(headers.pathName)) {

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -59,12 +59,12 @@ public class TestUtil {
         return mock;
     }
 
-    public static ServletResponse mockResponse(String contentType, String encoding) throws IOException {
+    public static ServletResponse mockResponse(String contentType, String encoding, String location) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
         mock.setContentLength(EasyMock.anyInt());
         EasyMock.expectLastCall();
         mock.setCharacterEncoding("utf-8");
-        EasyMock.expect(mock.getHeader("Location")).andReturn("");
+        EasyMock.expect(mock.getHeader("Location")).andReturn(location);
         EasyMock.expectLastCall();
         EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));
         EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();
@@ -88,7 +88,7 @@ public class TestUtil {
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
-        ServletResponse res = TestUtil.mockResponse(contentType, "");
+        ServletResponse res = mockResponse(contentType, "", option.getOrDefault("location", ""));
         FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -68,10 +68,11 @@ public class WovnServletFilterTest extends TestCase {
         HashMap<String, String> testQuery = new HashMap<String, String>() {{
             put("urlPattern", "query");
             put("defaultLang", "ja");
+            put("location", "https://example.com/search/?abc=123&wovn=ja");
         }};
         FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/?abc=123&wovn=ja", testQuery);
         HttpServletResponse res = (HttpServletResponse)mock.res;
-        assertEquals("", res.getHeader("Location"));
+        assertEquals("https://example.com/search/?abc=123&wovn=ja", res.getHeader("Location"));
     }
 
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -64,6 +64,16 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
+    public void testLocation() throws ServletException, IOException {
+        HashMap<String, String> testQuery = new HashMap<String, String>() {{
+            put("urlPattern", "query");
+            put("defaultLang", "ja");
+        }};
+        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/?abc=123&wovn=ja", testQuery);
+        HttpServletResponse res = (HttpServletResponse)mock.res;
+        assertEquals("", res.getHeader("Location"));
+    }
+
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
         put("urlPattern", "query");
     }};


### PR DESCRIPTION
> [prime]kanematsu: search text show wrong encoding

[issue/12121](https://github.com/WOVNio/equalizer/issues/12121)

We made a form and tried it, but we could not reproduce the same problem.
However, since unnecessary redirection has occurred, changed the redirect condition slightly.
This change may solve the problem, so need to have the customer test it.