### PR TITLE
Allow Lang lookup only by language code

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -147,7 +147,7 @@ class HtmlConverter {
         for (String lang : settings.supportedLangs) {
             Element link = new Element(Tag.valueOf("link"), "");
             link.attr("ref", "alternate");
-            link.attr("hreflang", Lang.getLang(lang).hreflangCode);
+            link.attr("hreflang", Lang.get(lang).hreflangCode);
             link.attr("href", headers.redirectLocation(lang));
             doc.head().appendChild(link);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -147,7 +147,7 @@ class HtmlConverter {
         for (String lang : settings.supportedLangs) {
             Element link = new Element(Tag.valueOf("link"), "");
             link.attr("ref", "alternate");
-            link.attr("hreflang", Lang.normalizeIso639_1(lang));
+            link.attr("hreflang", Lang.getLang(lang).hreflangCode);
             link.attr("href", headers.redirectLocation(lang));
             doc.head().appendChild(link);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/Lang.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Lang.java
@@ -50,7 +50,7 @@ class Lang {
         this.hreflangCode = hreflangCode;
     }
 
-    static Lang getLang(String langCode) {
+    static Lang get(String langCode) {
         if (langCode == null) return null;
 
         return LANG.get(langCode.toLowerCase());

--- a/src/main/java/com/github/wovnio/wovnjava/Lang.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Lang.java
@@ -50,7 +50,7 @@ class Lang {
         this.hreflangCode = hreflangCode;
     }
 
-    public static Lang getLang(String langCode) {
+    static Lang getLang(String langCode) {
         if (langCode == null) return null;
 
         return LANG.get(langCode.toLowerCase());

--- a/src/main/java/com/github/wovnio/wovnjava/Lang.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Lang.java
@@ -1,94 +1,58 @@
 package com.github.wovnio.wovnjava;
 
-import org.jetbrains.annotations.Contract;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 class Lang {
-    static final Map<String, Lang> LANG;
+    private static final Map<String, Lang> LANG;
     static {
         HashMap<String, Lang> map = new HashMap<String, Lang>();
-        map.put("ar", new Lang("ﺎﻠﻋﺮﺒﻳﺓ", "ar", "Arabic"));
-        map.put("bg", new Lang("Български", "bg", "Bulgarian"));
-        map.put("zh-CHS", new Lang("简体中文", "zh-CHS", "Simp Chinese"));
-        map.put("zh-CHT", new Lang("繁體中文", "zh-CHT", "Trad Chinese"));
-        map.put("da", new Lang("Dansk", "da", "Danish"));
-        map.put("nl", new Lang("Nederlands", "nl", "Dutch"));
-        map.put("en", new Lang("English", "en", "English"));
-        map.put("fi", new Lang("Suomi", "fi", "Finnish"));
-        map.put("fr", new Lang("Français", "fr", "French"));
-        map.put("de", new Lang("Deutsch", "de", "German"));
-        map.put("el", new Lang("Ελληνικά", "el", "Greek"));
-        map.put("he", new Lang("עברית", "he", "Hebrew"));
-        map.put("id", new Lang("Bahasa Indonesia", "id", "Indonesian"));
-        map.put("it", new Lang("Italiano", "it", "Italian"));
-        map.put("ja", new Lang("日本語", "ja", "Japanese"));
-        map.put("ko", new Lang("한국어", "ko", "Korean"));
-        map.put("ms", new Lang("Bahasa Melayu", "ms", "Malay"));
-        map.put("my", new Lang("ဗမာစာ", "my", "Burmese"));
-        map.put("ne", new Lang("नेपाली भाषा", "ne", "Nepali"));
-        map.put("no", new Lang("Norsk", "no", "Norwegian"));
-        map.put("pl", new Lang("Polski", "pl", "Polish"));
-        map.put("pt", new Lang("Português", "pt", "Portuguese"));
-        map.put("ru", new Lang("Русский", "ru", "Russian"));
-        map.put("es", new Lang("Español", "es", "Spanish"));
-        map.put("sv", new Lang("Svensk", "sv", "Swedish"));
-        map.put("th", new Lang("ภาษาไทย", "th", "Thai"));
-        map.put("hi", new Lang("हिन्दी", "hi", "Hindi"));
-        map.put("tr", new Lang("Türkçe", "tr", "Turkish"));
-        map.put("uk", new Lang("Українська", "uk", "Ukrainian"));
-        map.put("vi", new Lang("Tiếng Việt", "vi", "Vietnamese"));
-        map.put("tl", new Lang("Tagalog", "tl", "Tagalog"));
+        map.put("ar",     new Lang("ar", "ar", "Arabic", "ﺎﻠﻋﺮﺒﻳﺓ"));
+        map.put("bg",     new Lang("bg", "bg", "Bulgarian", "Български"));
+        map.put("zh-chs", new Lang("zh-CHS", "zh-Hans", "Simp Chinese", "简体中文"));
+        map.put("zh-cht", new Lang("zh-CHT", "zh-Hant", "Trad Chinese", "繁體中文"));
+        map.put("da",     new Lang("da", "da", "Danish", "Dansk"));
+        map.put("nl",     new Lang("nl", "nl", "Dutch", "Nederlands"));
+        map.put("en",     new Lang("en", "en", "English", "English"));
+        map.put("fi",     new Lang("fi", "fi", "Finnish", "Suomi"));
+        map.put("fr",     new Lang("fr", "fr", "French", "Français"));
+        map.put("de",     new Lang("de", "de", "German", "Deutsch"));
+        map.put("el",     new Lang("el", "el", "Greek", "Ελληνικά"));
+        map.put("he",     new Lang("he", "he", "Hebrew", "עברית"));
+        map.put("id",     new Lang("id", "id", "Indonesian", "Bahasa Indonesia"));
+        map.put("it",     new Lang("it", "it", "Italian", "Italiano"));
+        map.put("ja",     new Lang("ja", "ja", "Japanese", "日本語"));
+        map.put("ko",     new Lang("ko", "ko", "Korean", "한국어"));
+        map.put("ms",     new Lang("ms", "ms", "Malay", "Bahasa Melayu"));
+        map.put("my",     new Lang("my", "my", "Burmese", "ဗမာစာ"));
+        map.put("ne",     new Lang("ne", "ne", "Nepali", "नेपाली भाषा"));
+        map.put("no",     new Lang("no", "no", "Norwegian", "Norsk"));
+        map.put("pl",     new Lang("pl", "pl", "Polish", "Polski"));
+        map.put("pt",     new Lang("pt", "pt", "Portuguese", "Português"));
+        map.put("ru",     new Lang("ru", "ru", "Russian", "Русский"));
+        map.put("es",     new Lang("es", "es", "Spanish", "Español"));
+        map.put("sv",     new Lang("sv", "sv", "Swedish", "Svensk"));
+        map.put("th",     new Lang("th", "th", "Thai", "ภาษาไทย"));
+        map.put("hi",     new Lang("hi", "hi", "Hindi", "हिन्दी"));
+        map.put("tr",     new Lang("tr", "tr", "Turkish", "Türkçe"));
+        map.put("uk",     new Lang("uk", "uk", "Ukrainian", "Українська"));
+        map.put("vi",     new Lang("vi", "vi", "Vietnamese", "Tiếng Việt"));
+        map.put("tl",     new Lang("tl", "tl", "Tagalog", "Tagalog"));
         LANG = Collections.unmodifiableMap(map);
     }
 
-    String name;
     String code;
-    String en;
+    String hreflangCode;
 
-    Lang(String n, String c, String e) {
-        super();
-        this.name = n;
-        this.code = c;
-        this.en = e;
+    Lang(String code, String hreflangCode, String englishName, String nativeName) {
+        this.code = code;
+        this.hreflangCode = hreflangCode;
     }
 
-    @Contract("null -> null")
-    static String getCode(String langName) {
-        if (langName == null || langName.length() == 0) {
-            return null;
-        }
-        if (LANG.get(langName) != null) {
-            return langName;
-        }
-        for (Map.Entry<String, Lang> e : LANG.entrySet()) {
-            Lang l = e.getValue();
-            String langNameLC = langName.toLowerCase();
-            if ( langNameLC.equals(l.name.toLowerCase())
-                    || langNameLC.equals(l.en.toLowerCase())
-                    || langNameLC.equals(l.code.toLowerCase())
-                    ) {
-                return l.code;
-            }
-        }
-        return null;
-    }
+    public static Lang getLang(String langCode) {
+        if (langCode == null) return null;
 
-    static Lang getLang(String langName) {
-        String langCode = getCode(langName);
-        return LANG.get(langCode);
-    }
-
-    static String normalizeIso639_1(String langCode) {
-        String langCodeLC = langCode.toLowerCase();
-        if (langCodeLC.equals("zh-cht")) {
-            return "zh-Hant";
-        } else if (langCodeLC.equals("zh-chs")) {
-            return "zh-Hans";
-        } else {
-            return langCode;
-        }
+        return LANG.get(langCode.toLowerCase());
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -187,7 +187,7 @@ class Settings {
     }
 
     private void initialize() {
-        this.defaultLang = Lang.getCode(this.defaultLang);
+        this.defaultLang = Lang.getLang(this.defaultLang).code;
 
         if (this.supportedLangs.size() == 0) {
             this.supportedLangs.add(this.defaultLang);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -191,6 +191,12 @@ class Settings {
             throw new ConfigurationError("Invalid language code for defaultLang: " + this.defaultLang);
         }
 
+        for (int i = 0; i < this.supportedLangs.size(); i++) {
+            if (Lang.getLang(this.supportedLangs.get(i)) == null) {
+                throw new ConfigurationError("Invalid language code for supportedLangs: " + this.supportedLangs.get(i));
+            }
+        }
+
         if (this.supportedLangs.size() == 0) {
             this.supportedLangs.add(this.defaultLang);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -191,9 +191,9 @@ class Settings {
             throw new ConfigurationError("Invalid language code for defaultLang: " + this.defaultLang);
         }
 
-        for (int i = 0; i < this.supportedLangs.size(); i++) {
-            if (Lang.getLang(this.supportedLangs.get(i)) == null) {
-                throw new ConfigurationError("Invalid language code for supportedLangs: " + this.supportedLangs.get(i));
+        for (String supportedLang : this.supportedLangs) {
+            if (Lang.getLang(supportedLang) == null) {
+                throw new ConfigurationError("Invalid language code for supportedLangs: " + supportedLang);
             }
         }
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -187,12 +187,12 @@ class Settings {
     }
 
     private void initialize() throws ConfigurationError {
-        if (Lang.getLang(this.defaultLang) == null) {
+        if (Lang.get(this.defaultLang) == null) {
             throw new ConfigurationError("Invalid language code for defaultLang: " + this.defaultLang);
         }
 
         for (String supportedLang : this.supportedLangs) {
-            if (Lang.getLang(supportedLang) == null) {
+            if (Lang.get(supportedLang) == null) {
                 throw new ConfigurationError("Invalid language code for supportedLangs: " + supportedLang);
             }
         }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -37,7 +37,7 @@ class Settings {
     boolean debugMode = false;
     boolean enableFlushBuffer = false;
 
-    Settings(FilterConfig config) {
+    Settings(FilterConfig config) throws ConfigurationError {
         super();
 
         this.query = new ArrayList<String>();
@@ -186,8 +186,13 @@ class Settings {
         return param.equals("on") || param.equals("true") || param.equals("1");
     }
 
-    private void initialize() {
-        this.defaultLang = Lang.getLang(this.defaultLang).code;
+    private void initialize() throws ConfigurationError {
+        String inputCode = this.defaultLang;
+        Lang defaultLangObject = Lang.getLang(inputCode);
+        if (defaultLangObject == null) {
+            throw new ConfigurationError("Invalid language code for defaultLang: " + inputCode);
+        }
+        this.defaultLang = defaultLangObject.code;
 
         if (this.supportedLangs.size() == 0) {
             this.supportedLangs.add(this.defaultLang);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -187,12 +187,9 @@ class Settings {
     }
 
     private void initialize() throws ConfigurationError {
-        String inputCode = this.defaultLang;
-        Lang defaultLangObject = Lang.getLang(inputCode);
-        if (defaultLangObject == null) {
-            throw new ConfigurationError("Invalid language code for defaultLang: " + inputCode);
+        if (Lang.getLang(this.defaultLang) == null) {
+            throw new ConfigurationError("Invalid language code for defaultLang: " + this.defaultLang);
         }
-        this.defaultLang = defaultLangObject.code;
 
         if (this.supportedLangs.size() == 0) {
             this.supportedLangs.add(this.defaultLang);

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -13,9 +13,10 @@ abstract class UrlLanguagePatternHandler {
     protected String getLangMatch(String url, Pattern pattern) {
         Matcher matcher = pattern.matcher(url);
         if (matcher.find()) {
-            String lang = matcher.group(1);
-            if (lang != null && lang.length() > 0 && Lang.getLang(lang) != null) {
-                return Lang.getLang(lang).code;
+            String langMatch = matcher.group(1);
+            Lang lang = Lang.getLang(langMatch);
+            if (lang != null) {
+                return lang.code;
             }
         }
         return "";

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -15,10 +15,7 @@ abstract class UrlLanguagePatternHandler {
         if (matcher.find()) {
             String lang = matcher.group(1);
             if (lang != null && lang.length() > 0 && Lang.getLang(lang) != null) {
-                String langCode = Lang.getCode(lang);
-                if (langCode != null && langCode.length() > 0) {
-                    return langCode;
-                }
+                return Lang.getLang(lang).code;
             }
         }
         return "";

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -14,7 +14,7 @@ abstract class UrlLanguagePatternHandler {
         Matcher matcher = pattern.matcher(url);
         if (matcher.find()) {
             String langMatch = matcher.group(1);
-            Lang lang = Lang.getLang(langMatch);
+            Lang lang = Lang.get(langMatch);
             if (lang != null) {
                 return lang.code;
             }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -11,7 +11,7 @@ import org.easymock.EasyMock;
 
 public class HtmlConverterTest extends TestCase {
 
-    public void testDisablePrettyPrint() {
+    public void testDisablePrettyPrint() throws ConfigurationError {
         String original = "<html><head></head><body>\n " + "hello" + "\t\n</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = new HtmlConverter(settings, original);
@@ -19,7 +19,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(original, html);
     }
 
-    public void testRemoveWovnSnippet() {
+    public void testRemoveWovnSnippet() throws ConfigurationError {
         String original = "<html><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
         String removedHtml = "<html><head></head><body></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -29,7 +29,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(removedHtml, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveScripts() {
+    public void testRemoveScripts() throws ConfigurationError {
         String original = "<html><head><script>alert(1)</script></head><body>a <script>console.log(1)</script>b</body></html>";
         String removedHtml = "<html><head><!--wovn-marker-0--></head><body>a <!--wovn-marker-1-->b</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -39,7 +39,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(stripExtraSpaces(original), stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveHrefLangIfConflicts() {
+    public void testRemoveHrefLangIfConflicts() throws ConfigurationError {
         String original = "<html><head><link ref=\"altername\" hreflang=\"en\" href=\"http://localhost:8080/\"><link ref=\"altername\" hreflang=\"ja\" href=\"http://localhost:8080/ja/\"><link ref=\"altername\" hreflang=\"ar\" href=\"http://localhost:8080/ar/\"></head><body></body></html>";
         String removedHtml = "<html><head><link ref=\"altername\" hreflang=\"ar\" href=\"http://localhost:8080/ar/\"></head><body></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -49,7 +49,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(removedHtml, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveWovnIgnore() {
+    public void testRemoveWovnIgnore() throws ConfigurationError {
         String original = "<html><head></head><body><div>Hello <span wovn-ignore>Duke</span>.</div></body></html>";
         String removedHtml = "<html><head></head><body><div>Hello <!--wovn-marker-0-->.</div></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -59,7 +59,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(original, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveClassIgnore() {
+    public void testRemoveClassIgnore() throws ConfigurationError {
         String original = "<html><head></head><body>" +
           "<p class=\"no-ignore\">The pizza needs <b class=\"ingredient\">pineapple</b>, <span class=\"name\">Chad</span>!</p>" +
           "<p class=\"ignore-me\">It's a fruit, <span class=\"name\">Louie</span>!</p>" +
@@ -79,7 +79,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(original, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveForm() {
+    public void testRemoveForm() throws ConfigurationError {
         String original = "<html><head></head><body><form><input type=\"hidden\" name=\"csrf\" value=\"random\"><INPUT TYPE=\"HIDDEN\" NAME=\"CSRF_TOKEN\" VALUE=\"RANDOM\"></form></body></html>";
         String removedHtml = "<html><head></head><body><form><!--wovn-marker-0--><!--wovn-marker-1--></form></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -90,7 +90,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(original.replace("INPUT", "input"), stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testNested() {
+    public void testNested() throws ConfigurationError {
         String original = "<html><head></head><body><form wovn-ignore><script></script><input type=\"hidden\" name=\"csrf\" value=\"random\"><INPUT TYPE=\"HIDDEN\" NAME=\"CSRF_TOKEN\" VALUE=\"RANDOM\"></form></body></html>";
         String removedHtml = "<html><head></head><body><!--wovn-marker-1--></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
@@ -124,7 +124,7 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(expectedHtml, converter.convert(headers, "ja"));
     }
 
-    public void testMixAllCase() {
+    public void testMixAllCase() throws ConfigurationError {
         String original = "<html><head>" +
             "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script>" +
             "<script>alert(1)</script>" +

--- a/src/test/java/com/github/wovnio/wovnjava/LangTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/LangTest.java
@@ -5,125 +5,33 @@ import junit.framework.TestCase;
 import java.util.Map;
 
 public class LangTest extends TestCase {
-
-    public void testLangsExist() {
-        assertNotNull(Lang.LANG);
+    public void testGetLang__validCode() {
+        Lang english = Lang.getLang("en");
+        assertEquals("en", english.code);
+        assertEquals("en", english.hreflangCode);
     }
 
-    public void testLangsSize() {
-        assertEquals(31, Lang.LANG.size());
+    public void testGetLang__validCode_capitalLetters() {
+        Lang japanese = Lang.getLang("JA");
+        assertEquals("ja", japanese.code);
+        assertEquals("ja", japanese.hreflangCode);
     }
 
-    public void testKeyExist() {
-        for (Map.Entry<String, Lang> e : Lang.LANG.entrySet()) {
-            String k = e.getKey();
-            Lang l = e.getValue();
-            assertFalse(l.name == null || l.name.length() == 0);
-            assertFalse(l.code == null || l.code.length() == 0);
-            assertFalse(l.en == null || l.en.length() == 0);
-            assertEquals(k, l.code);
-        }
+    public void testGetLang__invalidCode() {
+        assertEquals(null, Lang.getLang("jp"));
     }
 
-    public void testLang() {
-        Lang lang = new Lang("日本語", "ja", "Japanese");
-        assertNotNull(lang);
-        assertEquals("日本語", lang.name);
-        assertEquals("ja", lang.code);
-        assertEquals("Japanese", lang.en);
+    public void testGetLang__null() {
+        assertEquals(null, Lang.getLang(null));
     }
 
-    public void testGetCodeWithValidCode() {
-        assertEquals("ms", Lang.getCode("ms"));
-    }
+    public void testGetLang__differentHreflangCode() {
+        Lang traditionalChinese = Lang.getLang("zh-CHT");
+        assertEquals("zh-CHT", traditionalChinese.code);
+        assertEquals("zh-Hant", traditionalChinese.hreflangCode);
 
-    public void testGetCodeWithCapitalLetters() {
-        assertEquals("zh-CHT", Lang.getCode("zh-cht"));
-    }
-
-    public void testGetCodeWithValidEnglishName() {
-        assertEquals("pt", Lang.getCode("Portuguese"));
-    }
-
-    public void testGetCodeWithValidNativeName() {
-        assertEquals("hi", Lang.getCode("हिन्दी"));
-    }
-
-    public void testGetCodeWithInvalidName() {
-        assertEquals(null, Lang.getCode("WOVN4LYFE"));
-    }
-
-    public void testGetCodeWithEmptyString() {
-        assertEquals(null, Lang.getCode(""));
-    }
-
-    public void testGetCodeWithNull() {
-        assertEquals(null, Lang.getCode(null));
-    }
-
-    public void testGetLangWithValidCode() {
-        assertSame(Lang.LANG.get("ms"), Lang.getLang("ms"));
-    }
-
-    public void testGetLangWithCapitalLetters() {
-        assertSame(Lang.LANG.get("zh-CHT"), Lang.getLang("zh-cht"));
-    }
-
-    public void testGetLangWithValidEnglishName() {
-        assertSame(Lang.LANG.get("pt"), Lang.getLang("Portuguese"));
-    }
-
-    public void testGetLangWithValidNativeName() {
-        assertSame(Lang.LANG.get("hi"), Lang.getLang("हिन्दी"));
-    }
-
-    public void testGetLangWithInvalidName() {
-        assertSame(null, Lang.getLang("WOVN4LYFE"));
-    }
-
-    public void testGetLangWithEmptyString() {
-        assertSame(null, Lang.getLang(""));
-    }
-
-    public void testGetLangWithNull() {
-        assertSame(null, Lang.getLang(null));
-    }
-
-    public void testNomalizeIso639_1() {
-        assertEquals("ar",       Lang.normalizeIso639_1("ar"));
-        assertEquals("bg",       Lang.normalizeIso639_1("bg"));
-
-        assertEquals("zh-Hans",  Lang.normalizeIso639_1("zh-CHS"));
-        assertEquals("zh-Hant",  Lang.normalizeIso639_1("zh-CHT"));
-
-        assertEquals("zh-Hans",  Lang.normalizeIso639_1("zh-chs"));
-        assertEquals("zh-Hant",  Lang.normalizeIso639_1("zh-cht"));
-
-        assertEquals("da",       Lang.normalizeIso639_1("da"));
-        assertEquals("nl",       Lang.normalizeIso639_1("nl"));
-        assertEquals("en",       Lang.normalizeIso639_1("en"));
-        assertEquals("fi",       Lang.normalizeIso639_1("fi"));
-        assertEquals("fr",       Lang.normalizeIso639_1("fr"));
-        assertEquals("de",       Lang.normalizeIso639_1("de"));
-        assertEquals("el",       Lang.normalizeIso639_1("el"));
-        assertEquals("he",       Lang.normalizeIso639_1("he"));
-        assertEquals("id",       Lang.normalizeIso639_1("id"));
-        assertEquals("it",       Lang.normalizeIso639_1("it"));
-        assertEquals("ja",       Lang.normalizeIso639_1("ja"));
-        assertEquals("ko",       Lang.normalizeIso639_1("ko"));
-        assertEquals("ms",       Lang.normalizeIso639_1("ms"));
-        assertEquals("my",       Lang.normalizeIso639_1("my"));
-        assertEquals("ne",       Lang.normalizeIso639_1("ne"));
-        assertEquals("no",       Lang.normalizeIso639_1("no"));
-        assertEquals("pl",       Lang.normalizeIso639_1("pl"));
-        assertEquals("pt",       Lang.normalizeIso639_1("pt"));
-        assertEquals("ru",       Lang.normalizeIso639_1("ru"));
-        assertEquals("es",       Lang.normalizeIso639_1("es"));
-        assertEquals("sv",       Lang.normalizeIso639_1("sv"));
-        assertEquals("th",       Lang.normalizeIso639_1("th"));
-        assertEquals("hi",       Lang.normalizeIso639_1("hi"));
-        assertEquals("tr",       Lang.normalizeIso639_1("tr"));
-        assertEquals("uk",       Lang.normalizeIso639_1("uk"));
-        assertEquals("vi",       Lang.normalizeIso639_1("vi"));
+        Lang simplifiedChinese = Lang.getLang("zh-chs");
+        assertEquals("zh-CHS", simplifiedChinese.code);
+        assertEquals("zh-Hans", simplifiedChinese.hreflangCode);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/LangTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/LangTest.java
@@ -6,31 +6,31 @@ import java.util.Map;
 
 public class LangTest extends TestCase {
     public void testGetLang__validCode() {
-        Lang english = Lang.getLang("en");
+        Lang english = Lang.get("en");
         assertEquals("en", english.code);
         assertEquals("en", english.hreflangCode);
     }
 
     public void testGetLang__validCode_capitalLetters() {
-        Lang japanese = Lang.getLang("JA");
+        Lang japanese = Lang.get("JA");
         assertEquals("ja", japanese.code);
         assertEquals("ja", japanese.hreflangCode);
     }
 
     public void testGetLang__invalidCode() {
-        assertEquals(null, Lang.getLang("jp"));
+        assertEquals(null, Lang.get("jp"));
     }
 
     public void testGetLang__null() {
-        assertEquals(null, Lang.getLang(null));
+        assertEquals(null, Lang.get(null));
     }
 
     public void testGetLang__differentHreflangCode() {
-        Lang traditionalChinese = Lang.getLang("zh-CHT");
+        Lang traditionalChinese = Lang.get("zh-CHT");
         assertEquals("zh-CHT", traditionalChinese.code);
         assertEquals("zh-Hant", traditionalChinese.hreflangCode);
 
-        Lang simplifiedChinese = Lang.getLang("zh-chs");
+        Lang simplifiedChinese = Lang.get("zh-chs");
         assertEquals("zh-CHS", simplifiedChinese.code);
         assertEquals("zh-Hans", simplifiedChinese.hreflangCode);
     }

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -11,6 +11,8 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("site.com/page/index.html"));
         assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?wovn=en"));
+        assertEquals("", sut.getLang("site.com/French/"));
+        assertEquals("", sut.getLang("site.com/Suomi/page/index.html"));
     }
 
     public void testGetLang__MatchingPath__ReturnLangCode() {
@@ -20,9 +22,6 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 		assertEquals("fr", sut.getLang("/fr/page"));
 		assertEquals("fr", sut.getLang("site.com/fr/page/index.html"));
 		assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
-        /* incorrect behavior below */
-		assertEquals("fr", sut.getLang("site.com/French/"));
-		assertEquals("fi", sut.getLang("site.com/Suomi/page/index.html"));
 	}
 
     public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnEmptyLang() {
@@ -33,6 +32,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 		assertEquals("", sut.getLang("/pre/fr/fix/page/index.html"));
 		assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
 		assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
+        assertEquals("", sut.getLang("/pre/fix/french/page/index.html"));
     }
 
     public void testGetLang__SitePrefixPath__MatchingPath__ReturnLangCode() {
@@ -42,8 +42,6 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 		assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
 		assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
 		assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
-        /* incorrect behavior below */
-		assertEquals("fr", sut.getLang("/pre/fix/french/page/index.html"));
     }
 
     public void testRemoveLang__NonMatchingPath__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -17,31 +17,31 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testGetLang__MatchingPath__ReturnLangCode() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
-		assertEquals("fr", sut.getLang("/fr"));
-		assertEquals("fr", sut.getLang("/fr/"));
-		assertEquals("fr", sut.getLang("/fr/page"));
-		assertEquals("fr", sut.getLang("site.com/fr/page/index.html"));
-		assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
-	}
+        assertEquals("fr", sut.getLang("/fr"));
+        assertEquals("fr", sut.getLang("/fr/"));
+        assertEquals("fr", sut.getLang("/fr/page"));
+        assertEquals("fr", sut.getLang("site.com/fr/page/index.html"));
+        assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
+    }
 
     public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnEmptyLang() {
         PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
-		assertEquals("", sut.getLang("site.com/fr"));
-		assertEquals("", sut.getLang("en.site.com/en/?wovn=en"));
-		assertEquals("", sut.getLang("/es/pre/fix/page/index.html"));
-		assertEquals("", sut.getLang("/pre/fr/fix/page/index.html"));
-		assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
-		assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
+        assertEquals("", sut.getLang("site.com/fr"));
+        assertEquals("", sut.getLang("en.site.com/en/?wovn=en"));
+        assertEquals("", sut.getLang("/es/pre/fix/page/index.html"));
+        assertEquals("", sut.getLang("/pre/fr/fix/page/index.html"));
+        assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
+        assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
         assertEquals("", sut.getLang("/pre/fix/french/page/index.html"));
     }
 
     public void testGetLang__SitePrefixPath__MatchingPath__ReturnLangCode() {
         PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
-		assertEquals("fr", sut.getLang("site.com/pre/fix/fr"));
-		assertEquals("fr", sut.getLang("site.com/pre/fix/fr/"));
-		assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
-		assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
-		assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
+        assertEquals("fr", sut.getLang("site.com/pre/fix/fr"));
+        assertEquals("fr", sut.getLang("site.com/pre/fix/fr/"));
+        assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
+        assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
+        assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
     }
 
     public void testRemoveLang__NonMatchingPath__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -12,6 +12,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("site.com/page/index.html"));
         assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?language=en"));
+        assertEquals("", sut.getLang("/en/?wovn=Nederlands"));
     }
 
     public void testGetLang__MatchingQuery__ReturnLangCode() {
@@ -21,8 +22,6 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
 		assertEquals("fr", sut.getLang("/en/?wovn=fr"));
 		assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
 		assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
-        /* incorrect behavior below */
-		assertEquals("nl", sut.getLang("/en/?wovn=Nederlands"));
 	}
 
     public void testRemoveLang__NonMatchingQuery__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -17,26 +17,26 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testGetLang__MatchingQuery__ReturnLangCode() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
-		assertEquals("fr", sut.getLang("?wovn=fr"));
-		assertEquals("fr", sut.getLang("/?wovn=fr"));
-		assertEquals("fr", sut.getLang("/en/?wovn=fr"));
-		assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
-		assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
-	}
+        assertEquals("fr", sut.getLang("?wovn=fr"));
+        assertEquals("fr", sut.getLang("/?wovn=fr"));
+        assertEquals("fr", sut.getLang("/en/?wovn=fr"));
+        assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
+        assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
+    }
 
     public void testRemoveLang__NonMatchingQuery__DoNotModify() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
-		assertEquals("/", sut.removeLang("/", "ja"));
-		assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
-		assertEquals("/page/?wovn=en", sut.removeLang("/page/?wovn=en", "ja"));
-		assertEquals("ja.site.com/ja/?lang=ja", sut.removeLang("ja.site.com/ja/?lang=ja", "ja"));
+        assertEquals("/", sut.removeLang("/", "ja"));
+        assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
+        assertEquals("/page/?wovn=en", sut.removeLang("/page/?wovn=en", "ja"));
+        assertEquals("ja.site.com/ja/?lang=ja", sut.removeLang("ja.site.com/ja/?lang=ja", "ja"));
     }
 
     public void testRemoveLang__MatchingQuery__RemoveLangCode() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
-		assertEquals("", sut.removeLang("?wovn=ja", "ja"));
-		assertEquals("/?search=pizza&lang=ja", sut.removeLang("/?search=pizza&wovn=ja&lang=ja", "ja"));
-		assertEquals("site.com/page/index.html?wovn&wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja&wovn", "ja"));
-		assertEquals("ja.site.com/ja/", sut.removeLang("ja.site.com/ja/?wovn=ja", "ja"));
+        assertEquals("", sut.removeLang("?wovn=ja", "ja"));
+        assertEquals("/?search=pizza&lang=ja", sut.removeLang("/?search=pizza&wovn=ja&lang=ja", "ja"));
+        assertEquals("site.com/page/index.html?wovn&wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja&wovn", "ja"));
+        assertEquals("ja.site.com/ja/", sut.removeLang("ja.site.com/ja/?wovn=ja", "ja"));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class RequestOptionsTest extends TestCase {
-    public void testDisableModeNoQueryParameter() {
+    public void testDisableModeNoQueryParameter() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn(null);
         EasyMock.replay(request);
@@ -17,7 +17,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(false, sut.getDisableMode());
     }
 
-    public void testDisableModeNonmatchingQueryParameter() {
+    public void testDisableModeNonmatchingQueryParameter() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("pen&pineapple&apple&pen");
         EasyMock.replay(request);
@@ -26,7 +26,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(false, sut.getDisableMode());
     }
 
-    public void testDisableModeMatchingQueryParameter() {
+    public void testDisableModeMatchingQueryParameter() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("pen&wovnDisable&pen");
         EasyMock.replay(request);
@@ -35,7 +35,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(true, sut.getDisableMode());
     }
 
-    public void testNoQueryParameter() {
+    public void testNoQueryParameter() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn(null);
         EasyMock.replay(request);
@@ -45,7 +45,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(false, sut.getDebugMode());
     }
 
-    public void testCacheDisable() {
+    public void testCacheDisable() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("user=Ceb&wovnCacheDisable");
         EasyMock.replay(request);
@@ -55,7 +55,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(false, sut.getDebugMode());
     }
 
-    public void testDebugMode() {
+    public void testDebugMode() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("wovnDebugMode&user=Ceb");
         EasyMock.replay(request);
@@ -65,7 +65,7 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(true, sut.getDebugMode());
     }
 
-    public void testQueryParameteresWithoutDebugModeSettings() {
+    public void testQueryParameteresWithoutDebugModeSettings() throws ConfigurationError {
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(request.getQueryString()).andReturn("wovnDebugMode&wovnDisableCache");
         EasyMock.replay(request);
@@ -75,14 +75,14 @@ public class RequestOptionsTest extends TestCase {
         assertEquals(false, sut.getDebugMode());
     }
 
-    private Settings debugModeSettings() {
+    private Settings debugModeSettings() throws ConfigurationError {
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("debugMode", "true");
         }});
         return settings;
     }
 
-    private Settings defaultSettings() {
+    private Settings defaultSettings() throws ConfigurationError {
         return TestUtil.makeSettings();
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -135,6 +135,23 @@ public class SettingsTest extends TestCase {
         assertEquals(true, exceptionThrown);
     }
 
+    public void testSettings__invalidSupportedLangs() throws ConfigurationError {
+        HashMap<String, String> parametersWithInvalidSupportedLangs = new HashMap<String, String>() {{
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,japan,korean");
+        }};
+        boolean exceptionThrown = false;
+        try {
+            TestUtil.makeSettings(parametersWithInvalidSupportedLangs);
+        } catch (ConfigurationError e) {
+            exceptionThrown = true;
+        }
+        assertEquals(true, exceptionThrown);
+    }
+
     public void testGetBoolParameter() {
         assertTrue(Settings.getBoolParameter("on"));
         assertTrue(Settings.getBoolParameter("true"));

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -58,7 +58,7 @@ public class SettingsTest extends TestCase {
     }
 
     // urlPattern is "path".
-    public void testSettingsWithEmptyConfig() {
+    public void testSettingsWithEmptyConfig() throws ConfigurationError {
         FilterConfig mock = mockEmptyConfig();
         Settings s = new Settings(mock);
 
@@ -77,7 +77,7 @@ public class SettingsTest extends TestCase {
         assertEquals("", s.originalQueryStringHeader);
     }
     // urlPattern is "subdomain".
-    public void testSettingsWithValidConfig() {
+    public void testSettingsWithValidConfig() throws ConfigurationError {
         FilterConfig mock = mockValidConfig();
         Settings s = new Settings(mock);
 
@@ -99,7 +99,7 @@ public class SettingsTest extends TestCase {
         assertEquals("REDIRECT_URL", s.originalUrlHeader);
         assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
     }
-    public void testSettingsWithQueryConfig() {
+    public void testSettingsWithQueryConfig() throws ConfigurationError {
         FilterConfig mock = mockQueryConfig();
         Settings s = new Settings(mock);
 
@@ -107,15 +107,32 @@ public class SettingsTest extends TestCase {
         assertEquals("query", s.urlPattern);
     }
 
-    public void testIsValidWithEmptyConfig() {
+    public void testIsValidWithEmptyConfig() throws ConfigurationError {
         FilterConfig mock = mockEmptyConfig();
         Settings s = new Settings(mock);
         assertFalse(s.isValid());
     }
-    public void testIsValidWithValidConfig() {
+    public void testIsValidWithValidConfig() throws ConfigurationError {
         FilterConfig mock = mockValidConfig();
         Settings s = new Settings(mock);
         assertTrue(s.isValid());
+    }
+
+    public void testSettings__invalidDefaultLang() throws ConfigurationError {
+        HashMap<String, String> parametersWithInvalidDefaultLang = new HashMap<String, String>() {{
+            put("projectToken", "2Wle3");
+            put("secretKey", "secret");
+            put("urlPattern", "query");
+            put("supportedLangs", "en,ja");
+            put("defaultLang", "INVALID");
+        }};
+        boolean exceptionThrown = false;
+        try {
+            TestUtil.makeSettings(parametersWithInvalidDefaultLang);
+        } catch (ConfigurationError e) {
+            exceptionThrown = true;
+        }
+        assertEquals(true, exceptionThrown);
     }
 
     public void testGetBoolParameter() {
@@ -160,7 +177,7 @@ public class SettingsTest extends TestCase {
         assertEquals(13, Settings.getIntParameter("13"));
     }
 
-    public void testSettingsWithValidConfigMultipleToken() {
+    public void testSettingsWithValidConfigMultipleToken() throws ConfigurationError {
         FilterConfig mock = mockValidConfigMultipleToken();
         Settings s = new Settings(mock);
 
@@ -183,13 +200,13 @@ public class SettingsTest extends TestCase {
         assertEquals("REDIRECT_QUERY_STRING", s.originalQueryStringHeader);
     }
 
-    public void testSettingsWithoutSitePrefix() {
+    public void testSettingsWithoutSitePrefix() throws ConfigurationError {
         Settings s = TestUtil.makeSettings();
         assertFalse(s.hasSitePrefixPath);
         assertEquals("", s.sitePrefixPath);
     }
 
-    public void testSettingsWithSitePrefix() {
+    public void testSettingsWithSitePrefix() throws ConfigurationError {
         HashMap<String, String> option = new HashMap<String, String>();
         option.put("sitePrefixPath", "/global/");
         Settings s = TestUtil.makeSettings(option);

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -12,6 +12,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("site.com/page/index.html"));
         assertEquals("", sut.getLang("site.com/en/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?language=en&wovn=fr"));
+        assertEquals("", sut.getLang("deutsch.site.com/page"));
     }
 
     public void testGetLang__MatchingSubdomain__ReturnLangCode() {
@@ -19,8 +20,6 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
 		assertEquals("en", sut.getLang("en.site.com"));
 		assertEquals("es", sut.getLang("es.site.com/"));
 		assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
-        /* incorrect behavior below */
-		assertEquals("de", sut.getLang("deutsch.site.com/page"));
 	}
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -17,24 +17,24 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testGetLang__MatchingSubdomain__ReturnLangCode() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
-		assertEquals("en", sut.getLang("en.site.com"));
-		assertEquals("es", sut.getLang("es.site.com/"));
-		assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
-	}
+        assertEquals("en", sut.getLang("en.site.com"));
+        assertEquals("es", sut.getLang("es.site.com/"));
+        assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
+    }
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
-		assertEquals("/", sut.removeLang("/", "en"));
+        assertEquals("/", sut.removeLang("/", "en"));
         assertEquals("site.com", sut.removeLang("site.com", "en"));
-		assertEquals("ja.site.com", sut.removeLang("ja.site.com", "fr"));
-		assertEquals("ja.fr.site.com", sut.removeLang("ja.fr.site.com", "fr"));
-		assertEquals("site.com/fr/index.html?wovn=fr", sut.removeLang("site.com/fr/index.html?wovn=fr", "fr"));
+        assertEquals("ja.site.com", sut.removeLang("ja.site.com", "fr"));
+        assertEquals("ja.fr.site.com", sut.removeLang("ja.fr.site.com", "fr"));
+        assertEquals("site.com/fr/index.html?wovn=fr", sut.removeLang("site.com/fr/index.html?wovn=fr", "fr"));
     }
 
     public void testRemoveLang__MatchingSubdomain__RemoveLangCode() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
-		assertEquals("site.com", sut.removeLang("en.site.com", "en"));
-		assertEquals("site.com/", sut.removeLang("es.site.com/", "es"));
-		assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.removeLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr"));
-	}
+        assertEquals("site.com", sut.removeLang("en.site.com", "en"));
+        assertEquals("site.com/", sut.removeLang("es.site.com/", "es"));
+        assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.removeLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr"));
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -32,11 +32,11 @@ public class TestUtil {
         return mock;
     }
 
-    public static Settings makeSettings() {
+    public static Settings makeSettings() throws ConfigurationError {
         return makeSettings(emptyOption);
     }
 
-    public static Settings makeSettings(HashMap<String, String> option) {
+    public static Settings makeSettings(HashMap<String, String> option) throws ConfigurationError {
         return new Settings(makeConfig(option));
     }
 


### PR DESCRIPTION
Change to allow Lang lookup only by language code. This fixes some incorrect behaviors in URL handling. `Lang.java` is greatly simplified in the process.

Note that in the Lang initialization, information for the names of languages is kept in the file, but it is no longer being used by the library.

### Changes
* Lang object lookup only uses language code now
    - This affects URL matches and settings configuration
* Raise ConfigurationError if the setting for defaultLang or supportedLangs is invalid
    - This is added now because a configuration like `defaultLang=English` becomes invalid
* Access ISO639-1 language code for hreflang using a Lang field instead of conversion function
* (Whitespace changes) retab test files for UrlLanguagePatternHandlers