### PR TITLE
[Refactor] Calculate requestLang at Headers initialization

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -27,7 +27,7 @@ class Headers {
         this.request = r;
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
-        this.requestLang = this.calculateRequestLang();
+        this.requestLang = this.computeRequestLang();
 
         this.protocol = this.request.getScheme();
 
@@ -263,7 +263,7 @@ class Headers {
         return this.pathName.startsWith(this.settings.sitePrefixPath);
     }
 
-    private String calculateRequestLang() {
+    private String computeRequestLang() {
         String path;
         if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
             path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -273,6 +273,6 @@ class Headers {
         if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
             path += "?" + this.request.getQueryString();
         }
-        return this.patternHandler.getLang(path);
+        return this.urlLanguagePatternHandler.getLang(path);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -27,6 +27,8 @@ class Headers {
         this.request = r;
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
+        this.pathLang = this.calculateRequestLang();
+
         this.protocol = this.request.getScheme();
 
         String requestUri = null;
@@ -139,18 +141,6 @@ class Headers {
     }
 
     String getPathLang() {
-        if (this.pathLang == null) {
-            String path;
-            if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
-                path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();
-            } else {
-                path = this.request.getServerName() + this.request.getRequestURI();
-            }
-            if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
-                path += "?" + this.request.getQueryString();
-            }
-            this.pathLang = this.urlLanguagePatternHandler.getLang(path);
-        }
         return this.pathLang;
     }
 
@@ -271,5 +261,18 @@ class Headers {
 
     boolean isValidPath() {
         return this.pathName.startsWith(this.settings.sitePrefixPath);
+    }
+
+    private String calculateRequestLang() {
+        String path;
+        if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
+            path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();
+        } else {
+            path = this.request.getServerName() + this.request.getRequestURI();
+        }
+        if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
+            path += "?" + this.request.getQueryString();
+        }
+        return this.patternHandler.getLang(path);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -19,7 +19,7 @@ class Headers {
     String url;
 
     private HttpServletRequest request;
-    private String pathLang;
+    private String requestLang;
     private UrlLanguagePatternHandler urlLanguagePatternHandler;
 
     Headers(HttpServletRequest r, Settings s, UrlLanguagePatternHandler urlLanguagePatternHandler) {
@@ -27,7 +27,7 @@ class Headers {
         this.request = r;
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
-        this.pathLang = this.calculateRequestLang();
+        this.requestLang = this.calculateRequestLang();
 
         this.protocol = this.request.getScheme();
 
@@ -132,7 +132,7 @@ class Headers {
     }
 
     String langCode() {
-        String pl = getPathLang();
+        String pl = this.requestLang;
         if (pl != null && pl.length() > 0) {
             return pl;
         } else {
@@ -140,8 +140,8 @@ class Headers {
         }
     }
 
-    String getPathLang() {
-        return this.pathLang;
+    String getRequestLang() {
+        return this.requestLang;
     }
 
     /**
@@ -254,7 +254,7 @@ class Headers {
 
     String removeLang(String uri, String lang) {
         if (lang == null || lang.length() == 0) {
-            lang = this.getPathLang();
+            lang = this.requestLang;
         }
         return this.urlLanguagePatternHandler.removeLang(uri, lang);
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -16,7 +16,7 @@ class Interceptor {
     }
 
     String translate(String body) {
-        String lang = headers.getPathLang();
+        String lang = headers.getRequestLang();
         boolean canTranslate = lang.length() > 0 && !lang.equals(settings.defaultLang);
         if (canTranslate) {
             return apiTranslate(lang, body);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -41,7 +41,7 @@ public class WovnServletFilter implements Filter {
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
-        String lang = headers.getPathLang();
+        String lang = headers.getRequestLang();
         boolean isRequestWithDefaultLanguageCode = settings.urlPattern.equals("path") && lang.length() > 0 && lang.equals(settings.defaultLang);
         boolean canProcessRequest = !requestOptions.getDisableMode() && headers.isValidPath() && htmlChecker.canTranslatePath(headers.pathName);
 
@@ -69,7 +69,7 @@ public class WovnServletFilter implements Filter {
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");
 
-        if (settings.urlPattern.equals("path") && headers.getPathLang().length() > 0) {
+        if (settings.urlPattern.equals("path") && headers.getRequestLang().length() > 0) {
             wovnRequest.getRequestDispatcher(headers.pathNameKeepTrailingSlash).forward(wovnRequest, wovnResponse);
         } else {
             chain.doFilter(wovnRequest, wovnResponse);

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -191,7 +191,7 @@ public class HeadersTest extends TestCase {
         assertEquals("?abc=123", h.query);
     }
 
-    public void testGetPathLangPath() throws ConfigurationError {
+    public void testGetRequestLangPath() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath();
         FilterConfig mockConfig = mockConfigPath();
 
@@ -199,10 +199,10 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getPathLang());
+        assertEquals("ja", h.getRequestLang());
     }
 
-    public void testGetPathLangSubdomain() throws ConfigurationError {
+    public void testGetRequestLangSubdomain() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestSubdomain();
         FilterConfig mockConfig = mockConfigSubdomain();
 
@@ -210,10 +210,10 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getPathLang());
+        assertEquals("ja", h.getRequestLang());
     }
 
-    public void testGetPathLangQuery() throws ConfigurationError {
+    public void testGetRequestLangQuery() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestQuery();
         FilterConfig mockConfig = mockConfigQuery();
 
@@ -221,7 +221,7 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getPathLang());
+        assertEquals("ja", h.getRequestLang());
     }
 
     public void testRedirectLocationPathTop() throws ConfigurationError {


### PR DESCRIPTION
### Changes
* Rename `pathLang` to `requestLang`.
* Calculate `requestLang` only once, when Headers is instantiated. Change the getter to simply return the value.

Logic for calculating the value remains unchanged.