### PR TITLE
Disable super.flushBuffer on response wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,11 @@ Including three classes, `email-address-element`, `my-secret-class`, and `noshow
   ...
 </filter>
 ```
+
+### 2.10. enableFlushBuffer
+This parameter is set to `false` by default.
+
+When `enableFlushBuffer` is set to `false`, the wovnjava servlet filter will capture calls to `response.flushBuffer()` without
+immediately writing content to the client. Only when the complete HTML response is ready will the filter translate the content
+and send it to the client. This is necessary in order to translate the content properly.
+

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -35,6 +35,7 @@ class Settings {
     final String version = VERSION;
     int connectTimeout = 1000;
     int readTimeout = 1000;
+    boolean enableFlushBuffer = false;
 
     Settings(FilterConfig config) {
         super();
@@ -136,6 +137,11 @@ class Settings {
         p = config.getInitParameter("strictHtmlCheck");
         if (p != null && !p.isEmpty()) {
             this.strictHtmlCheck = getBoolParameter(p);
+        }
+
+        p = config.getInitParameter("enableFlushBuffer");
+        if (p != null && !p.isEmpty()) {
+            this.enableFlushBuffer = getBoolParameter(p);
         }
 
         this.initialize();

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -17,8 +17,6 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
     private ServletOutputStream output;
     private Headers headers;
 
-    private boolean disableFlushBuffer = true;
-
     WovnHttpServletResponse(HttpServletResponse response, Headers headers) {
         super(response);
         this.buff = new ByteArrayOutputStream();
@@ -88,11 +86,9 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
 
         // Calling `super.flushBuffer` may lead to response already being committed.
         // This prevents us from, among other things, changing the HTTP content-length.
-        // This problem happens in Weblogic when a servlet forward method trigger a
-        // flush before it forwarded.
-        // disableFlushBuffer for that purpose is 'true' by default
+        // flushBuffer for that purpose is disabled by default
         // See: https://jira.terracotta.org/jira/si/jira.issueviews:issue-html/EHC-447/EHC-447.html
-        if (!disableFlushBuffer) {
+        if (this.headers.settings.enableFlushBuffer) {
           super.flushBuffer();
         }
     }

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -23,7 +23,7 @@ public class TestUtil {
 
     public static FilterConfig makeConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses", "enableFlushBuffer"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);


### PR DESCRIPTION
### Comments
If `flushBuffer()` gets called on the ServletResponse, it commits changes to the response such that we can no longer change headers. However, wovnjava relies on changing `content-length` because we alter the size of the response.

Here is from [Oracle docs](https://docs.oracle.com/javaee/7/api/javax/servlet/ServletResponse.html#flushBuffer--):
```
void flushBuffer()
          throws IOException
Forces any content in the buffer to be written to the client. A call to this method
automatically commits the response, meaning the status code and headers will be written.
```

Using the library with a servlet deployed on WebLogic, the response was flushed before reaching our filter, which made us unable to change `content-length` to a bigger value. Therefore, the last part of the document was lost.

### Request before change
Request for original language receives full document, while the request for translated language loses the last part of its document. (content-length remains at 637)
```
$ curl -v weblogic.test/encode/utf.html
...
< HTTP/1.1 200 OK
< date: Thu, 07 Feb 2019 06:22:26 GMT
< accept-ranges: bytes
< content-length: 637
< content-type: text/html; charset=utf-8
...
```
```
$ curl -v weblogic.test/en/encode/utf.html
...
< HTTP/1.1 200 OK
< date: Thu, 07 Feb 2019 06:33:07 GMT
< accept-ranges: bytes
< content-length: 637
< content-type: text/html; charset=utf-8
...
```

### Request after change
After the change, the request for translated language is able to expand content length, and the full document is received. (content-length increased to 853)
```
$ curl -v weblogic.test/en/encode/utf.html
...
< HTTP/1.1 200 OK
< date: Thu, 07 Feb 2019 06:59:24 GMT
< accept-ranges: bytes
< content-length: 853
< content-type: text/html; charset=utf-8
...
```