### PR TITLE
HTTP header debugging fields

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -93,7 +93,7 @@ class Api {
                 }
                 return extractHtml(input);
             } else {
-                throw new ApiException("status_" + String.valueOf(status), "");
+                throw new ApiException("Failure", "Status code " + String.valueOf(status));
             }
         } catch (UnsupportedEncodingException e) {
             throw new ApiException("UnsupportedEncodingException", e.getMessage());
@@ -136,7 +136,7 @@ class Api {
         LinkedHashMap<String, String> dict = JSON.decode(json);
         String html = dict.get("body");
         if (html == null) {
-            throw new ApiException("unknown_json_format", "");
+            throw new ApiException("ResponseFormatError", "Unknown JSON format");
         }
         return html;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -47,6 +47,7 @@ class Api {
     }
 
     String translate(String lang, String html) throws ApiException {
+        response.setHeader("X-Wovn-Api", "requested");
         HttpURLConnection con = null;
         try {
             URL url = getApiUrl(lang, html);

--- a/src/main/java/com/github/wovnio/wovnjava/ApiException.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ApiException.java
@@ -1,9 +1,20 @@
 package com.github.wovnio.wovnjava;
 
 class ApiException extends Exception {
-    static final ApiException timeout = new ApiException("timeout");
+    private String type;
+    private String details;
 
-    ApiException(String message) {
-        super(message);
+    ApiException(String type, String details) {
+        super(type + " : " + details);
+        this.type = type;
+        this.details = details;
+    }
+
+    String getType() {
+        return this.type;
+    }
+
+    String getDetails() {
+        return this.details;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -56,7 +56,7 @@ class Headers {
         }
         // Both getRequestURI() and getPathInfo() do not have query parameters.
         if (this.settings.originalQueryStringHeader.isEmpty()) {
-            if (this.request.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
+            if (r.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
                 requestUri += "?" + this.request.getQueryString();
             }
         } else {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -56,7 +56,7 @@ class Headers {
         }
         // Both getRequestURI() and getPathInfo() do not have query parameters.
         if (this.settings.originalQueryStringHeader.isEmpty()) {
-            if (r.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
+            if (this.request.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
                 requestUri += "?" + this.request.getQueryString();
             }
         } else {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -30,10 +30,10 @@ class HtmlConverter {
         return doc.html();
     }
 
-    String convert(Headers headers, String lang, String type) {
+    String convert(Headers headers, String lang) {
         removeSnippet();
         removeHrefLangIfConflicts();
-        appendSnippet(lang, type);
+        appendSnippet(lang);
         appendHrefLang(headers);
         replaceContentType();
         return doc.html();
@@ -118,7 +118,7 @@ class HtmlConverter {
         }
     }
 
-    private void appendSnippet(String lang, String type) {
+    private void appendSnippet(String lang) {
         Element js = new Element(Tag.valueOf("script"), "");
         StringBuilder sb = new StringBuilder();
         sb.append("key=");
@@ -130,7 +130,7 @@ class HtmlConverter {
         sb.append("&urlPattern=");
         sb.append(settings.urlPattern);
         sb.append("&langCodeAliases={}&version=");
-        sb.append(settings.version);
+        sb.append(Settings.VERSION);
         if (settings.hasSitePrefixPath) {
             sb.append("&site_prefix_path=");
             sb.append(settings.sitePrefixPathWithoutSlash.replaceFirst("/", ""));
@@ -138,7 +138,7 @@ class HtmlConverter {
         String key = sb.toString();
         js.attr("src", settings.snippetUrl);
         js.attr("data-wovnio", key);
-        js.attr("data-wovnio-type", type);
+        js.attr("data-wovnio-type", "fallback");
         js.attr("async", "async");
         doc.head().appendChild(js);
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -6,13 +6,13 @@ class Interceptor {
     private final Settings settings;
     private final Headers headers;
     private final Api api;
-    private final HttpServletResponse response;
+    private final ResponseHeaders responseHeaders;
 
-    Interceptor(Headers headers, Settings settings, Api api, HttpServletResponse response) {
+    Interceptor(Headers headers, Settings settings, Api api, ResponseHeaders responseHeaders) {
         this.headers = headers;
         this.settings = settings;
         this.api = api;
-        this.response = response;
+        this.responseHeaders = responseHeaders;
     }
 
     String translate(String body) {
@@ -30,10 +30,10 @@ class Interceptor {
             HtmlConverter converter = new HtmlConverter(settings, body);
             String convertedBody = converter.strip();
             String translatedBody = api.translate(lang, convertedBody);
-            this.response.setHeader("X-Wovn-Api", "Success");
+            responseHeaders.setApi("Success");
             return converter.restore(translatedBody);
         } catch (ApiException e) {
-            this.response.setHeader("X-Wovn-Api", e.getType());
+            responseHeaders.setApi(e.getType());
             Logger.log.error("ApiException", e);
             return apiTranslateFail(body, lang);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -30,7 +30,7 @@ class Interceptor {
             HtmlConverter converter = new HtmlConverter(settings, body);
             String convertedBody = converter.strip();
             String translatedBody = api.translate(lang, convertedBody);
-            this.response.setHeader("X-Wovn-Api", "success");
+            this.response.setHeader("X-Wovn-Api", "Success");
             return converter.restore(translatedBody);
         } catch (ApiException e) {
             this.response.setHeader("X-Wovn-Api", e.getType());

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -1,14 +1,18 @@
 package com.github.wovnio.wovnjava;
 
+import javax.servlet.http.HttpServletResponse;
+
 class Interceptor {
     private final Settings settings;
     private final Headers headers;
     private final Api api;
+    private final HttpServletResponse response;
 
-    Interceptor(Headers headers, Settings settings, Api api) {
+    Interceptor(Headers headers, Settings settings, Api api, HttpServletResponse response) {
         this.headers = headers;
         this.settings = settings;
         this.api = api;
+        this.response = response;
     }
 
     String translate(String body) {
@@ -26,18 +30,20 @@ class Interceptor {
             HtmlConverter converter = new HtmlConverter(settings, body);
             String convertedBody = converter.strip();
             String translatedBody = api.translate(lang, convertedBody);
+            this.response.setHeader("X-Wovn-Api", "success");
             return converter.restore(translatedBody);
         } catch (ApiException e) {
+            this.response.setHeader("X-Wovn-Api", e.getType());
             Logger.log.error("ApiException", e);
-            return apiTranslateFail(body, lang, e.getMessage());
+            return apiTranslateFail(body, lang);
         }
     }
 
-    private String apiTranslateFail(String body, String lang, String reason) {
-        return new HtmlConverter(settings, body).convert(headers, lang, reason);
+    private String apiTranslateFail(String body, String lang) {
+        return new HtmlConverter(settings, body).convert(headers, lang);
     }
 
     private String localTranslate(String lang, String body) {
-        return new HtmlConverter(settings, body).convert(headers, lang, "backend_without_api");
+        return new HtmlConverter(settings, body).convert(headers, lang);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
@@ -11,8 +11,8 @@ import javax.xml.bind.DatatypeConverter;
 import net.arnx.jsonic.JSON;
 
 class ResponseHeaders {
-    private static final String apiHeaderName = "X-Wovn-Api";
-    private static final String apiStatusHeaderName = "X-Wovn-Api-Status";
+    private static final String apiHeaderName = "X-Wovn-Api-Status";
+    private static final String apiStatusHeaderName = "X-Wovn-Api-StatusCode";
     private static final Map<String, String> fastlyHeaders;
     static {
         Map<String, String> headers = new HashMap<String, String>();

--- a/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
@@ -1,0 +1,50 @@
+package com.github.wovnio.wovnjava;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Collections;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.xml.bind.DatatypeConverter;
+
+import net.arnx.jsonic.JSON;
+
+class ResponseHeaders {
+    private static final String apiHeaderName = "X-Wovn-Api";
+    private static final String apiStatusHeaderName = "X-Wovn-Api-Status";
+    private static final Map<String, String> fastlyHeaders;
+    static {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("X-Cache", "X-Wovn-Cache");
+        headers.put("X-Cache-Hits", "X-Wovn-Cache-Hits");
+        headers.put("X-Wovn-Surrogate-Key", "X-Wovn-Surrogate-Key");
+        fastlyHeaders = Collections.unmodifiableMap(headers);
+    }
+
+    private final HttpServletResponse response;
+
+    ResponseHeaders(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    public void setApi(String value) {
+        this.response.setHeader(ResponseHeaders.apiHeaderName, value);
+    }
+
+    public void setApiStatus(String value) {
+        this.response.setHeader(ResponseHeaders.apiStatusHeaderName, value);
+    }
+
+    public void forwardFastlyHeaders(HttpURLConnection con) {
+        String apiHeaderName, responseHeaderName, value;
+        for (Map.Entry<String, String> entry : ResponseHeaders.fastlyHeaders.entrySet()) {
+            apiHeaderName = entry.getKey();
+            responseHeaderName = entry.getValue();
+            value = con.getHeaderField(apiHeaderName);
+            if (value != null) {
+                this.response.setHeader(responseHeaderName, value);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -52,7 +52,6 @@ public class WovnServletFilter implements Filter {
     private void tryTranslate(Headers headers, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers);
-        response.setHeader("X-Wovn-Api", "unused");
 
         if (settings.urlPattern.equals("path") && headers.getPathLang().length() > 0) {
             wovnRequest.getRequestDispatcher(headers.pathNameKeepTrailingSlash).forward(wovnRequest, wovnResponse);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -31,7 +31,7 @@ public class WovnServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
         ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
-        ((HttpServletResponse)response).setHeader("X-Wovn-Api", "unused");
+        ((HttpServletResponse)response).setHeader("X-Wovn-Api", "Unused");
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
         boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -30,13 +30,15 @@ public class WovnServletFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
+        ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+        ((HttpServletResponse)response).setHeader("X-Wovn-Api", "unused");
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
         boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
         if (hasShorterPath) {
             ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
         } else if (headers.isValidPath() && htmlChecker.canTranslatePath(headers.pathName)) {
-            tryTranslate(headers, (HttpServletRequest)request, response, chain);
+            tryTranslate(headers, (HttpServletRequest)request, (HttpServletResponse)response, chain);
         } else {
             WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
             chain.doFilter(wovnRequest, response);
@@ -47,9 +49,10 @@ public class WovnServletFilter implements Filter {
     public void destroy() {
     }
 
-    private void tryTranslate(Headers headers, HttpServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    private void tryTranslate(Headers headers, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
-        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse((HttpServletResponse)response, headers);
+        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers);
+        response.setHeader("X-Wovn-Api", "unused");
 
         if (settings.urlPattern.equals("path") && headers.getPathLang().length() > 0) {
             wovnRequest.getRequestDispatcher(headers.pathNameKeepTrailingSlash).forward(wovnRequest, wovnResponse);
@@ -63,8 +66,8 @@ public class WovnServletFilter implements Filter {
             String body = null;
             if (htmlChecker.canTranslate(response.getContentType(), headers.pathName, originalBody)) {
                 // html
-                Api api = new Api(settings, headers);
-                Interceptor interceptor = new Interceptor(headers, settings, api);
+                Api api = new Api(settings, headers, response);
+                Interceptor interceptor = new Interceptor(headers, settings, api, response);
                 body = interceptor.translate(originalBody);
             } else {
                 // css, javascript or others

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -31,7 +31,6 @@ public class WovnServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
         ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
-        ((HttpServletResponse)response).setHeader("X-Wovn-Api", "Unused");
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
         boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
@@ -53,6 +52,9 @@ public class WovnServletFilter implements Filter {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers);
 
+        ResponseHeaders responseHeaders = new ResponseHeaders(response);
+        responseHeaders.setApi("Unused");
+
         if (settings.urlPattern.equals("path") && headers.getPathLang().length() > 0) {
             wovnRequest.getRequestDispatcher(headers.pathNameKeepTrailingSlash).forward(wovnRequest, wovnResponse);
         } else {
@@ -65,8 +67,8 @@ public class WovnServletFilter implements Filter {
             String body = null;
             if (htmlChecker.canTranslate(response.getContentType(), headers.pathName, originalBody)) {
                 // html
-                Api api = new Api(settings, headers, response);
-                Interceptor interceptor = new Interceptor(headers, settings, api, response);
+                Api api = new Api(settings, headers, responseHeaders);
+                Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
                 body = interceptor.translate(originalBody);
             } else {
                 // css, javascript or others

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -52,11 +52,11 @@ public class ApiTest extends TestCase {
         }});
 
         HttpServletRequest request = TestUtil.mockRequestPath("/ja/somepage/"); // mocks "https://example.com"
-        HttpServletResponse response = TestUtil.mockSimpleHttpServletResponse();
+        ResponseHeaders responseHeaders = mockResponseHeaders();
 
         Headers headers = new Headers(request, settings);
 
-        Api api = new Api(settings, headers, response);
+        Api api = new Api(settings, headers, responseHeaders);
 
         ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
         ByteArrayInputStream responseStream = new ByteArrayInputStream(apiServerResponse);
@@ -99,9 +99,6 @@ public class ApiTest extends TestCase {
         EasyMock.expect(mock.getContentEncoding()).andReturn(encoding);
         EasyMock.expect(mock.getOutputStream()).andReturn(requestStream);
         EasyMock.expect(mock.getInputStream()).andReturn(responseStream);
-        EasyMock.expect(mock.getHeaderField("X-Cache")).andReturn("mock fastly x-cache");
-        EasyMock.expect(mock.getHeaderField("X-Cache-Hits")).andReturn("mock fastly x-cache-his");
-        EasyMock.expect(mock.getHeaderField("X-Wovn-Surrogate-Key")).andReturn("mock fastly x-wovn-surrogate-key");
         EasyMock.replay(mock);
         return mock;
     }
@@ -125,5 +122,15 @@ public class ApiTest extends TestCase {
             br.close();
         }
         return sb.toString();
+    }
+
+    private ResponseHeaders mockResponseHeaders() {
+        ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
+        mock.forwardFastlyHeaders(EasyMock.anyObject(HttpURLConnection.class));
+        EasyMock.expectLastCall().times(1);
+        mock.setApiStatus("200");
+        EasyMock.expectLastCall().times(1);
+        EasyMock.replay(mock);
+        return mock;
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -52,10 +52,11 @@ public class ApiTest extends TestCase {
         }});
 
         HttpServletRequest request = TestUtil.mockRequestPath("/ja/somepage/"); // mocks "https://example.com"
+        HttpServletResponse response = TestUtil.mockSimpleHttpServletResponse();
 
         Headers headers = new Headers(request, settings);
 
-        Api api = new Api(settings, headers);
+        Api api = new Api(settings, headers, response);
 
         ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
         ByteArrayInputStream responseStream = new ByteArrayInputStream(apiServerResponse);

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -99,6 +99,9 @@ public class ApiTest extends TestCase {
         EasyMock.expect(mock.getContentEncoding()).andReturn(encoding);
         EasyMock.expect(mock.getOutputStream()).andReturn(requestStream);
         EasyMock.expect(mock.getInputStream()).andReturn(responseStream);
+        EasyMock.expect(mock.getHeaderField("X-Cache")).andReturn("mock fastly x-cache");
+        EasyMock.expect(mock.getHeaderField("X-Cache-Hits")).andReturn("mock fastly x-cache-his");
+        EasyMock.expect(mock.getHeaderField("X-Wovn-Surrogate-Key")).andReturn("mock fastly x-wovn-surrogate-key");
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -103,7 +103,7 @@ public class HtmlConverterTest extends TestCase {
 
     public void testConvertWithSitePrefixPath() {
         String original = "<html><head></head><body></body></html>";
-        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;site_prefix_path=global\" data-wovnio-type=\"test-type\" async></script>";
+        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;site_prefix_path=global\" data-wovnio-type=\"fallback\" async></script>";
         String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">";

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -120,7 +120,7 @@ public class HtmlConverterTest extends TestCase {
         Headers headers = new Headers(mockRequest, settings);
         HtmlConverter converter = new HtmlConverter(settings, original);
 
-        assertEquals(expectedHtml, converter.convert(headers, "ja", "test-type"));
+        assertEquals(expectedHtml, converter.convert(headers, "ja"));
     }
 
     public void testMixAllCase() {

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -23,7 +23,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/ja/", originalHtml, settings, mockApiSuccess());
+        String html = translate("/ja/", originalHtml, settings, mockApiSuccess(), mockResponseHeadersSuccess());
         String expect = "replaced html";
         assertEquals(expect, stripExtraSpaces(html));
     }
@@ -35,7 +35,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/ja/", originalHtml, settings, mockApiTimeout());
+        String html = translate("/ja/", originalHtml, settings, mockApiTimeout(), mockResponseHeadersTimeout());
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
@@ -53,7 +53,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/", originalHtml, settings, null);
+        String html = translate("/", originalHtml, settings, null, null);
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
@@ -64,10 +64,9 @@ public class InterceptorTest extends TestCase {
         assertEquals(expect, stripExtraSpaces(html));
     }
 
-    private String translate(String path, String html, Settings settings, Api api) throws NoSuchMethodException, IllegalAccessException, IOException, ServletException {
+    private String translate(String path, String html, Settings settings, Api api, ResponseHeaders responseHeaders) throws NoSuchMethodException, IllegalAccessException, IOException, ServletException {
         HttpServletRequest request = mockRequestPath(path);
-        HttpServletResponse response = TestUtil.mockSimpleHttpServletResponse();
-        Interceptor interceptor = new Interceptor(new Headers(request, settings), settings, api, response);
+        Interceptor interceptor = new Interceptor(new Headers(request, settings), settings, api, responseHeaders);
         return interceptor.translate(html);
     }
 
@@ -107,5 +106,21 @@ public class InterceptorTest extends TestCase {
 
     private String stripExtraSpaces(String html) {
         return html.replaceAll("\\s +", "").replaceAll(">\\s+<", "><");
+    }
+
+    private ResponseHeaders mockResponseHeadersSuccess() {
+        ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
+        mock.setApi("Success");
+        EasyMock.expectLastCall().times(1);
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private ResponseHeaders mockResponseHeadersTimeout() {
+        ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
+        mock.setApi("SocketTimeoutException");
+        EasyMock.expectLastCall().times(1);
+        EasyMock.replay(mock);
+        return mock;
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
@@ -10,7 +10,7 @@ import org.easymock.EasyMock;
 public class ResponseHeadersTest extends TestCase {
     public void testSetApi() {
         HttpServletResponse mockResponse = EasyMock.createMock(HttpServletResponse.class);
-        mockResponse.setHeader("X-Wovn-Api", "test value");
+        mockResponse.setHeader("X-Wovn-Api-Status", "test value");
         EasyMock.expectLastCall().atLeastOnce();
         EasyMock.replay(mockResponse);
 
@@ -20,12 +20,12 @@ public class ResponseHeadersTest extends TestCase {
 
     public void testSetApiStatus() {
         HttpServletResponse mockResponse = EasyMock.createMock(HttpServletResponse.class);
-        mockResponse.setHeader("X-Wovn-Api-Status", "test value");
+        mockResponse.setHeader("X-Wovn-Api-StatusCode", "500");
         EasyMock.expectLastCall().atLeastOnce();
         EasyMock.replay(mockResponse);
 
         ResponseHeaders responseHeaders = new ResponseHeaders(mockResponse);
-        responseHeaders.setApiStatus("test value");
+        responseHeaders.setApiStatus("500");
     }
 
     public void testForwardFastlyHeaders() {

--- a/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
@@ -1,0 +1,54 @@
+package com.github.wovnio.wovnjava;
+
+import java.net.HttpURLConnection;
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.easymock.EasyMock;
+
+public class ResponseHeadersTest extends TestCase {
+    public void testSetApi() {
+        HttpServletResponse mockResponse = EasyMock.createMock(HttpServletResponse.class);
+        mockResponse.setHeader("X-Wovn-Api", "test value");
+        EasyMock.expectLastCall().atLeastOnce();
+        EasyMock.replay(mockResponse);
+
+        ResponseHeaders responseHeaders = new ResponseHeaders(mockResponse);
+        responseHeaders.setApi("test value");
+    }
+
+    public void testSetApiStatus() {
+        HttpServletResponse mockResponse = EasyMock.createMock(HttpServletResponse.class);
+        mockResponse.setHeader("X-Wovn-Api-Status", "test value");
+        EasyMock.expectLastCall().atLeastOnce();
+        EasyMock.replay(mockResponse);
+
+        ResponseHeaders responseHeaders = new ResponseHeaders(mockResponse);
+        responseHeaders.setApiStatus("test value");
+    }
+
+    public void testForwardFastlyHeaders() {
+        HttpServletResponse mockResponse = EasyMock.createMock(HttpServletResponse.class);
+        mockResponse.setHeader("X-Wovn-Cache", "mock fastly x-cache");
+        EasyMock.expectLastCall().atLeastOnce();
+        mockResponse.setHeader("X-Wovn-Cache-Hits", "mock fastly x-cache-hits");
+        EasyMock.expectLastCall().atLeastOnce();
+        mockResponse.setHeader("X-Wovn-Surrogate-Key", "mock fastly x-wovn-surrogate-key");
+        EasyMock.expectLastCall().atLeastOnce();
+        EasyMock.replay(mockResponse);
+
+        ResponseHeaders responseHeaders = new ResponseHeaders(mockResponse);
+        HttpURLConnection con = mockConnection();
+        responseHeaders.forwardFastlyHeaders(con);
+    }
+
+    private HttpURLConnection mockConnection() {
+        HttpURLConnection mock = EasyMock.createMock(HttpURLConnection.class);
+        EasyMock.expect(mock.getHeaderField("X-Cache")).andReturn("mock fastly x-cache");
+        EasyMock.expect(mock.getHeaderField("X-Cache-Hits")).andReturn("mock fastly x-cache-hits");
+        EasyMock.expect(mock.getHeaderField("X-Wovn-Surrogate-Key")).andReturn("mock fastly x-wovn-surrogate-key");
+        EasyMock.replay(mock);
+        return mock;
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -67,6 +67,8 @@ public class TestUtil {
         EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));
         EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();
         EasyMock.expect(mock.getCharacterEncoding()).andReturn(encoding);
+        mock.setHeader(EasyMock.anyString(), EasyMock.anyString());
+        EasyMock.expectLastCall().atLeastOnce();
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -8,8 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.FilterConfig;
 import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.ServletException;
 import org.easymock.EasyMock;
 
@@ -59,7 +57,7 @@ public class TestUtil {
         return mock;
     }
 
-    public static ServletResponse mockResponse(String contentType, String encoding, String location) throws IOException {
+    public static HttpServletResponse mockResponse(String contentType, String encoding, String location) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
         mock.setContentLength(EasyMock.anyInt());
         EasyMock.expectLastCall();
@@ -70,6 +68,11 @@ public class TestUtil {
         EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();
         EasyMock.expect(mock.getCharacterEncoding()).andReturn(encoding);
         EasyMock.replay(mock);
+        return mock;
+    }
+
+    public static HttpServletResponse mockSimpleHttpServletResponse() {
+        HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
         return mock;
     }
 
@@ -88,7 +91,7 @@ public class TestUtil {
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
-        ServletResponse res = mockResponse(contentType, "", option.getOrDefault("location", ""));
+        HttpServletResponse res = mockResponse(contentType, "", option.getOrDefault("location", ""));
         FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import javax.servlet.FilterConfig;
 import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;


### PR DESCRIPTION
Improve debugging by including information about the request handling in HTTP header fields.

### Changes
* Include Fastly HTTP headers from the API response
    - `X-Wovn-Cache`
    - `X-Wovn-Cache-Hits`
    - `X-Wovn-Surrogate-Key`
* Set HTTP headers for the status of API request
    - `X-Wovn-Api`
    - `X-Wovn-Api-Status`
* Whenever wovnjava touches the request, declare itself in HTTP header
    - `X-Wovn-Handler`
* Adjusted ApiException management to make it simpler to declare such errors in `X-Wovn-Api` header field
* Remove dynamic setting of `data-wovnio-type` snippet attribute
    - The value is now always set to `fallback` for when wovnjava processes the HTML response
    - Once the widget has been updated, this attribute will declare wovnjava version
* In the cache key for translation API request, wovnjava will now include its version.
    - This make sure that behavior gets updated when the customer updates wovnjava