### PR TITLE
Create workaround for error with maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,18 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+
+            <!--
+            Set useSystemClassLoader to false as workaround for the issue discussed here
+            https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Circleci is currently not able to run tests because of an error raised by maven-surefire-plugin
```
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```
This change applies a workaround for it.

Currently failing CI: https://circleci.com/gh/WOVNio/wovnjava/316?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

SO thread: https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class