### PR TITLE
Simplify sitePrefixPath settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,72 @@
 version: 2
 
+workflows:
+  version: 2
+  test:
+    jobs:
+      - oraclejdk8
+      - openjdk8
+
+anchors:
+  - restore_cache: &restore_cache
+      key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+  - save_cache: &save_cache
+      paths:
+        - ~/.m2
+      key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+
 jobs:
-  build:
+  oraclejdk8:
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - checkout
+
+      - run:
+         name: install oracle jdk
+         command: |
+           cd ~/
+           curl -O https://bootstrap.pypa.io/get-pip.py
+           python get-pip.py --user
+           export PATH=~/.local/bin/:$PATH
+           pip install awscli --upgrade --user
+           aws s3 cp s3://$JDK_FILE_PATH ./jdk8-oracle.tar.gz > /dev/null 2>&1
+           mkdir jdk8-oracle && tar zxf jdk8-oracle.tar.gz -C jdk8-oracle --strip-components 1
+           sudo cp -a ~/jdk8-oracle /usr/lib/jvm
+           cd /usr/lib/jvm
+           sed -e "s/\(java-8-openjdk-amd64\|java-1.8.0-openjdk-amd64\)/jdk8-oracle/g" .java-1.8.0-openjdk-amd64.jinfo | sudo tee .jdk8-oracle.jinfo
+           cat .jdk8-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install
+           sudo update-java-alternatives --set jdk8-oracle
+           export JAVA_HOME=/usr/lib/jvm/jdk8-oracle
+
+      - restore_cache:
+          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+
+      - run: mvn package
+
+      - store_test_results:
+          path: target/surefire-reports
+
+      - run:
+          name: Collect artifacts
+          command: |
+            mkdir target/artifacts
+            version=`grep '^    <version>' pom.xml | sed -e 's/    <version>//' | sed -e 's!</version>!!'`
+            zip target/wovnjava-jar-${version}.zip -jr target/wovnjava-*.jar licenses/*
+            mv target/wovnjava-* target/artifacts
+
+      - store_artifacts:
+          path: target/artifacts/
+
+
+  openjdk8:
     docker:
       - image: circleci/openjdk:8-jdk
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: java
-
-jdk:
-  - oraclejdk8
-  - openjdk8

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -136,7 +136,7 @@ class Api {
         appendKeyValue(sb, "&token=", settings.projectToken);
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
-        appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPathWithoutSlash);
+        appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPath);
         appendKeyValue(sb, "&product=", "wovnjava");
         appendKeyValue(sb, "&version=", Settings.VERSION);
         appendKeyValue(sb, "&debug_mode=", String.valueOf(this.requestOptions.getDebugMode()));

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -287,7 +287,7 @@ class Headers {
             return Pattern.compile("(^|(//))" + lang + "\\.", Pattern.CASE_INSENSITIVE)
                     .matcher(uri).replaceFirst("$1");
         } else {
-            String prefix = this.settings.sitePrefixPathWithSlash;
+            String prefix = this.settings.sitePrefixPathWithoutSlash + "/";
             return uri.replaceFirst(prefix + lang + "(/|$)", prefix);
         }
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -183,7 +183,7 @@ class Headers {
             } else {
                 // path
                 if (settings.hasSitePrefixPath) {
-                    String sitePrefixPath = this.settings.sitePrefixPathWithoutSlash;
+                    String sitePrefixPath = this.settings.sitePrefixPath;
                     if (this.pathName.startsWith(sitePrefixPath)) {
                         location = location.replaceFirst(sitePrefixPath, sitePrefixPath + "/" + lang);
                         if (!location.endsWith("/")) {
@@ -230,7 +230,7 @@ class Headers {
         }
         path = UrlPath.normalize(path);
 
-        if (!path.startsWith(this.settings.sitePrefixPathWithoutSlash)) {
+        if (!path.startsWith(this.settings.sitePrefixPath)) {
             return location;
         }
 
@@ -264,7 +264,7 @@ class Headers {
             subdomainLangCode = lang + ".";
         } else {
             pathLangCode = "/" + lang;
-            sitePrefixPath = this.settings.sitePrefixPathWithoutSlash;
+            sitePrefixPath = this.settings.sitePrefixPath;
             path = path.replaceFirst(sitePrefixPath, "");
         }
         return locationProtocol + "://" + subdomainLangCode + host + sitePrefixPath + pathLangCode + path + queryLangCode;
@@ -287,12 +287,12 @@ class Headers {
             return Pattern.compile("(^|(//))" + lang + "\\.", Pattern.CASE_INSENSITIVE)
                     .matcher(uri).replaceFirst("$1");
         } else {
-            String prefix = this.settings.sitePrefixPathWithoutSlash + "/";
+            String prefix = this.settings.sitePrefixPath + "/";
             return uri.replaceFirst(prefix + lang + "(/|$)", prefix);
         }
     }
 
     boolean isValidPath() {
-        return this.pathName.startsWith(this.settings.sitePrefixPathWithoutSlash);
+        return this.pathName.startsWith(this.settings.sitePrefixPath);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -133,7 +133,7 @@ class HtmlConverter {
         sb.append(Settings.VERSION);
         if (settings.hasSitePrefixPath) {
             sb.append("&sitePrefixPath=");
-            sb.append(settings.sitePrefixPathWithoutSlash.replaceFirst("/", ""));
+            sb.append(settings.sitePrefixPath.replaceFirst("/", ""));
         }
         String key = sb.toString();
         js.attr("src", settings.snippetUrl);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -61,8 +61,8 @@ class Settings {
         }
 
         p = config.getInitParameter("sitePrefixPath");
-        this.hasSitePrefixPath = p != null && p.length() > 0;
-        if (this.hasSitePrefixPath) {
+        if (p != null && p.length() > 0) {
+            this.hasSitePrefixPath = true;
             if (!p.startsWith("/")) p = "/" + p;
             if (p.endsWith("/")) {
                 this.sitePrefixPath = p.substring(0, p.length() - 1);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -20,7 +20,6 @@ class Settings {
 
     String projectToken = "";
     boolean hasSitePrefixPath = false;
-    String sitePrefixPathWithSlash = "/";
     String sitePrefixPathWithoutSlash = "";
     String secretKey = "";
     String urlPattern = "path";
@@ -66,10 +65,8 @@ class Settings {
         if (this.hasSitePrefixPath) {
             if (!p.startsWith("/")) p = "/" + p;
             if (p.endsWith("/")) {
-                this.sitePrefixPathWithSlash = p;
                 this.sitePrefixPathWithoutSlash = p.substring(0, p.length() - 1);
             } else {
-                this.sitePrefixPathWithSlash = p + "/";
                 this.sitePrefixPathWithoutSlash = p;
             }
         }
@@ -273,7 +270,7 @@ class Settings {
         for (String q : query) {
             md.update(q.getBytes());
         }
-        md.update(sitePrefixPathWithSlash.getBytes());
+        md.update(sitePrefixPathWithoutSlash.getBytes());
         md.update(defaultLang.getBytes());
         for (String lang : supportedLangs) {
             md.update(lang.getBytes());

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -20,7 +20,7 @@ class Settings {
 
     String projectToken = "";
     boolean hasSitePrefixPath = false;
-    String sitePrefixPathWithoutSlash = "";
+    String sitePrefixPath = "";
     String secretKey = "";
     String urlPattern = "path";
     String urlPatternReg = UrlPatternRegPath;
@@ -65,9 +65,9 @@ class Settings {
         if (this.hasSitePrefixPath) {
             if (!p.startsWith("/")) p = "/" + p;
             if (p.endsWith("/")) {
-                this.sitePrefixPathWithoutSlash = p.substring(0, p.length() - 1);
+                this.sitePrefixPath = p.substring(0, p.length() - 1);
             } else {
-                this.sitePrefixPathWithoutSlash = p;
+                this.sitePrefixPath = p;
             }
         }
 
@@ -204,7 +204,7 @@ class Settings {
 
         if (this.urlPattern.equals("path")) {
             this.urlPatternReg = UrlPatternRegPath;
-            String prefix = this.sitePrefixPathWithoutSlash;
+            String prefix = this.sitePrefixPath;
             if (prefix.length() > 0 && !this.urlPatternReg.contains(prefix)) {
                 this.urlPatternReg = prefix + UrlPatternRegPath;
             }
@@ -270,7 +270,7 @@ class Settings {
         for (String q : query) {
             md.update(q.getBytes());
         }
-        md.update(sitePrefixPathWithoutSlash.getBytes());
+        md.update(sitePrefixPath.getBytes());
         md.update(defaultLang.getBytes());
         for (String lang : supportedLangs) {
             md.update(lang.getBytes());

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -192,7 +192,6 @@ public class SettingsTest extends TestCase {
     public void testSettingsWithoutSitePrefix() {
         Settings s = TestUtil.makeSettings();
         assertFalse(s.hasSitePrefixPath);
-        assertEquals("/", s.sitePrefixPathWithSlash);
         assertEquals("", s.sitePrefixPathWithoutSlash);
     }
 
@@ -201,7 +200,6 @@ public class SettingsTest extends TestCase {
         option.put("sitePrefixPath", "/global/");
         Settings s = TestUtil.makeSettings(option);
         assertTrue(s.hasSitePrefixPath);
-        assertEquals("/global/", s.sitePrefixPathWithSlash);
         assertEquals("/global", s.sitePrefixPathWithoutSlash);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -192,7 +192,7 @@ public class SettingsTest extends TestCase {
     public void testSettingsWithoutSitePrefix() {
         Settings s = TestUtil.makeSettings();
         assertFalse(s.hasSitePrefixPath);
-        assertEquals("", s.sitePrefixPathWithoutSlash);
+        assertEquals("", s.sitePrefixPath);
     }
 
     public void testSettingsWithSitePrefix() {
@@ -200,6 +200,6 @@ public class SettingsTest extends TestCase {
         option.put("sitePrefixPath", "/global/");
         Settings s = TestUtil.makeSettings(option);
         assertTrue(s.hasSitePrefixPath);
-        assertEquals("/global", s.sitePrefixPathWithoutSlash);
+        assertEquals("/global", s.sitePrefixPath);
     }
 }


### PR DESCRIPTION
Site prefix path has two settings variables.
* `sitePrefixPathWithoutSlash` is the common format
* `sitePrefixPathWithSlash` is only being used one place

With these changes,
1. remove `sitePrefixPathWithSlash` and always access the common format
2. rename `sitePrefixPathWithoutSlash` to just `sitePrefixPath`