### PR TITLE
Stop Intercepting archive files

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -66,5 +66,5 @@ class HtmlChecker {
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
     private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
     private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
-    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar(.gz)?|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
 }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -66,5 +66,5 @@ class HtmlChecker {
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
     private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
     private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
-    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.(zip|tar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
 }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -66,5 +66,5 @@ class HtmlChecker {
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
     private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
     private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
-    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|7z|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
 }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -66,5 +66,5 @@ class HtmlChecker {
     private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
     private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
     private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
-    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar(.gz)?|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -26,6 +26,7 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslatePath(false, "mp4");
         assertCanTranslatePath(false, "zip");
         assertCanTranslatePath(false, "7zip");
+        assertCanTranslatePath(false, "7z");
         assertCanTranslatePath(false, "gzip");
         assertCanTranslatePath(false, "tar");
         assertCanTranslatePath(false, "gz");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -28,6 +28,7 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslatePath(false, "7zip");
         assertCanTranslatePath(false, "gzip");
         assertCanTranslatePath(false, "tar.gz");
+        assertCanTranslatePath(false, "gz");
         assertCanTranslatePath(false, "rar");
         assertCanTranslatePath(false, "pdf");
         assertCanTranslatePath(false, "js");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -27,7 +27,7 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslatePath(false, "zip");
         assertCanTranslatePath(false, "7zip");
         assertCanTranslatePath(false, "gzip");
-        assertCanTranslatePath(false, "tar.gz");
+        assertCanTranslatePath(false, "tar");
         assertCanTranslatePath(false, "gz");
         assertCanTranslatePath(false, "rar");
         assertCanTranslatePath(false, "pdf");

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -25,6 +25,10 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslatePath(false, "mp3");
         assertCanTranslatePath(false, "mp4");
         assertCanTranslatePath(false, "zip");
+        assertCanTranslatePath(false, "7zip");
+        assertCanTranslatePath(false, "gzip");
+        assertCanTranslatePath(false, "tar.gz");
+        assertCanTranslatePath(false, "rar");
         assertCanTranslatePath(false, "pdf");
         assertCanTranslatePath(false, "js");
         assertCanTranslatePath(false, "css");


### PR DESCRIPTION
Files like ZIP, TAR, RAR and gziped should not be intercepted.