### PR TITLE
Create feature sitePrefixPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Including three classes, `email-address-element`, `my-secret-class`, and `noshow
 
 ### 2.11. sitePrefixPath
 
-This parameter lets you set a path for which WOVN will translate pages. By default, WOVN will translate all pages for your domain.
+This parameter lets you set a prefix path to use as an anchor for which WOVN will translate pages. With this setting, WOVN will only translate pages that match the prefix path, and the path language code will be added _after_ the prefix path.
 
 If, for example, you set your sitePrefix path to `city` as follows
 ```
@@ -229,4 +229,19 @@ If, for example, you set your sitePrefix path to `city` as follows
 ```
 WOVN will only translate pages that match `http://www.mysite.com/city/*`.
 
-`http://www.mysite.com/city/tokyo/map.html` would be translated, and it would be possible to access that page with language code (in english) like this: `http://www.mysite.com/city/en/tokyo.map.html`. Notice that the language code is set _after_ the sitePrefixPath.
+`http://www.mysite.com/city/tokyo/map.html` would be translated, and it would be possible to access that page with language code (in english) like this: `http://www.mysite.com/city/en/tokyo.map.html`.
+
+By default, WOVN will translate all pages for your domain and process path language codes at the beginning of the path.
+
+#### Requirements
+
+This setting _must_ be used together with the `urlPattern = path` setting.
+
+Furthermore, it is highly recommended to also configure your `web.xml` with a corresponding filter-mapping for the wovnjava servlet filter. If prefix path is set to `city` as in the example above, the corresponding filter-mapping would look as follows.
+```
+<filter-mapping>
+  <filter-name>wovn</filter-name>
+  <url-pattern>/city/*</url-pattern>
+  ...
+</filter-mapping>
+```

--- a/README.md
+++ b/README.md
@@ -211,3 +211,22 @@ Including three classes, `email-address-element`, `my-secret-class`, and `noshow
   ...
 </filter>
 ```
+
+### 2.11. sitePrefixPath
+
+This parameter lets you set a path for which WOVN will translate pages. By default, WOVN will translate all pages for your domain.
+
+If, for example, you set your sitePrefix path to `city` as follows
+```
+<filter>
+  ...
+  <init-param>
+    <param-name>sitePrefixPath</param-name>
+    <param-value>city</param-value>
+  </init-param>
+  ...
+</filter>
+```
+WOVN will only translate pages that match `http://www.mysite.com/city/*`.
+
+`http://www.mysite.com/city/tokyo/map.html` would be translated, and it would be possible to access that page with language code (in english) like this: `http://www.mysite.com/city/en/tokyo.map.html`. Notice that the language code is set _after_ the sitePrefixPath.

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -150,6 +150,8 @@ class Api {
         appendValue(sb, lang);
         appendValue(sb, "&version=");
         appendValue(sb, settings.version);
+        appendValue(sb, "&site_prefix_path=");
+        appendValue(sb, settings.sitePrefixPathWithoutSlash);
         appendValue(sb, ")");
         return new URL(sb.toString());
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -130,6 +130,7 @@ class Api {
         appendKeyValue(sb, "&token=", settings.projectToken);
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
+        appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
         appendKeyValue(sb, "&body=", body);
         return sb.toString();
     }
@@ -150,8 +151,6 @@ class Api {
         appendValue(sb, lang);
         appendValue(sb, "&version=");
         appendValue(sb, settings.version);
-        appendValue(sb, "&site_prefix_path=");
-        appendValue(sb, settings.sitePrefixPathWithoutSlash);
         appendValue(sb, ")");
         return new URL(sb.toString());
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -311,6 +311,10 @@ class Headers {
         }
     }
 
+    boolean isValidPath() {
+        return this.pathName.startsWith(this.settings.sitePrefixPathWithoutSlash);
+    }
+
     private String removeFilePart(String path) {
         if (path.endsWith("/")) {
             return path;

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -201,10 +201,20 @@ class Headers {
                 location = lang.toLowerCase() + "." + location;
             } else {
                 // path
-                if (location.contains("/")) {
-                    location = location.replaceFirst("/", "/" + lang + "/");
+                if (settings.hasSitePrefixPath) {
+                    String sitePrefixPath = this.settings.sitePrefixPathWithoutSlash;
+                    if (this.pathName.startsWith(sitePrefixPath)) {
+                        location = location.replaceFirst(sitePrefixPath, sitePrefixPath + "/" + lang);
+                        if (!location.endsWith("/")) {
+                          location += "/";
+                        }
+                    }
                 } else {
-                    location += "/" + lang + "/";
+                    if (location.contains("/")) {
+                        location = location.replaceFirst("/", "/" + lang + "/");
+                    } else {
+                        location += "/" + lang + "/";
+                    }
                 }
             }
             return protocol + "://" + location;

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -239,6 +239,10 @@ class Headers {
         }
         path = pathNormalize(path);
 
+        if (!path.startsWith(this.settings.sitePrefixPathWithoutSlash)) {
+            return location;
+        }
+
         // check location already have language code
         if (settings.urlPattern.equals("query") && location.contains("wovn=")) {
             return location;
@@ -258,6 +262,7 @@ class Headers {
         String queryLangCode = "";
         String subdomainLangCode = "";
         String pathLangCode = "";
+        String sitePrefixPath = "";
         if (settings.urlPattern.equals("query")) {
             if (location.contains("?")) {
                 queryLangCode = "&wovn=" + lang;
@@ -268,8 +273,10 @@ class Headers {
             subdomainLangCode = lang + ".";
         } else {
             pathLangCode = "/" + lang;
+            sitePrefixPath = this.settings.sitePrefixPathWithoutSlash;
+            path = path.replaceFirst(sitePrefixPath, "");
         }
-        return locationProtocol + "://" + subdomainLangCode + host + pathLangCode + path + queryLangCode;
+        return locationProtocol + "://" + subdomainLangCode + host + sitePrefixPath + pathLangCode + path + queryLangCode;
     }
     /**
      * @return String Returns request URL without any language code

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -131,7 +131,8 @@ class HtmlConverter {
         sb.append("&langCodeAliases={}&version=");
         sb.append(settings.version);
         if (settings.hasSitePrefixPath) {
-            sb.append("&site_prefix_path=" + settings.sitePrefixPathWithoutSlash);
+            sb.append("&site_prefix_path=");
+            sb.append(settings.sitePrefixPathWithoutSlash);
         }
         String key = sb.toString();
         js.attr("src", "//j.wovn.io/1");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -132,7 +132,7 @@ class HtmlConverter {
         sb.append(settings.version);
         if (settings.hasSitePrefixPath) {
             sb.append("&site_prefix_path=");
-            sb.append(settings.sitePrefixPathWithoutSlash);
+            sb.append(settings.sitePrefixPathWithoutSlash.replaceFirst("/", ""));
         }
         String key = sb.toString();
         js.attr("src", "//j.wovn.io/1");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -130,6 +130,9 @@ class HtmlConverter {
         sb.append(settings.urlPattern);
         sb.append("&langCodeAliases={}&version=");
         sb.append(settings.version);
+        if (settings.hasSitePrefixPath) {
+            sb.append("&site_prefix_path=" + settings.sitePrefixPathWithoutSlash);
+        }
         String key = sb.toString();
         js.attr("src", "//j.wovn.io/1");
         js.attr("data-wovnio", key);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -59,6 +59,7 @@ class Settings {
         p = config.getInitParameter("sitePrefixPath");
         this.hasSitePrefixPath = p != null && p.length() > 0;
         if (this.hasSitePrefixPath) {
+            if (!p.startsWith("/")) p = "/" + p;
             if (p.endsWith("/")) {
                 this.sitePrefixPathWithSlash = p;
                 this.sitePrefixPathWithoutSlash = p.substring(0, p.length() - 1);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -226,6 +226,10 @@ class Settings {
             valid = false;
             errors.add("Supported langs is not configured.");
         }
+        if (hasSitePrefixPath && urlPattern != "path") {
+            valid = false;
+            errors.add("sitePrefixPath must be used together with urlPattern=path.");
+        }
 
         if (errors.size() > 0) {
             Logger.log.error("Settings is invalid: " + errors.toString());

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -33,7 +33,7 @@ public class WovnServletFilter implements Filter {
         boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
         if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
-        } else if (htmlChecker.canTranslatePath(headers.pathName)) {
+        } else if (headers.isValidPath() && htmlChecker.canTranslatePath(headers.pathName)) {
             tryTranslate(headers, (HttpServletRequest)request, response, chain);
         } else {
             WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -70,6 +70,7 @@ public class ApiTest extends TestCase {
                                      "&token=token0" +
                                      "&lang_code=ja" +
                                      "&url_pattern=path" +
+                                     "&site_prefix_path=" +
                                      "&body=" + html;
         assertEquals(expectedRequestBody, apiRequestBody);
 

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -428,6 +428,21 @@ public class HeadersTest extends TestCase {
         assertEquals("https://example.com/th/", h.locationWithLangCode("https://example.com/th/"));
     }
 
+    public void testIsValidPath() {
+        Headers h;
+        h = makeHeaderWithSitePrefixPath("/", "global");
+        assertEquals(false, h.isValidPath());
+
+        h = makeHeaderWithSitePrefixPath("/global", "global");
+        assertEquals(true, h.isValidPath());
+
+        h = makeHeaderWithSitePrefixPath("/global/ja/foo", "global");
+        assertEquals(true, h.isValidPath());
+
+        h = makeHeaderWithSitePrefixPath("/ja/global/foo", "global");
+        assertEquals(false, h.isValidPath());
+    }
+
     private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) {
         HttpServletRequest mockRequest = mockRequestPath(requestPath);
         HashMap<String, String> option = new HashMap<String, String>() {{

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -304,7 +304,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testSitePrefixPath() {
-        Headers h = makeHeader("/global/en/foo", "/global/");
+        Headers h = makeHeaderWithSitePrefixPath("/global/en/foo", "/global/");
         assertEquals("/global/", h.removeLang("/global/en/", null));
         assertEquals("/en/global/", h.removeLang("/en/global/", null));
     }
@@ -389,9 +389,29 @@ public class HeadersTest extends TestCase {
         assertEquals("https://ja.example.com/file", h.locationWithLangCode("../../file"));
     }
 
-    private Headers makeHeader(String requestPath, String sitePrefix) {
+    public void testLocationWithSitePrefixPath() {
+        Headers h = makeHeaderWithSitePrefixPath("/global/ja/foo", "/global/");
+        assertEquals("http://example.com/", h.locationWithLangCode("http://example.com/"));
+        assertEquals("http://example.com/global/ja/", h.locationWithLangCode("http://example.com/global/"));
+        assertEquals("https://example.com/global/ja/", h.locationWithLangCode("https://example.com/global/"));
+        assertEquals("https://example.com/global/ja/", h.locationWithLangCode("https://example.com/global/ja/"));
+        assertEquals("https://example.com/global/th/", h.locationWithLangCode("https://example.com/global/th/"));
+        assertEquals("https://example.com/global/ja/tokyo/", h.locationWithLangCode("https://example.com/global/tokyo/"));
+        assertEquals("https://example.com/global/ja/file.html", h.locationWithLangCode("https://example.com/global/file.html"));
+        assertEquals("https://example.com/global/ja/file.html", h.locationWithLangCode("https://example.com/pics/../global/file.html"));
+        assertEquals("https://example.com/global/../../file.html", h.locationWithLangCode("https://example.com/global/../../file.html"));
+        assertEquals("https://example.com/tokyo/", h.locationWithLangCode("https://example.com/tokyo/"));
+        assertEquals("https://example.com/tokyo/global/", h.locationWithLangCode("https://example.com/tokyo/global/"));
+        assertEquals("https://example.com/ja/global/", h.locationWithLangCode("https://example.com/ja/global/"));
+        assertEquals("https://example.com/th/global/", h.locationWithLangCode("https://example.com/th/global/"));
+        assertEquals("https://example.com/th/", h.locationWithLangCode("https://example.com/th/"));
+    }
+
+    private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) {
         HttpServletRequest mockRequest = mockRequestPath(requestPath);
-        HashMap<String, String> option = new HashMap<String, String>(){ { put("sitePrefixPath", "/global/"); } };
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("sitePrefixPath", sitePrefixPath);
+        }};
         Settings s = TestUtil.makeSettings(option);
         return new Headers(mockRequest, s);
     }

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -248,21 +248,21 @@ public class HeadersTest extends TestCase {
         assertEquals("https://example.com/ja/dir1/dir2/", h.redirectLocation("ja"));
     }
 
-    public void testRedirectLocationWithSitePrefixPathBasePathOnly() {
+    public void testRedirectLocation_WithSitePrefixPathBasePathOnly_AddsLanguageToUrl() {
         Headers h = makeHeaderWithSitePrefixPath("/global", "/global/");
         assertEquals("https://example.com/global", h.redirectLocation("en")); // `en` is defaultLang
         assertEquals("https://example.com/global/ja/", h.redirectLocation("ja"));
         assertEquals("https://example.com/global/garbage/", h.redirectLocation("garbage"));
     }
 
-    public void testRedirectLocationWithSitePrefixPathMatchingPath() {
+    public void testRedirectLocation_WithSitePrefixPathMatchingPath_AddsLanguageToUrl() {
         Headers h = makeHeaderWithSitePrefixPath("/global/tokyo/", "/global/");
         assertEquals("https://example.com/global/tokyo/", h.redirectLocation("en")); // `en` is defaultLang
         assertEquals("https://example.com/global/ja/tokyo/", h.redirectLocation("ja"));
         assertEquals("https://example.com/global/garbage/tokyo/", h.redirectLocation("garbage"));
     }
 
-    public void testRedirectLocationWithSitePrefixPathNonmatchingPath() {
+    public void testRedirectLocation_WithSitePrefixPathNonmatchingPath_DoesNotModifyUrl() {
         Headers h = makeHeaderWithSitePrefixPath("/tokyo/global/", "/global/");
         assertEquals("https://example.com/tokyo/global/", h.redirectLocation("en")); // `en` is defaultLang
         assertEquals("https://example.com/tokyo/global/", h.redirectLocation("ja"));

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -248,6 +248,27 @@ public class HeadersTest extends TestCase {
         assertEquals("https://example.com/ja/dir1/dir2/", h.redirectLocation("ja"));
     }
 
+    public void testRedirectLocationWithSitePrefixPathBasePathOnly() {
+        Headers h = makeHeaderWithSitePrefixPath("/global", "/global/");
+        assertEquals("https://example.com/global", h.redirectLocation("en")); // `en` is defaultLang
+        assertEquals("https://example.com/global/ja/", h.redirectLocation("ja"));
+        assertEquals("https://example.com/global/garbage/", h.redirectLocation("garbage"));
+    }
+
+    public void testRedirectLocationWithSitePrefixPathMatchingPath() {
+        Headers h = makeHeaderWithSitePrefixPath("/global/tokyo/", "/global/");
+        assertEquals("https://example.com/global/tokyo/", h.redirectLocation("en")); // `en` is defaultLang
+        assertEquals("https://example.com/global/ja/tokyo/", h.redirectLocation("ja"));
+        assertEquals("https://example.com/global/garbage/tokyo/", h.redirectLocation("garbage"));
+    }
+
+    public void testRedirectLocationWithSitePrefixPathNonmatchingPath() {
+        Headers h = makeHeaderWithSitePrefixPath("/tokyo/global/", "/global/");
+        assertEquals("https://example.com/tokyo/global/", h.redirectLocation("en")); // `en` is defaultLang
+        assertEquals("https://example.com/tokyo/global/", h.redirectLocation("ja"));
+        assertEquals("https://example.com/tokyo/global/", h.redirectLocation("garbage"));
+    }
+
     public void testRedirectLocationSubdomain() {
 
     }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -103,7 +103,7 @@ public class HtmlConverterTest extends TestCase {
 
     public void testConvertWithSitePrefixPath() {
         String original = "<html><head></head><body></body></html>";
-        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;site_prefix_path=/global\" data-wovnio-type=\"test-type\" async></script>";
+        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;site_prefix_path=global\" data-wovnio-type=\"test-type\" async></script>";
         String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">";


### PR DESCRIPTION
sitePrefixPath lets the customer set a prefix path to use as an anchor for which WOVN will translate pages. With this setting, WOVN will only translate pages that match the prefix path, and the path language code will be added after the prefix path.

With this setting the following behaviors are affected
* Only process requests that match prefix path
* Detect language code in request path after matching prefix path
* Insert hreflangs with language code after matching prefix path
* Send sitePrefixPath setting in snippet settings (if the setting is used)
* Send sitePrefixPath setting in request to translation API (always)