### PR TITLE
Use camelCase for snippet settings

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -132,7 +132,7 @@ class HtmlConverter {
         sb.append("&langCodeAliases={}&version=");
         sb.append(Settings.VERSION);
         if (settings.hasSitePrefixPath) {
-            sb.append("&site_prefix_path=");
+            sb.append("&sitePrefixPath=");
             sb.append(settings.sitePrefixPathWithoutSlash.replaceFirst("/", ""));
         }
         String key = sb.toString();

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -103,7 +103,7 @@ public class HtmlConverterTest extends TestCase {
 
     public void testConvertWithSitePrefixPath() {
         String original = "<html><head></head><body></body></html>";
-        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;site_prefix_path=global\" data-wovnio-type=\"fallback\" async></script>";
+        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;sitePrefixPath=global\" data-wovnio-type=\"fallback\" async></script>";
         String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">" +
                                    "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">";


### PR DESCRIPTION
Update site prefix path snippet setting to use camel case.
The corresponding widget change will go out next release.