### PR TITLE
[MISC] Update circleci env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,14 @@ jobs:
            export MAVEN_HOME=~/.m2
 
       - restore_cache:
-          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+          key: circleci-wovnjava-pom-{{ checksum "~/.m2" }}
 
       - run: mvn dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
-          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+          key: circleci-wovnjava-pom-{{ checksum "~/.m2" }}
 
       - run: mvn package
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ anchors:
 jobs:
   oraclejdk8:
     docker:
-      - image: ubuntu:16:04
+      - image: circleci/circleci-cli:latest
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
            cat .jdk8-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install || true
            export JAVA_HOME=/usr/lib/jvm/jdk8-oracle
            export PATH=${JAVA_HOME}/bin:$PATH
+           export M2_HOME=~/.m2
+           export MAVEN_HOME=~/.m2
 
       - restore_cache:
           key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ anchors:
 jobs:
   oraclejdk8:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/ubuntu-server:latest
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
            mkdir jdk8-oracle && tar zxf jdk8-oracle.tar.gz -C jdk8-oracle --strip-components 1
            sudo cp -a ~/jdk8-oracle /usr/lib/jvm
            cd /usr/lib/jvm
-           export JAVA_HOME=/usr/lib/jvm/
+           sed -e "s/\(java-8-openjdk-amd64\|java-1.8.0-openjdk-amd64\)/jdk8-oracle/g" .java-1.8.0-openjdk-amd64.jinfo | sudo tee .jdk8-oracle.jinfo
+           cat .jdk8-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install || true
+           export JAVA_HOME=/usr/lib/jvm/jdk8-oracle
            export PATH=${JAVA_HOME}/bin:$PATH
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ anchors:
 jobs:
   oraclejdk8:
     docker:
-      - image: circleci/ubuntu-server:latest
+      - image: circleci/circleci-cli:alpine
     steps:
       - checkout
 
@@ -34,10 +34,9 @@ jobs:
            mkdir jdk8-oracle && tar zxf jdk8-oracle.tar.gz -C jdk8-oracle --strip-components 1
            sudo cp -a ~/jdk8-oracle /usr/lib/jvm
            cd /usr/lib/jvm
-           sed -e "s/\(java-8-openjdk-amd64\|java-1.8.0-openjdk-amd64\)/jdk8-oracle/g" .java-1.8.0-openjdk-amd64.jinfo | sudo tee .jdk8-oracle.jinfo
-           cat .jdk8-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install
-           sudo update-java-alternatives --set jdk8-oracle
-           export JAVA_HOME=/usr/lib/jvm/jdk8-oracle
+           export JAVA_HOME=/usr/lib/jvm/
+           export PATH=${JAVA_HOME}/bin:$PATH
+           sudo apt install -y maven
 
       - restore_cache:
           key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,6 @@ workflows:
       - oraclejdk8
       - openjdk8
 
-anchors:
-  - restore_cache: &restore_cache
-      key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
-  - save_cache: &save_cache
-      paths:
-        - ~/.m2
-      key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
-
 jobs:
   oraclejdk8:
     docker:
@@ -47,14 +39,14 @@ jobs:
            export MAVEN_HOME=~/.m2
 
       - restore_cache:
-          key: circleci-wovnjava-pom-{{ checksum "~/.m2" }}
+          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
 
       - run: mvn dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
-          key: circleci-wovnjava-pom-{{ checksum "~/.m2" }}
+          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
 
       - run: mvn package
 
@@ -80,14 +72,14 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+          key: circleci-wovnjava-openjdk-pom-{{ checksum "pom.xml" }}
 
       - run: mvn dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
-          key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}
+          key: circleci-wovnjava-openjdk-pom-{{ checksum "pom.xml" }}
 
       - run: mvn package
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ anchors:
 jobs:
   oraclejdk8:
     docker:
-      - image: circleci/circleci-cli:alpine
+      - image: ubuntu:16:04
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
       - run:
          name: install oracle jdk
          command: |
+           sudo cp /etc/apt/sources.list /etc/apt/org_sources.list
+           sudo sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+           sudo apt-get clean
+           sudo apt-get update
+           sudo apt install -y maven
            cd ~/
            curl -O https://bootstrap.pypa.io/get-pip.py
            python get-pip.py --user
@@ -36,7 +41,6 @@ jobs:
            cd /usr/lib/jvm
            export JAVA_HOME=/usr/lib/jvm/
            export PATH=${JAVA_HOME}/bin:$PATH
-           sudo apt install -y maven
 
       - restore_cache:
           key: circleci-wovnjava-pom-{{ checksum "pom.xml" }}


### PR DESCRIPTION
This PR change image for oraclejdk to another circleci image.
The name of image for `oraclejdk` env was `circleci/openjdk:8-jdk` .
It can lead to mis-understanding.

Additionally, update cache key for use cache.
