### PR TITLE
Document supportedLangs setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,58 @@ Including three classes, `email-address-element`, `my-secret-class`, and `noshow
   ...
 </filter>
 ```
+
+### 2.12. supportedLangs
+
+This parameter lists the set of languages for which the library performs translations.
+
+Example settings for English, Japanese, and Korean:
+```xml
+<filter>
+    ...
+    <init-param>
+      <param-name>supportedLangs</param-name>
+      <param-value>en,ja,ko</param-value>
+    </init-param>
+    ...
+</filter>
+```
+Note: `defaultLang` will automatically be included in the set of supported languages.
+
+Find a list of languages that WOVN supports below.
+
+## Supported Langauges
+
+Language code | Language name | Name in English
+---|---|---
+ar | ﺎﻠﻋﺮﺒﻳﺓ | Arabic
+bg | Български | Bulgarian
+zh-CHS | 简体中文 | Simp Chinese
+zh-CHT | 繁體中文 | Trad Chinese
+da | Dansk | Danish
+nl | Nederlands | Dutch
+en | English | English
+fi | Suomi | Finnish
+fr | Français | French
+de | Deutsch | German
+el | Ελληνικά | Greek
+he | עברית | Hebrew
+id | Bahasa | Indonesian
+it | Italiano | Italian
+ja | 日本語 | Japanese
+ko | 한국어 | Korean
+ms | Bahasa | Malay
+my | ဗမာစာ | Burmese
+ne | नेपाली भाषा | Nepali
+no | Norsk | Norwegian
+pl | Polski | Polish
+pt | Português | Portuguese
+ru | Русский | Russian
+es | Español | Spanish
+sv | Svensk | Swedish
+th | ภาษาไทย | Thai
+hi | हिन्दी | Hindi
+tr | Türkçe | Turkish
+uk | Українська | Ukrainian
+vi | Tiếng | Vietnamese
+tl | Tagalog | Tagalog

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -41,7 +41,6 @@ class Settings {
 
         this.query = new ArrayList<String>();
         this.supportedLangs = new ArrayList<String>();
-        this.supportedLangs.add("en");
         this.ignoreClasses = new ArrayList<String>();
 
         String p;


### PR DESCRIPTION
`supportedLangs` is an important setting, and this adds instructions for it to the README.

In order to help configure it, we also include a list of languages that WOVN can support.

Also, `"en"` is no longer included in `supportedLangs` by default.

#### Future work
This setting should probably be a required setting. For now, we don't change configuration requirements.