### PR TITLE
Set content-type to UTF-8 also for fallback method

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -35,6 +35,7 @@ class HtmlConverter {
         removeHrefLangIfConflicts();
         appendSnippet(lang, type);
         appendHrefLang(headers);
+        replaceContentType();
         return doc.html();
     }
 
@@ -156,5 +157,20 @@ class HtmlConverter {
         Comment comment = new Comment(WOVN_MARKER_PREFIX + String.valueOf(markers.size()));
         element.replaceWith(comment);
         markers.add(restore(element.outerHtml())); // restore original text if element has marker
+    }
+
+    private void replaceContentType() {
+        // Remove old content type
+        Elements elements = doc.getElementsByTag("meta");
+        for (Element element : elements) {
+            if (element.attr("http-equiv").toLowerCase().equals("content-type")) {
+                element.remove();
+            }
+        }
+        // Set new content type
+        Element meta = new Element(Tag.valueOf("meta"), "");
+        meta.attr("http-equiv", "Content-Type");
+        meta.attr("content", "text/html; charset=UTF-8");
+        doc.head().appendChild(meta);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -107,7 +107,8 @@ public class HtmlConverterTest extends TestCase {
         String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">";
-        String expectedHtml = "<html><head>" + expectedSnippet + expectedHrefLangs + "</head><body></body></html>";
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = "<html><head>" + expectedSnippet + expectedHrefLangs + expectedContentType + "</head><body></body></html>";
 
         HashMap<String, String> option = new HashMap<String, String>() {{
             put("defaultLang", "ja");

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -29,7 +29,7 @@ public class InterceptorTest extends TestCase {
     }
 
     public void testApiTimeout() throws NoSuchMethodException, IllegalAccessException, IOException, ServletException {
-        String originalHtml = "<!doctype html><html><head><title>test</title></head><body>test</body></html>";
+        String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">test</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("projectToken", "token0");
             put("defaultLang", "en");
@@ -41,12 +41,13 @@ public class InterceptorTest extends TestCase {
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
                         "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +
+                        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" +
                         "</head><body>test</body></html>";
         assertEquals(expect, stripExtraSpaces(html));
     }
 
     public void testNoApi() throws NoSuchMethodException, IllegalAccessException, IOException, ServletException {
-        String originalHtml = "<!doctype html><html><head><title>test</title></head><body>test</body></html>";
+        String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body>test</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("projectToken", "token0");
             put("defaultLang", "en");
@@ -58,6 +59,7 @@ public class InterceptorTest extends TestCase {
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
                         "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +
+                        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" +
                         "</head><body>test</body></html>";
         assertEquals(expect, stripExtraSpaces(html));
     }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -29,7 +29,7 @@ public class InterceptorTest extends TestCase {
     }
 
     public void testApiTimeout() throws NoSuchMethodException, IllegalAccessException, IOException, ServletException {
-        String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">test</body></html>";
+        String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body>test</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("projectToken", "token0");
             put("defaultLang", "en");


### PR DESCRIPTION
When translating by API, we set a meta tag to declare content-type UTF-8.

With this change, we insert this meta tag also when processing the request without using the API for translation. Any existing content-type declaration will be replaced.