### PR TITLE
Catch flushBuffer on response wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,11 @@ Including three classes, `email-address-element`, `my-secret-class`, and `noshow
   ...
 </filter>
 ```
+
+### 2.10. enableFlushBuffer
+This parameter is set to `false` by default.
+
+When `enableFlushBuffer` is set to `false`, the wovnjava servlet filter will capture calls to `response.flushBuffer()` without
+immediately writing content to the client. Only when the complete HTML response is ready will the filter translate the content
+and send it to the client. This is necessary in order to translate the content properly.
+

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -35,6 +35,7 @@ class Settings {
     final String version = VERSION;
     int connectTimeout = 1000;
     int readTimeout = 1000;
+    boolean enableFlushBuffer = false;
 
     Settings(FilterConfig config) {
         super();
@@ -136,6 +137,11 @@ class Settings {
         p = config.getInitParameter("strictHtmlCheck");
         if (p != null && !p.isEmpty()) {
             this.strictHtmlCheck = getBoolParameter(p);
+        }
+
+        p = config.getInitParameter("enableFlushBuffer");
+        if (p != null && !p.isEmpty()) {
+            this.enableFlushBuffer = getBoolParameter(p);
         }
 
         this.initialize();

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -17,8 +17,6 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
     private ServletOutputStream output;
     private Headers headers;
 
-    private boolean disableFlushBuffer = true;
-
     WovnHttpServletResponse(HttpServletResponse response, Headers headers) {
         super(response);
         this.buff = new ByteArrayOutputStream();
@@ -88,11 +86,9 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
 
         // Calling `super.flushBuffer` may lead to response already being committed.
         // This prevents us from, among other things, changing the HTTP content-length.
-        // This problem happens in Weblogic when a servlet forward method trigger a
-        // flush before it forwarded.
-        // disableFlushBuffer for that purpose is 'true' by default
+        // flushBuffer for that purpose is disabled by default
         // See: https://jira.terracotta.org/jira/si/jira.issueviews:issue-html/EHC-447/EHC-447.html
-        if (!disableFlushBuffer) {
+        if (this.headers.settings.enableFlushBuffer) {
           super.flushBuffer();
         }
     }

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -23,7 +23,7 @@ public class TestUtil {
 
     public static FilterConfig makeConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "urlPatternReg", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses", "enableFlushBuffer"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);


### PR DESCRIPTION
This change makes sure that when `response.flushBuffer()` is called on the WovnHttpServletResponse, the call is not propagated to the wrapped original ServletResponse.

If flushBuffer is called on the original ServletResponse, we can no longer modify headers to f.ex. increase content-length (to have room for translated content). The filter also becomes vulnerable to errors such as IllegalStateException when attempting to access `response.getWriter()` and `response.getOutputBuffer()`.

See also the initial flushBuffer PR for discussion on the change: https://github.com/WOVNio/wovnjava/pull/83
That PR was used for investigating erroneous behavior on the customer's server, and will not be merged.