### PR TITLE
Fix and improve tests for getLang

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -4,14 +4,12 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
-    static final String PATH_GET_LANG_PATTERN_REGEX = "/([^/.?]+)";
-
     private String sitePrefixPath;
     private Pattern getLangPattern;
 
     PathUrlLanguagePatternHandler(String sitePrefixPath) {
         this.sitePrefixPath = sitePrefixPath;
-        this.getLangPattern = Pattern.compile(sitePrefixPath + PATH_GET_LANG_PATTERN_REGEX);
+        this.getLangPattern = this.buildGetLangPattern(sitePrefixPath);
     }
 
     String getLang(String url) {
@@ -26,6 +24,16 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
 
     String insertLang(String url, String lang) {
         return "site.com/en/path";
+    }
+
+    private Pattern buildGetLangPattern(String sitePrefixPath) {
+        Pattern p = Pattern.compile(
+                "^(?:.*://)?" + /* schema, optional non-capturing group */
+                "(?:[^/]*)?" + /* host, optional non-capturing group */
+                "(?:" + sitePrefixPath + "/)" + /* sitePrefixPath, non-capturing group */
+                "([^/.?]+)" /* capture next path section */
+        );
+        return p;
     }
 
     private Pattern buildRemoveLangPattern(String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -3,12 +3,10 @@ package com.github.wovnio.wovnjava;
 import java.util.regex.Pattern;
 
 class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
-    static final String QUERY_GET_LANG_PATTERN_REGEX = "(?:(?:\\?.*&)|\\?)wovn=([^&]+)(?:&|$)";
-
     private Pattern getLangPattern;
 
     QueryUrlLanguagePatternHandler() {
-        this.getLangPattern = Pattern.compile(QUERY_GET_LANG_PATTERN_REGEX);
+        this.getLangPattern = this.buildGetLangPattern();
     }
 
     String getLang(String url) {
@@ -22,5 +20,14 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
 
     String insertLang(String url, String lang) {
         return "site.com/path?wovn=en";
+    }
+
+    private Pattern buildGetLangPattern() {
+        Pattern p = Pattern.compile(
+                "(?:(?:\\?.*&)|\\?)" + /* `?` or `?.*&`, non-capturing group */
+                "wovn=" + /* wovn language parameter */
+                "([^&]+)" /* match until `&` or end-of-string */
+        );
+        return p;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -3,12 +3,10 @@ package com.github.wovnio.wovnjava;
 import java.util.regex.Pattern;
 
 class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
-    static final String SUBDOMAIN_GET_LANG_PATTERN_REGEX = "^([^.]+)\\.";
-
     private Pattern getLangPattern;
 
     SubdomainUrlLanguagePatternHandler() {
-        this.getLangPattern = Pattern.compile(SUBDOMAIN_GET_LANG_PATTERN_REGEX);
+        this.getLangPattern = this.buildGetLangPattern();
     }
 
     String getLang(String url) {
@@ -22,6 +20,14 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
 
     String insertLang(String url, String lang) {
         return "en.site.com/path";
+    }
+
+    private Pattern buildGetLangPattern() {
+        Pattern p = Pattern.compile(
+                "^(?:.*://)?" + /* schema, optional non-capturing group */
+                "([^.]+)\\." /* capture first subdomain, before first `.` */
+        );
+        return p;
     }
 }
 

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -12,15 +12,17 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?wovn=en"));
         assertEquals("", sut.getLang("site.com/French/"));
-        assertEquals("", sut.getLang("site.com/Suomi/page/index.html"));
+        assertEquals("", sut.getLang("http://site.com/Suomi/page/index.html"));
     }
 
     public void testGetLang__MatchingPath__ReturnLangCode() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
         assertEquals("fr", sut.getLang("/fr"));
         assertEquals("fr", sut.getLang("/fr/"));
-        assertEquals("fr", sut.getLang("/fr/page"));
-        assertEquals("fr", sut.getLang("site.com/fr/page/index.html"));
+        assertEquals("fr", sut.getLang("/fr?wovn=en"));
+        assertEquals("fr", sut.getLang("/fr/?wovn=en"));
+        assertEquals("fr", sut.getLang("http://site.com/fr/page"));
+        assertEquals("fr", sut.getLang("https://site.com/fr/page/index.html"));
         assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
     }
 
@@ -33,6 +35,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
         assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
         assertEquals("", sut.getLang("/pre/fix/french/page/index.html"));
+        assertEquals("", sut.getLang("https://en.site.com/en/page/"));
     }
 
     public void testGetLang__SitePrefixPath__MatchingPath__ReturnLangCode() {
@@ -42,6 +45,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
         assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
         assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
+        assertEquals("fr", sut.getLang("https://en.site.com/pre/fix/fr/page/"));
     }
 
     public void testRemoveLang__NonMatchingPath__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -13,6 +13,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?language=en"));
         assertEquals("", sut.getLang("/en/?wovn=Nederlands"));
+        assertEquals("", sut.getLang("http://site.com?wovn="));
     }
 
     public void testGetLang__MatchingQuery__ReturnLangCode() {
@@ -21,6 +22,9 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("fr", sut.getLang("/?wovn=fr"));
         assertEquals("fr", sut.getLang("/en/?wovn=fr"));
         assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
+        assertEquals("fr", sut.getLang("site.com?wovn=fr"));
+        assertEquals("fr", sut.getLang("site.com/?lang=en&wovn=fr"));
+        assertEquals("fr", sut.getLang("http://site.com/?wovn=fr"));
         assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -13,6 +13,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("", sut.getLang("site.com/en/pre/fix/index.html"));
         assertEquals("", sut.getLang("/page?language=en&wovn=fr"));
         assertEquals("", sut.getLang("deutsch.site.com/page"));
+        assertEquals("", sut.getLang("http://site.com"));
     }
 
     public void testGetLang__MatchingSubdomain__ReturnLangCode() {
@@ -20,6 +21,8 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("en", sut.getLang("en.site.com"));
         assertEquals("es", sut.getLang("es.site.com/"));
         assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
+        assertEquals("en", sut.getLang("http://en.site.com/"));
+        assertEquals("en", sut.getLang("https://en.site.com?wovn=fr"));
     }
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {


### PR DESCRIPTION
We want `getLang(url)` to find the language code of URLs of any form.

Specifically, these changes make sure that URLs with schema, of the form `http://site.com/path?query`, are matched correctly by all UrlLanguagePatternHandlers. Test cases are added to that effect.

Lastly, the regexes supporting getLang are all given comments explaining what they do.