### PR TITLE
Add support for debugging query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ urlPattern                | yes      | 'path'
 query                     |          | ''
 defaultLang               | yes      | 'en'
 useProxy                  |          | 'false'
-debugMode                 |          | '0'
+debugMode                 |          | 'false'
 originalUrlHeader         |          | ''
 originalQueryStringHeader |          | ''
 ignoreClasses             |          | ''
@@ -147,7 +147,31 @@ When using a reverse proxy, if the WOVN.io Java Library is not given an appropri
 
 ### 2.7. debugMode
 
-As a development feature, if debugMode is set to 1, wovnjava will output debug logs.
+By turning on debugMode, you will enable extra debugging features for wovnjava.
+
+Turn on debugMode like this:
+```XML
+  <init-param>
+    <param-name>debugMode</param-name>
+    <param-value>true</param-value>
+  </init-param>
+```
+
+Two extra query parameters become available to change wovnjava's behavior:
+
+#### wovnCacheDisable
+Example request: `http://example.com/page/top.html?wovnCacheDisable`
+
+Using `wovnCacheDisable` as a query parameter will make wovnjava bypass the translation API cache, such that translation is always re-processed.
+This will make the request slower, but it is sometimes useful in order to force updated behavior.
+
+#### wovnDebugMode
+Example request: `http://example.com/page/top.html?wovnDebugMode`
+
+Using `wovnDebugMode` as a query parameter will activate embedded debug information in the response HTML comming from the server.
+This is intended to better understand what the problem is if something is not working correctly with wovnjava on your server.
+
+_Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMode is turned on in your wovnjava configuration._
 
 ### 2.8. originalUrlHeader, originalQueryStringHeader
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>0.4.3</version>
+    <version>0.5.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -135,6 +135,8 @@ class Api {
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
         appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
+        appendKeyValue(sb, "&product=", "wovnjava");
+        appendKeyValue(sb, "&version=", Settings.VERSION);
         appendKeyValue(sb, "&body=", body);
         return sb.toString();
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -137,6 +137,7 @@ class Api {
         appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
         appendKeyValue(sb, "&product=", "wovnjava");
         appendKeyValue(sb, "&version=", Settings.VERSION);
+        appendKeyValue(sb, "&debug_mode=", String.valueOf(headers.getDebugMode());
         appendKeyValue(sb, "&body=", body);
         return sb.toString();
     }
@@ -157,6 +158,10 @@ class Api {
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");
         appendValue(sb, Settings.VERSION);
+        if (headers.getCacheDisableMode() || headers.getDebugMode()) {
+            appendValue(sb, "&timestamp=");
+            appendValue(sb, String.valueOf(System.currentTimeMillis()));
+        }
         appendValue(sb, ")");
         return new URL(sb.toString());
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -137,7 +137,7 @@ class Api {
         appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
         appendKeyValue(sb, "&product=", "wovnjava");
         appendKeyValue(sb, "&version=", Settings.VERSION);
-        appendKeyValue(sb, "&debug_mode=", String.valueOf(headers.getDebugMode());
+        appendKeyValue(sb, "&debug_mode=", String.valueOf(headers.getDebugMode()));
         appendKeyValue(sb, "&body=", body);
         return sb.toString();
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -24,12 +24,14 @@ class Api {
     private final int READ_BUFFER_SIZE = 8196;
     private final Settings settings;
     private final Headers headers;
+    private final RequestOptions requestOptions;
     private final ResponseHeaders responseHeaders;
     private final String responseEncoding = "UTF-8"; // always response is UTF8
 
-    Api(Settings settings, Headers headers, ResponseHeaders responseHeaders) {
+    Api(Settings settings, Headers headers, RequestOptions requestOptions, ResponseHeaders responseHeaders) {
         this.settings = settings;
         this.headers = headers;
+        this.requestOptions = requestOptions;
         this.responseHeaders = responseHeaders;
     }
 
@@ -137,7 +139,7 @@ class Api {
         appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
         appendKeyValue(sb, "&product=", "wovnjava");
         appendKeyValue(sb, "&version=", Settings.VERSION);
-        appendKeyValue(sb, "&debug_mode=", String.valueOf(headers.getDebugMode()));
+        appendKeyValue(sb, "&debug_mode=", String.valueOf(this.requestOptions.getDebugMode()));
         appendKeyValue(sb, "&body=", body);
         return sb.toString();
     }
@@ -158,7 +160,7 @@ class Api {
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");
         appendValue(sb, Settings.VERSION);
-        if (headers.getCacheDisableMode() || headers.getDebugMode()) {
+        if (this.requestOptions.getCacheDisableMode() || this.requestOptions.getDebugMode()) {
             appendValue(sb, "&timestamp=");
             appendValue(sb, String.valueOf(System.currentTimeMillis()));
         }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -27,10 +27,20 @@ class Headers {
     private String unmaskedHost;
     private String unmaskedPathName;
     private String unmaskedUrl;
+    /* cacheDisableMode will bypass cache when sending request to translation API */
+    private boolean cacheDisableMode;
+    /* debugMode will activate extra debugging information.
+     * Only available if debugMode is also turned on server side. */
+    private boolean debugMode;
 
     Headers(HttpServletRequest r, Settings s) {
         this.settings = s;
         this.request = r;
+
+        this.cacheDisableMode = false;
+        this.debugMode = false;
+
+        setRequestModeByQueryString();
 
         this.protocol = this.request.getScheme();
         if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
@@ -144,6 +154,14 @@ class Headers {
         this.pathNameKeepTrailingSlash = this.pathName;
         this.pathName = Pattern.compile("/$").matcher(this.pathName).replaceAll("");
         this.pageUrl = this.host + this.pathName + this.query;
+    }
+
+    public boolean getCacheDisableMode() {
+        return this.cacheDisableMode;
+    }
+
+    public boolean getDebugMode() {
+        return this.debugMode;
     }
 
     String langCode() {
@@ -357,5 +375,13 @@ class Headers {
                 path = newPath;
             }
         }
+    }
+
+    private void setRequestModeByQueryString() {
+        String query = this.request.getQueryString();
+        if (query == null) return;
+
+        this.cacheDisableMode = (this.settings.debugMode && query.matches("wovnCacheDisable"));
+        this.debugMode = (this.settings.debugMode && query.matches("wovnDebugMode"));
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -27,20 +27,10 @@ class Headers {
     private String unmaskedHost;
     private String unmaskedPathName;
     private String unmaskedUrl;
-    /* cacheDisableMode will bypass cache when sending request to translation API */
-    private boolean cacheDisableMode;
-    /* debugMode will activate extra debugging information.
-     * Only available if debugMode is also turned on server side. */
-    private boolean debugMode;
 
     Headers(HttpServletRequest r, Settings s) {
         this.settings = s;
         this.request = r;
-
-        this.cacheDisableMode = false;
-        this.debugMode = false;
-
-        setRequestModeByQueryString();
 
         this.protocol = this.request.getScheme();
         if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
@@ -154,14 +144,6 @@ class Headers {
         this.pathNameKeepTrailingSlash = this.pathName;
         this.pathName = Pattern.compile("/$").matcher(this.pathName).replaceAll("");
         this.pageUrl = this.host + this.pathName + this.query;
-    }
-
-    public boolean getCacheDisableMode() {
-        return this.cacheDisableMode;
-    }
-
-    public boolean getDebugMode() {
-        return this.debugMode;
     }
 
     String langCode() {
@@ -375,13 +357,5 @@ class Headers {
                 path = newPath;
             }
         }
-    }
-
-    private void setRequestModeByQueryString() {
-        String query = this.request.getQueryString();
-        if (query == null) return;
-
-        this.cacheDisableMode = (this.settings.debugMode && query.matches("wovnCacheDisable"));
-        this.debugMode = (this.settings.debugMode && query.matches("wovnDebugMode"));
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -4,6 +4,14 @@ import javax.servlet.http.HttpServletRequest;
 
 class RequestOptions {
     /*
+     * Check for `wovnDisable` in the query string
+     */
+    public static boolean wovnDisableMode(HttpServletRequest request) {
+        String query = request.getQueryString();
+        return query != null && query.matches("(.*)wovnDisable(.*)");
+    }
+
+    /*
      * cacheDisableMode:
      *      - bypass cache for request to translation API
      * Only available if debugMode is also turned on server side.

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -1,0 +1,41 @@
+package com.github.wovnio.wovnjava;
+
+import javax.servlet.http.HttpServletRequest;
+
+class RequestOptions {
+    /*
+     * cacheDisableMode:
+     *      - bypass cache for request to translation API
+     * Only available if debugMode is also turned on server side.
+     */
+    private boolean cacheDisableMode;
+    /*
+     * debugMode:
+     *      - activate extra debugging information.
+     *      - send "debug_mode=true" to translation API
+     *      - bypass cache for request to translation API
+     * Only available if debugMode is also turned on server side.
+     */
+    private boolean debugMode;
+
+    RequestOptions(Settings settings, HttpServletRequest request) {
+        this.cacheDisableMode = false;
+        this.debugMode = false;
+
+        if (settings.debugMode) {
+            String query = request.getQueryString();
+            if (query != null) {
+                this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
+                this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
+            }
+        }
+    }
+
+    public boolean getCacheDisableMode() {
+        return this.cacheDisableMode;
+    }
+
+    public boolean getDebugMode() {
+        return this.debugMode;
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -1,16 +1,14 @@
 package com.github.wovnio.wovnjava;
 
+import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
 class RequestOptions {
     /*
-     * Check for `wovnDisable` in the query string
+     * disableMode:
+     *      - do nothing to the request
      */
-    public static boolean wovnDisableMode(HttpServletRequest request) {
-        String query = request.getQueryString();
-        return query != null && query.matches("(.*)wovnDisable(.*)");
-    }
-
+    private boolean disableMode;
     /*
      * cacheDisableMode:
      *      - bypass cache for request to translation API
@@ -26,17 +24,23 @@ class RequestOptions {
      */
     private boolean debugMode;
 
-    RequestOptions(Settings settings, HttpServletRequest request) {
+    RequestOptions(Settings settings, ServletRequest request) {
+        this.disableMode = false;
         this.cacheDisableMode = false;
         this.debugMode = false;
 
-        if (settings.debugMode) {
-            String query = request.getQueryString();
-            if (query != null) {
+        String query = ((HttpServletRequest)request).getQueryString();
+        if (query != null) {
+            this.disableMode = query.matches("(.*)wovnDisable(.*)");
+            if (settings.debugMode) {
                 this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
                 this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
             }
         }
+    }
+
+    public boolean getDisableMode() {
+        return this.disableMode;
     }
 
     public boolean getCacheDisableMode() {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -39,6 +39,7 @@ class Settings {
     int connectTimeout = 1000;
     int readTimeout = 1000;
     boolean devMode = false;
+    boolean debugMode = false;
     boolean enableFlushBuffer = false;
 
     Settings(FilterConfig config) {
@@ -146,6 +147,11 @@ class Settings {
         p = config.getInitParameter("devMode");
         if (p != null && !p.isEmpty()) {
             this.devMode = getBoolParameter(p);
+        }
+
+        p = config.getInitParameter("debugMode");
+        if (p != null && !p.isEmpty()) {
+            this.debugMode = getBoolParameter(p);
         }
 
         p = config.getInitParameter("enableFlushBuffer");

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -20,7 +20,7 @@ public class WovnServletFilter implements Filter {
     private Settings settings;
     private final HtmlChecker htmlChecker = new HtmlChecker();
 
-    public static final String VERSION = Settings.VERSION;  // for backword compatibility
+    public static final String VERSION = Settings.VERSION;  // for backward compatibility
 
     @Override
     public void init(FilterConfig config) throws ServletException {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -72,7 +72,8 @@ public class WovnServletFilter implements Filter {
             String body = null;
             if (htmlChecker.canTranslate(response.getContentType(), headers.pathName, originalBody)) {
                 // html
-                Api api = new Api(settings, headers, responseHeaders);
+                RequestOptions requestOptions = new RequestOptions(this.settings, request);
+                Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
                 body = interceptor.translate(originalBody);
             } else {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -30,6 +30,11 @@ public class WovnServletFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
+        if (disableFilter(request)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         Headers headers = new Headers((HttpServletRequest)request, settings);
         String lang = headers.getPathLang();
@@ -85,5 +90,13 @@ public class WovnServletFilter implements Filter {
             out.write(wovnResponse.getData());
             out.close();
         }
+    }
+
+    /*
+     * Check for `wovnDisable` in the query string
+     */
+    private boolean disableFilter(ServletRequest request) {
+        String query = ((HttpServletRequest)request).getQueryString();
+        return query != null && query.matches("wovnDisable");
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -30,7 +30,7 @@ public class WovnServletFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
-        if (disableFilter(request)) {
+        if (RequestOptions.wovnDisableMode((HttpServletRequest)request)) {
             chain.doFilter(request, response);
             return;
         }
@@ -91,13 +91,5 @@ public class WovnServletFilter implements Filter {
             out.write(wovnResponse.getData());
             out.close();
         }
-    }
-
-    /*
-     * Check for `wovnDisable` in the query string
-     */
-    private boolean disableFilter(ServletRequest request) {
-        String query = ((HttpServletRequest)request).getQueryString();
-        return query != null && query.matches("wovnDisable");
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -31,22 +31,23 @@ public class WovnServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
+
         if (requestOptions.getDisableMode()) {
             chain.doFilter(request, response);
-            return;
-        }
-
-        ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
-        Headers headers = new Headers((HttpServletRequest)request, settings);
-        String lang = headers.getPathLang();
-        boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
-        if (hasShorterPath) {
-            ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
-        } else if (headers.isValidPath() && htmlChecker.canTranslatePath(headers.pathName)) {
-            tryTranslate(headers, requestOptions, (HttpServletRequest)request, (HttpServletResponse)response, chain);
         } else {
-            WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
-            chain.doFilter(wovnRequest, response);
+            ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+
+            Headers headers = new Headers((HttpServletRequest)request, this.settings);
+            String lang = headers.getPathLang();
+            boolean hasShorterPath = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
+            if (hasShorterPath) {
+                ((HttpServletResponse) response).sendRedirect(headers.redirectLocation(settings.defaultLang));
+            } else if (headers.isValidPath() && htmlChecker.canTranslatePath(headers.pathName)) {
+                tryTranslate(headers, requestOptions, (HttpServletRequest)request, (HttpServletResponse)response, chain);
+            } else {
+                WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
+                chain.doFilter(wovnRequest, response);
+            }
         }
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -55,8 +55,9 @@ public class ApiTest extends TestCase {
         ResponseHeaders responseHeaders = mockResponseHeaders();
 
         Headers headers = new Headers(request, settings);
+        RequestOptions requestOptions = new RequestOptions(settings, request);
 
-        Api api = new Api(settings, headers, responseHeaders);
+        Api api = new Api(settings, headers, requestOptions, responseHeaders);
 
         ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
         ByteArrayInputStream responseStream = new ByteArrayInputStream(apiServerResponse);

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -72,6 +72,9 @@ public class ApiTest extends TestCase {
                                      "&lang_code=ja" +
                                      "&url_pattern=path" +
                                      "&site_prefix_path=" +
+                                     "&product=wovnjava" +
+                                     "&version=" + Settings.VERSION +
+                                     "&debug_mode=false" +
                                      "&body=" + html;
         assertEquals(expectedRequestBody, apiRequestBody);
 

--- a/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
@@ -8,6 +8,27 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class RequestOptionsTest extends TestCase {
+    public void testDisableModeNoQueryParameter() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn(null);
+        EasyMock.replay(request);
+        assertEquals(false, RequestOptions.wovnDisableMode(request));
+    }
+
+    public void testDisableModeNonmatchingQueryParameter() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn("pen&pineapple&apple&pen");
+        EasyMock.replay(request);
+        assertEquals(false, RequestOptions.wovnDisableMode(request));
+    }
+
+    public void testDisableModeMatchingQueryParameter() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn("pen&wovnDisable&pen");
+        EasyMock.replay(request);
+        assertEquals(true, RequestOptions.wovnDisableMode(request));
+    }
+
     public void testNoQueryParameter() {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn(null);

--- a/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
@@ -12,21 +12,27 @@ public class RequestOptionsTest extends TestCase {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn(null);
         EasyMock.replay(request);
-        assertEquals(false, RequestOptions.wovnDisableMode(request));
+
+        RequestOptions sut = new RequestOptions(defaultSettings(), request);
+        assertEquals(false, sut.getDisableMode());
     }
 
     public void testDisableModeNonmatchingQueryParameter() {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("pen&pineapple&apple&pen");
         EasyMock.replay(request);
-        assertEquals(false, RequestOptions.wovnDisableMode(request));
+
+        RequestOptions sut = new RequestOptions(defaultSettings(), request);
+        assertEquals(false, sut.getDisableMode());
     }
 
     public void testDisableModeMatchingQueryParameter() {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("pen&wovnDisable&pen");
         EasyMock.replay(request);
-        assertEquals(true, RequestOptions.wovnDisableMode(request));
+
+        RequestOptions sut = new RequestOptions(defaultSettings(), request);
+        assertEquals(true, sut.getDisableMode());
     }
 
     public void testNoQueryParameter() {

--- a/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
@@ -1,0 +1,61 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.HashMap;
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.TestCase;
+
+import org.easymock.EasyMock;
+
+public class RequestOptionsTest extends TestCase {
+    public void testNoQueryParameter() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn(null);
+        EasyMock.replay(request);
+
+        RequestOptions sut = new RequestOptions(debugModeSettings(), request);
+        assertEquals(false, sut.getCacheDisableMode());
+        assertEquals(false, sut.getDebugMode());
+    }
+
+    public void testCacheDisable() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn("user=Ceb&wovnCacheDisable");
+        EasyMock.replay(request);
+
+        RequestOptions sut = new RequestOptions(debugModeSettings(), request);
+        assertEquals(true, sut.getCacheDisableMode());
+        assertEquals(false, sut.getDebugMode());
+    }
+
+    public void testDebugMode() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn("wovnDebugMode&user=Ceb");
+        EasyMock.replay(request);
+
+        RequestOptions sut = new RequestOptions(debugModeSettings(), request);
+        assertEquals(false, sut.getCacheDisableMode());
+        assertEquals(true, sut.getDebugMode());
+    }
+
+    public void testQueryParameteresWithoutDebugModeSettings() {
+        HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(request.getQueryString()).andReturn("wovnDebugMode&wovnDisableCache");
+        EasyMock.replay(request);
+
+        RequestOptions sut = new RequestOptions(defaultSettings(), request);
+        assertEquals(false, sut.getCacheDisableMode());
+        assertEquals(false, sut.getDebugMode());
+    }
+
+    private Settings debugModeSettings() {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("debugMode", "true");
+        }});
+        return settings;
+    }
+
+    private Settings defaultSettings() {
+        return TestUtil.makeSettings();
+    }
+}


### PR DESCRIPTION
### Changes
* Add server-side debugMode setting
* Query parameters to change the behavior of wovnjava
  - `wovnDisable`
    - always available
    - wovnajva does nothing
  - `wovnCacheDisable`
    - only available if debugMode is activated server-side
    - bypass translation API cache
  - `wovnDebugMode`
    - only available if debugMode is activated server-side
    - bypass translation API cache
    - send `debug_mode=true` to translation API
    - opportunity to embed debugging information in the response HTML
* Always send product and version information to translation API
* Bump version to 0.5.0