### PR TITLE
[Refactor] Move removeLang into PatternHandlers

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -266,7 +266,7 @@ class Headers {
         if (lang == null || lang.length() == 0) {
             lang = this.getPathLang();
         }
-        return this.patternHandler.removeLang(uri, lang);
+        return this.urlLanguagePatternHandler.removeLang(uri, lang);
     }
 
     boolean isValidPath() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -266,16 +266,7 @@ class Headers {
         if (lang == null || lang.length() == 0) {
             lang = this.getPathLang();
         }
-        if (this.settings.urlPattern.equals("query")) {
-            return uri.replaceFirst("(^|\\?|&)wovn=" + lang + "(&|$)", "$1")
-                    .replaceAll("(\\?|&)$", "");
-        } else if (this.settings.urlPattern.equals("subdomain")) {
-            return Pattern.compile("(^|(//))" + lang + "\\.", Pattern.CASE_INSENSITIVE)
-                    .matcher(uri).replaceFirst("$1");
-        } else {
-            String prefix = this.settings.sitePrefixPath + "/";
-            return uri.replaceFirst(prefix + lang + "(/|$)", prefix);
-        }
+        return this.patternHandler.removeLang(uri, lang);
     }
 
     boolean isValidPath() {

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -5,9 +5,11 @@ import java.util.regex.Pattern;
 class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     static final String PATH_GET_LANG_PATTERN_REGEX = "/([^/.?]+)";
 
+    private String sitePrefixPath;
     private Pattern getLangPattern;
 
-    PathUrlLanguagePatternHandler(String sitePrefixPath) {
+    PathPatternHandler(String sitePrefixPath) {
+        this.sitePrefixPath = sitePrefixPath;
         this.getLangPattern = Pattern.compile(sitePrefixPath + PATH_GET_LANG_PATTERN_REGEX);
     }
 
@@ -15,8 +17,9 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return this.getLangMatch(url, this.getLangPattern);
     }
 
-    String removeLang(String url) {
-        return "site.com/path";
+    String removeLang(String url, String lang) {
+        String prefix = this.sitePrefixPath + "/";
+        return url.replaceFirst(prefix + lang + "(/|$)", prefix);
     }
 
     String insertLang(String url, String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -8,7 +8,7 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     private String sitePrefixPath;
     private Pattern getLangPattern;
 
-    PathPatternHandler(String sitePrefixPath) {
+    PathUrlLanguagePatternHandler(String sitePrefixPath) {
         this.sitePrefixPath = sitePrefixPath;
         this.getLangPattern = Pattern.compile(sitePrefixPath + PATH_GET_LANG_PATTERN_REGEX);
     }

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -15,8 +15,9 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return this.getLangMatch(url, this.getLangPattern);
     }
 
-    String removeLang(String url) {
-        return "site.com/path";
+    String removeLang(String url, String lang) {
+        return url.replaceFirst("(^|\\?|&)wovn=" + lang + "(&|$)", "$1")
+                  .replaceAll("(\\?|&)$", "");
     }
 
     String insertLang(String url, String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -15,8 +15,9 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return this.getLangMatch(url, this.getLangPattern);
     }
 
-    String removeLang(String url) {
-        return "site.com/path";
+    String removeLang(String url, String lang) {
+        return Pattern.compile("(^|(//))" + lang + "\\.", Pattern.CASE_INSENSITIVE)
+                      .matcher(url).replaceFirst("$1");
     }
 
     String insertLang(String url, String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 abstract class UrlLanguagePatternHandler {
     abstract String getLang(String url);
 
-    abstract String removeLang(String url);
+    abstract String removeLang(String url, String lang);
 
     abstract String insertLang(String url, String lang);
 

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -1,0 +1,99 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class PathUrlLanguagePatternHandlerTest extends TestCase {
+    public void testGetLang__NonMatchingPath__ReturnEmptyLang() {
+        PathUrlLanguagePatternHandler sut = createWithParams("");
+        assertEquals("", sut.getLang("/"));
+        assertEquals("", sut.getLang("/page"));
+        assertEquals("", sut.getLang("site.com/page/index.html"));
+        assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
+        assertEquals("", sut.getLang("/page?wovn=en"));
+    }
+
+    public void testGetLang__MatchingPath__ReturnLangCode() {
+        PathUrlLanguagePatternHandler sut = createWithParams("");
+		assertEquals("fr", sut.getLang("/fr"));
+		assertEquals("fr", sut.getLang("/fr/"));
+		assertEquals("fr", sut.getLang("/fr/page"));
+		assertEquals("fr", sut.getLang("site.com/fr/page/index.html"));
+		assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
+        /* incorrect behavior below */
+		assertEquals("fr", sut.getLang("site.com/French/"));
+		assertEquals("fi", sut.getLang("site.com/Suomi/page/index.html"));
+	}
+
+    public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnEmptyLang() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+		assertEquals("", sut.getLang("site.com/fr"));
+		assertEquals("", sut.getLang("en.site.com/en/?wovn=en"));
+		assertEquals("", sut.getLang("/es/pre/fix/page/index.html"));
+		assertEquals("", sut.getLang("/pre/fr/fix/page/index.html"));
+		assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
+		assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
+    }
+
+    public void testGetLang__SitePrefixPath__MatchingPath__ReturnLangCode() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+		assertEquals("fr", sut.getLang("site.com/pre/fix/fr"));
+		assertEquals("fr", sut.getLang("site.com/pre/fix/fr/"));
+		assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
+		assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
+		assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
+        /* incorrect behavior below */
+		assertEquals("fr", sut.getLang("/pre/fix/french/page/index.html"));
+    }
+
+    public void testRemoveLang__NonMatchingPath__DoNotModify() {
+        PathUrlLanguagePatternHandler sut = createWithParams("");
+        assertEquals("/", sut.removeLang("/", "ja"));
+        assertEquals("site.com", sut.removeLang("site.com", "ja"));
+        assertEquals("site.com/", sut.removeLang("site.com/", "ja"));
+        assertEquals("site.com/page/", sut.removeLang("site.com/page/", "ja"));
+        assertEquals("/global/en/page/", sut.removeLang("/global/en/page/", "ja"));
+        assertEquals("site.com", sut.removeLang("site.com", "ja"));
+        assertEquals("site.com/en/page/", sut.removeLang("site.com/en/page/", "ja"));
+        assertEquals("site.com/english/page/", sut.removeLang("site.com/english/page/", "en"));
+    }
+
+    public void testRemoveLang__MatchingLang__RemoveLang() {
+        PathUrlLanguagePatternHandler sut = createWithParams("");
+        assertEquals("/", sut.removeLang("/ja", "ja"));
+        assertEquals("site.com/", sut.removeLang("site.com/en", "en"));
+        assertEquals("site.com/", sut.removeLang("site.com/ja/", "ja"));
+        assertEquals("site.com/index.html", sut.removeLang("site.com/no/index.html", "no"));
+        assertEquals("site.com/page/index.html", sut.removeLang("site.com/en/page/index.html", "en"));
+        assertEquals("/page/index.html", sut.removeLang("/en/page/index.html", "en"));
+        assertEquals("site.com/en/page/", sut.removeLang("site.com/ja/en/page/", "ja"));
+        assertEquals("site.com/ja/page/", sut.removeLang("site.com/ja/ja/page/", "ja"));
+        /* incorrect behavior below */
+        assertEquals("site.com/en/page/", sut.removeLang("site.com/en/ja/page/", "ja"));
+        assertEquals("/global/page/index.html", sut.removeLang("/global/page/ja/index.html", "ja"));
+    }
+
+    public void testRemoveLang__SitePrefixPath__NonMatchingPath__DoNotModify() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        assertEquals("/", sut.removeLang("/", "ja"));
+        assertEquals("site.com", sut.removeLang("site.com", "ja"));
+        assertEquals("site.com/pre/fix/", sut.removeLang("site.com/pre/fix/", "ja"));
+        assertEquals("site.com/no/index.html", sut.removeLang("site.com/no/index.html", "no"));
+        assertEquals("site.com/fr/pre/fix/", sut.removeLang("site.com/fr/pre/fix/", "fr"));
+        assertEquals("site.com/pre/ja/fix/", sut.removeLang("site.com/pre/ja/fix/", "ja"));
+        assertEquals("site.com/prefix/no", sut.removeLang("site.com/prefix/no", "no"));
+        assertEquals("/pre/fix/page/en/index.html", sut.removeLang("/pre/fix/page/en/index.html", "en"));
+        assertEquals("/pre/fix/ja/page/index.html", sut.removeLang("/pre/fix/ja/page/index.html", "en"));
+    }
+
+    public void testRemoveLang__SitePrefixPath__MatchingSupportedLang__RemoveLang() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        assertEquals("/pre/fix/", sut.removeLang("/pre/fix/ja", "ja"));
+        assertEquals("http://site.com/pre/fix/", sut.removeLang("http://site.com/pre/fix/en/", "en"));
+        assertEquals("site.com/pre/fix/page/index.html", sut.removeLang("site.com/pre/fix/no/page/index.html", "no"));
+    }
+
+    private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {
+        return new PathUrlLanguagePatternHandler(sitePrefixPath);
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -58,7 +58,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("site.com/english/page/", sut.removeLang("site.com/english/page/", "en"));
     }
 
-    public void testRemoveLang__MatchingLang__RemoveLang() {
+    public void testRemoveLang__MatchingLang__RemoveLangCode() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
         assertEquals("/", sut.removeLang("/ja", "ja"));
         assertEquals("site.com/", sut.removeLang("site.com/en", "en"));
@@ -86,7 +86,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("/pre/fix/ja/page/index.html", sut.removeLang("/pre/fix/ja/page/index.html", "en"));
     }
 
-    public void testRemoveLang__SitePrefixPath__MatchingSupportedLang__RemoveLang() {
+    public void testRemoveLang__SitePrefixPath__MatchingSupportedLang__RemoveLangCode() {
         PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
         assertEquals("/pre/fix/", sut.removeLang("/pre/fix/ja", "ja"));
         assertEquals("http://site.com/pre/fix/", sut.removeLang("http://site.com/pre/fix/en/", "en"));

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -1,0 +1,43 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class QueryUrlLanguagePatternHandlerTest extends TestCase {
+    public void testGetLang__NonMatchingQuery__ReturnEmptyLang() {
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        assertEquals("", sut.getLang("/"));
+        assertEquals("", sut.getLang("/en"));
+        assertEquals("", sut.getLang("/en/page?wovn&en"));
+        assertEquals("", sut.getLang("site.com/page/index.html"));
+        assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
+        assertEquals("", sut.getLang("/page?language=en"));
+    }
+
+    public void testGetLang__MatchingQuery__ReturnLangCode() {
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+		assertEquals("fr", sut.getLang("?wovn=fr"));
+		assertEquals("fr", sut.getLang("/?wovn=fr"));
+		assertEquals("fr", sut.getLang("/en/?wovn=fr"));
+		assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
+		assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
+        /* incorrect behavior below */
+		assertEquals("nl", sut.getLang("/en/?wovn=Nederlands"));
+	}
+
+    public void testRemoveLang__NonMatchingQuery__DoNotModify() {
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+		assertEquals("/", sut.removeLang("/", "ja"));
+		assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
+		assertEquals("/page/?wovn=en", sut.removeLang("/page/?wovn=en", "ja"));
+		assertEquals("ja.site.com/ja/?lang=ja", sut.removeLang("ja.site.com/ja/?lang=ja", "ja"));
+    }
+
+    public void testRemoveLang__MatchingQuery__RemoveLangCode() {
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+		assertEquals("", sut.removeLang("?wovn=ja", "ja"));
+		assertEquals("/?search=pizza&lang=ja", sut.removeLang("/?search=pizza&wovn=ja&lang=ja", "ja"));
+		assertEquals("site.com/page/index.html?wovn&wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja&wovn", "ja"));
+		assertEquals("ja.site.com/ja/", sut.removeLang("ja.site.com/ja/?wovn=ja", "ja"));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -1,0 +1,41 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
+    public void testGetLang__NonMatchingSubdomain__ReturnEmptyLang() {
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        assertEquals("", sut.getLang("/"));
+        assertEquals("", sut.getLang("/en"));
+        assertEquals("", sut.getLang("/en/page"));
+        assertEquals("", sut.getLang("site.com/page/index.html"));
+        assertEquals("", sut.getLang("site.com/en/pre/fix/index.html"));
+        assertEquals("", sut.getLang("/page?language=en&wovn=fr"));
+    }
+
+    public void testGetLang__MatchingSubdomain__ReturnLangCode() {
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+		assertEquals("en", sut.getLang("en.site.com"));
+		assertEquals("es", sut.getLang("es.site.com/"));
+		assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
+        /* incorrect behavior below */
+		assertEquals("de", sut.getLang("deutsch.site.com/page"));
+	}
+
+    public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+		assertEquals("/", sut.getLang("/"));
+        assertEquals("site.com", sut.getLang("site.com"));
+		assertEquals("ja.site.com", sut.getLang("ja.site.com", "fr"));
+		assertEquals("ja.fr.site.com", sut.getLang("ja.fr.site.com", "fr"));
+		assertEquals("site.com/fr/index.html?wovn=fr", sut.getLang("site.com/fr/index.html?wovn=fr", "fr"));
+    }
+
+    public void testRemoveLang__MatchingSubdomain__RemoveLangCode() {
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+		assertEquals("site.com", sut.getLang("en.site.com", "en"));
+		assertEquals("site.com/", sut.getLang("es.site.com/", "es"));
+		assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.getLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr");
+	}
+}

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -25,17 +25,17 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
-		assertEquals("/", sut.getLang("/"));
-        assertEquals("site.com", sut.getLang("site.com"));
-		assertEquals("ja.site.com", sut.getLang("ja.site.com", "fr"));
-		assertEquals("ja.fr.site.com", sut.getLang("ja.fr.site.com", "fr"));
-		assertEquals("site.com/fr/index.html?wovn=fr", sut.getLang("site.com/fr/index.html?wovn=fr", "fr"));
+		assertEquals("/", sut.removeLang("/", "en"));
+        assertEquals("site.com", sut.removeLang("site.com", "en"));
+		assertEquals("ja.site.com", sut.removeLang("ja.site.com", "fr"));
+		assertEquals("ja.fr.site.com", sut.removeLang("ja.fr.site.com", "fr"));
+		assertEquals("site.com/fr/index.html?wovn=fr", sut.removeLang("site.com/fr/index.html?wovn=fr", "fr"));
     }
 
     public void testRemoveLang__MatchingSubdomain__RemoveLangCode() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
-		assertEquals("site.com", sut.getLang("en.site.com", "en"));
-		assertEquals("site.com/", sut.getLang("es.site.com/", "es"));
-		assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.getLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr");
+		assertEquals("site.com", sut.removeLang("en.site.com", "en"));
+		assertEquals("site.com/", sut.removeLang("es.site.com/", "es"));
+		assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.removeLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr"));
 	}
 }


### PR DESCRIPTION
Move `removeLang` logic from Headers into the respective PatternHandlers.

Logic remains unchanged.