### PR TITLE
Fix and improve tests for removeLang

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -1,16 +1,23 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     static final String PATH_GET_LANG_PATTERN_REGEX = "/([^/.?]+)";
 
     private String sitePrefixPath;
     private Pattern getLangPattern;
+    private Pattern removeLangPattern;
 
     PathUrlLanguagePatternHandler(String sitePrefixPath) {
+        // placeholder supportedLangs
+        ArrayList<String> supportedLangs = new ArrayList<String>();
+        supportedLangs.add("en");
+
         this.sitePrefixPath = sitePrefixPath;
         this.getLangPattern = Pattern.compile(sitePrefixPath + PATH_GET_LANG_PATTERN_REGEX);
+        this.removeLangPattern = this.buildRemoveLangPattern(supportedLangs, sitePrefixPath);
     }
 
     String getLang(String url) {
@@ -18,11 +25,22 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     }
 
     String removeLang(String url, String lang) {
-        String prefix = this.sitePrefixPath + "/";
-        return url.replaceFirst(prefix + lang + "(/|$)", prefix);
+        Matcher matcher = this.removeLangPattern.matcher(url);
+        return matcher.replaceFirst("$1$2$3");
     }
 
     String insertLang(String url, String lang) {
         return "site.com/en/path";
+    }
+
+    private Pattern buildRemoveLangPattern(ArrayList<String> supportedLangs, String sitePrefixPath) {
+        Pattern p = Pattern.compile(
+                "^(.*://)?" + /* optional schema */
+                "([^/]*)?" + /* optional host */
+                "(" + sitePrefixPath + "/)" + /* sitePrefixPath */
+                "(" + String.join("|", supportedLangs) + ")" + /* lang code */
+                "(/|$)"
+        );
+        return p;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -8,16 +8,10 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
 
     private String sitePrefixPath;
     private Pattern getLangPattern;
-    private Pattern removeLangPattern;
 
     PathUrlLanguagePatternHandler(String sitePrefixPath) {
-        // placeholder supportedLangs
-        ArrayList<String> supportedLangs = new ArrayList<String>();
-        supportedLangs.add("en");
-
         this.sitePrefixPath = sitePrefixPath;
         this.getLangPattern = Pattern.compile(sitePrefixPath + PATH_GET_LANG_PATTERN_REGEX);
-        this.removeLangPattern = this.buildRemoveLangPattern(supportedLangs, sitePrefixPath);
     }
 
     String getLang(String url) {
@@ -25,7 +19,8 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     }
 
     String removeLang(String url, String lang) {
-        Matcher matcher = this.removeLangPattern.matcher(url);
+        Pattern removeLangPattern = buildRemoveLangPattern(lang);
+        Matcher matcher = removeLangPattern.matcher(url);
         return matcher.replaceFirst("$1$2$3");
     }
 
@@ -33,12 +28,12 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return "site.com/en/path";
     }
 
-    private Pattern buildRemoveLangPattern(ArrayList<String> supportedLangs, String sitePrefixPath) {
+    private Pattern buildRemoveLangPattern(String lang) {
         Pattern p = Pattern.compile(
                 "^(.*://)?" + /* optional schema */
                 "([^/]*)?" + /* optional host */
-                "(" + sitePrefixPath + "/)" + /* sitePrefixPath */
-                "(" + String.join("|", supportedLangs) + ")" + /* lang code */
+                "(" + this.sitePrefixPath + "/)" + /* sitePrefixPath */
+                "(" + lang + ")" + /* lang code */
                 "(/|$)"
         );
         return p;

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -54,6 +54,10 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("site.com", sut.removeLang("site.com", "ja"));
         assertEquals("site.com/en/page/", sut.removeLang("site.com/en/page/", "ja"));
         assertEquals("site.com/english/page/", sut.removeLang("site.com/english/page/", "en"));
+        assertEquals("site.com/en/ja/page/", sut.removeLang("site.com/en/ja/page/", "ja"));
+        assertEquals("/global/page/ja/index.html", sut.removeLang("/global/page/ja/index.html", "ja"));
+        assertEquals("http://www.site.com/global/ja", sut.removeLang("http://www.site.com/global/ja", "ja"));
+        assertEquals("https://test.com/en/path/", sut.removeLang("https://test.com/en/path/", "ja"));
     }
 
     public void testRemoveLang__MatchingLang__RemoveLangCode() {
@@ -66,9 +70,8 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("/page/index.html", sut.removeLang("/en/page/index.html", "en"));
         assertEquals("site.com/en/page/", sut.removeLang("site.com/ja/en/page/", "ja"));
         assertEquals("site.com/ja/page/", sut.removeLang("site.com/ja/ja/page/", "ja"));
-        /* incorrect behavior below */
-        assertEquals("site.com/en/page/", sut.removeLang("site.com/en/ja/page/", "ja"));
-        assertEquals("/global/page/index.html", sut.removeLang("/global/page/ja/index.html", "ja"));
+        assertEquals("http://www.site.com/", sut.removeLang("http://www.site.com/ja", "ja"));
+        assertEquals("https://test.com/path/index.html", sut.removeLang("https://test.com/en/path/index.html", "en"));
     }
 
     public void testRemoveLang__SitePrefixPath__NonMatchingPath__DoNotModify() {
@@ -82,6 +85,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("site.com/prefix/no", sut.removeLang("site.com/prefix/no", "no"));
         assertEquals("/pre/fix/page/en/index.html", sut.removeLang("/pre/fix/page/en/index.html", "en"));
         assertEquals("/pre/fix/ja/page/index.html", sut.removeLang("/pre/fix/ja/page/index.html", "en"));
+        assertEquals("http://www.site.com/ja", sut.removeLang("http://www.site.com/ja", "ja"));
     }
 
     public void testRemoveLang__SitePrefixPath__MatchingSupportedLang__RemoveLangCode() {
@@ -89,6 +93,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("/pre/fix/", sut.removeLang("/pre/fix/ja", "ja"));
         assertEquals("http://site.com/pre/fix/", sut.removeLang("http://site.com/pre/fix/en/", "en"));
         assertEquals("site.com/pre/fix/page/index.html", sut.removeLang("site.com/pre/fix/no/page/index.html", "no"));
+        assertEquals("http://www.site.com/pre/fix/", sut.removeLang("http://www.site.com/pre/fix/ja", "ja"));
     }
 
     private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -30,13 +30,14 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
         assertEquals("/page/?wovn=en", sut.removeLang("/page/?wovn=en", "ja"));
         assertEquals("ja.site.com/ja/?lang=ja", sut.removeLang("ja.site.com/ja/?lang=ja", "ja"));
+        assertEquals("http://site.com/page/?wovn=japan", sut.removeLang("http://site.com/page/?wovn=japan", "ja"));
     }
 
     public void testRemoveLang__MatchingQuery__RemoveLangCode() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
         assertEquals("", sut.removeLang("?wovn=ja", "ja"));
         assertEquals("/?search=pizza&lang=ja", sut.removeLang("/?search=pizza&wovn=ja&lang=ja", "ja"));
-        assertEquals("site.com/page/index.html?wovn&wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja&wovn", "ja"));
-        assertEquals("ja.site.com/ja/", sut.removeLang("ja.site.com/ja/?wovn=ja", "ja"));
+        assertEquals("site.com/page/index.html?wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja", "ja"));
+        assertEquals("https://ja.site.com/ja/", sut.removeLang("https://ja.site.com/ja/?wovn=ja", "ja"));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -28,6 +28,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
         assertEquals("/", sut.removeLang("/", "ja"));
         assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
+        assertEquals("?wovn=en", sut.removeLang("?wovn=en", "ja"));
         assertEquals("/page/?wovn=en", sut.removeLang("/page/?wovn=en", "ja"));
         assertEquals("ja.site.com/ja/?lang=ja", sut.removeLang("ja.site.com/ja/?lang=ja", "ja"));
         assertEquals("http://site.com/page/?wovn=japan", sut.removeLang("http://site.com/page/?wovn=japan", "ja"));

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -25,9 +25,11 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
         assertEquals("/", sut.removeLang("/", "en"));
+        assertEquals("/en/path/index.php", sut.removeLang("/en/path/index.php", "en"));
+        assertEquals("?lang=english", sut.removeLang("?lang=english", "en"));
         assertEquals("site.com", sut.removeLang("site.com", "en"));
         assertEquals("ja.site.com", sut.removeLang("ja.site.com", "fr"));
-        assertEquals("ja.fr.site.com", sut.removeLang("ja.fr.site.com", "fr"));
+        assertEquals("https://ja.fr.site.com", sut.removeLang("https://ja.fr.site.com", "fr"));
         assertEquals("site.com/fr/index.html?wovn=fr", sut.removeLang("site.com/fr/index.html?wovn=fr", "fr"));
     }
 
@@ -35,6 +37,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
         assertEquals("site.com", sut.removeLang("en.site.com", "en"));
         assertEquals("site.com/", sut.removeLang("es.site.com/", "es"));
+        assertEquals("http://site.com/", sut.removeLang("http://es.site.com/", "es"));
         assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.removeLang("fr.site.com/fr/index.html?lang=fr&wovn=fr", "fr"));
     }
 }


### PR DESCRIPTION
Fix bugs with `removeLang` for when `urlPattern=path`, and improve test cases for all removeLang variations.

### Changes
* Fix PathUrlLanguagePatternHandler to only match path lang code at the beginning of the path
* Add test cases for when the input URL includes schema (this was also broken for urlPattern path)
    - now we should be able to pass a URL of any form into `removeLang` and see expected behavior