### PR TITLE
Compute client request URL

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -21,16 +21,14 @@ class Headers {
     private HttpServletRequest request;
     private String requestLang;
     private UrlLanguagePatternHandler urlLanguagePatternHandler;
-    private String clientRequestUrl;
 
     Headers(HttpServletRequest r, Settings s, UrlLanguagePatternHandler urlLanguagePatternHandler) {
         this.settings = s;
         this.request = r;
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
-        this.requestLang = this.computeRequestLang();
-
-        this.clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s);
+        String clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s);
+        this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
 
         this.protocol = this.request.getScheme();
 
@@ -264,18 +262,5 @@ class Headers {
 
     boolean isValidPath() {
         return this.pathName.startsWith(this.settings.sitePrefixPath);
-    }
-
-    private String computeRequestLang() {
-        String path;
-        if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
-            path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();
-        } else {
-            path = this.request.getServerName() + this.request.getRequestURI();
-        }
-        if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
-            path += "?" + this.request.getQueryString();
-        }
-        return this.urlLanguagePatternHandler.getLang(path);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -30,7 +30,7 @@ class Headers {
 
         this.requestLang = this.computeRequestLang();
 
-        this.clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s.useProxy, s.originalUrlHeader, s.originalQueryStringHeader);
+        this.clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s);
 
         this.protocol = this.request.getScheme();
 

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -21,6 +21,7 @@ class Headers {
     private HttpServletRequest request;
     private String requestLang;
     private UrlLanguagePatternHandler urlLanguagePatternHandler;
+    private String clientRequestUrl;
 
     Headers(HttpServletRequest r, Settings s, UrlLanguagePatternHandler urlLanguagePatternHandler) {
         this.settings = s;
@@ -28,6 +29,8 @@ class Headers {
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
         this.requestLang = this.computeRequestLang();
+
+        this.clientRequestUrl = UrlResolver.calculateClientRequestUrl(r, s.useProxy, s.originalUrlHeader, s.originalQueryStringHeader);
 
         this.protocol = this.request.getScheme();
 

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -30,7 +30,7 @@ class Headers {
 
         this.requestLang = this.computeRequestLang();
 
-        this.clientRequestUrl = UrlResolver.calculateClientRequestUrl(r, s.useProxy, s.originalUrlHeader, s.originalQueryStringHeader);
+        this.clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s.useProxy, s.originalUrlHeader, s.originalQueryStringHeader);
 
         this.protocol = this.request.getScheme();
 

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -22,12 +22,12 @@ class Headers {
     private String requestLang;
     private UrlLanguagePatternHandler urlLanguagePatternHandler;
 
-    Headers(HttpServletRequest r, Settings s, UrlLanguagePatternHandler urlLanguagePatternHandler) {
-        this.settings = s;
-        this.request = r;
+    Headers(HttpServletRequest request, Settings settings, UrlLanguagePatternHandler urlLanguagePatternHandler) {
+        this.settings = settings;
+        this.request = request;
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
-        String clientRequestUrl = UrlResolver.computeClientRequestUrl(r, s);
+        String clientRequestUrl = UrlResolver.computeClientRequestUrl(request, settings);
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
 
         this.protocol = this.request.getScheme();
@@ -49,7 +49,7 @@ class Headers {
         }
         // Both getRequestURI() and getPathInfo() do not have query parameters.
         if (this.settings.originalQueryStringHeader.isEmpty()) {
-            if (r.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
+            if (request.getQueryString() != null && !this.request.getQueryString().isEmpty()) {
                 requestUri += "?" + this.request.getQueryString();
             }
         } else {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -5,18 +5,7 @@ import javax.servlet.http.HttpServletRequest;
 final class UrlResolver {
     private UrlResolver() {}
 
-    static String calculateCurrentRequestPath(HttpServletRequest request) {
-        if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
-            path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();
-        } else {
-            path = this.request.getServerName() + this.request.getRequestURI();
-        }
-        if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
-            path += "?" + this.request.getQueryString();
-        }
-    }
-
-    static String calculateClientRequestUrl(
+    static String computeClientRequestUrl(
             HttpServletRequest request,
             boolean useProxy,
             String originalUrlHeaderSetting,
@@ -29,7 +18,7 @@ final class UrlResolver {
         return scheme + "://" + host + path + query;
     }
 
-    private static String clientRequestedHostAndPort(HttpServletRequest request, boolean useProxy) {
+    private static String clientRequestHostAndPort(HttpServletRequest request, boolean useProxy) {
         String host;
         if (useProxy && request.getHeader("X-Forwarded-Host") != null) {
             host = request.getHeader("X-Forwarded-Host");
@@ -53,7 +42,7 @@ final class UrlResolver {
         }
     }
 
-    private static String clientRequestedPath(HttpServletRequest request, String originalUrlHeaderSetting) {
+    private static String clientRequestPath(HttpServletRequest request, String originalUrlHeaderSetting) {
         String path = null;
         if (!originalUrlHeaderSetting.isEmpty()) {
             path = request.getHeader(originalUrlHeaderSetting);
@@ -67,15 +56,15 @@ final class UrlResolver {
         return path;
     }
 
-    private static String clientRequestedQuery(HttpServletRequest request, String originalQueryStringHeaderSetting) {
+    private static String clientRequestQuery(HttpServletRequest request, String originalQueryStringHeaderSetting) {
         String query;
-        if (originalQueryStringHeaderSetting.isEmpty()) {
+        if (!originalQueryStringHeaderSetting.isEmpty()) {
+            query = request.getHeader(originalQueryStringHeaderSetting);
+        } else {
             query = request.getAttribute("javax.servlet.forward.query_string");
             if (query == null || query.isEmpty()) {
                 query = request.getQueryString();
             }
-        } else {
-            query = request.getHeader(originalQueryStringHeaderSetting);
         }
 
         if (query == null || query.isEmpty()) {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -5,36 +5,40 @@ import javax.servlet.http.HttpServletRequest;
 final class UrlResolver {
     private UrlResolver() {}
 
-    static String computeClientRequestUrl(
-            HttpServletRequest request,
-            boolean useProxy,
-            String originalUrlHeaderSetting,
-            String originalQueryStringHeaderSetting)
-    {
+    static String computeClientRequestUrl(HttpServletRequest request, Settings settings) {
         String scheme = request.getScheme();
-        String host = clientRequestHostAndPort(request, useProxy);
-        String path = clientRequestPath(request, originalUrlHeaderSetting);
-        String query = clientRequestQuery(request, originalQueryStringHeaderSetting);
+        String host = clientRequestHostAndPort(request, settings.useProxy);
+        String path = clientRequestPath(request, settings.originalUrlHeader);
+        String query = clientRequestQuery(request, settings.originalQueryStringHeader);
         return scheme + "://" + host + path + query;
     }
 
     private static String clientRequestHostAndPort(HttpServletRequest request, boolean useProxy) {
         String host;
-        if (useProxy && request.getHeader("X-Forwarded-Host") != null) {
-            host = request.getHeader("X-Forwarded-Host");
-        } else {
-            host = request.getServerName();
-        }
         int port;
         if (useProxy) {
-            if (request.getHeader("X-Forwarded-Port") == null || request.getHeader("X-Forwarded-Port").isEmpty()) {
+            /* request.getHeader returns String or null */
+            String forwardedHost = request.getHeader("X-Forwarded-Host");
+            if (forwardedHost != null) {
+                host = forwardedHost;
+            } else {
+                /* X-Fowarded-Host is required for `useProxy`. Set empty string to avoid crashing. */
+                host = "";
+            }
+            /* request.getHeader returns String or null */
+            String forwardedPort = request.getHeader("X-Forwarded-Port");
+            if (forwardedPort == null || forwardedPort.isEmpty()) {
                 port = 80;
             } else {
-                port = Integer.parseInt(request.getHeader("X-Forwarded-Port"));
+                port = Integer.parseInt(forwardedPort);
             }
         } else {
+            /* request.getServerName returns String */
+            host = request.getServerName();
+            /* request.getServerPort returns int */
             port = request.getServerPort();
         }
+
         if (port != 80 && port != 443) {
             return host + ":" + port;
         } else {
@@ -43,17 +47,24 @@ final class UrlResolver {
     }
 
     private static String clientRequestPath(HttpServletRequest request, String originalUrlHeaderSetting) {
-        String path = null;
+        String path;
         if (!originalUrlHeaderSetting.isEmpty()) {
+            /* request.getHeader returns String or null */
             path = request.getHeader(originalUrlHeaderSetting);
+        } else {
+            /* request.getAttribute returns Object */
+            path = (String) request.getAttribute("javax.servlet.forward.request_uri").toString();
+            if (path == null || path.isEmpty()) {
+                /* request.getRequestURI returns String */
+                path = request.getRequestURI();
+            }
         }
-        if (path == null || path.isEmpty()) {
-            path = (String) request.getAttribute("javax.servlet.forward.request_uri");
+
+        if (path == null) {
+            return "";
+        } else {
+            return path;
         }
-        if (path == null || path.isEmpty()) {
-            path = request.getRequestURI();
-        }
-        return path;
     }
 
     private static String clientRequestQuery(HttpServletRequest request, String originalQueryStringHeaderSetting) {
@@ -61,8 +72,10 @@ final class UrlResolver {
         if (!originalQueryStringHeaderSetting.isEmpty()) {
             query = request.getHeader(originalQueryStringHeaderSetting);
         } else {
-            query = request.getAttribute("javax.servlet.forward.query_string");
+            /* request.getAttribute returns Object */
+            query = request.getAttribute("javax.servlet.forward.query_string").toString();
             if (query == null || query.isEmpty()) {
+                /* request.getQueryString returns String or null */
                 query = request.getQueryString();
             }
         }

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -1,0 +1,87 @@
+package com.github.wovnio.wovnjava;
+
+import javax.servlet.http.HttpServletRequest;
+
+final class UrlResolver {
+    private UrlResolver() {}
+
+    static String calculateCurrentRequestPath(HttpServletRequest request) {
+        if (this.settings.useProxy && this.request.getHeader("X-Forwarded-Host") != null) {
+            path = this.request.getHeader("X-Forwarded-Host") + this.request.getRequestURI();
+        } else {
+            path = this.request.getServerName() + this.request.getRequestURI();
+        }
+        if (this.request.getQueryString() != null && this.request.getQueryString().length() > 0) {
+            path += "?" + this.request.getQueryString();
+        }
+    }
+
+    static String calculateClientRequestUrl(
+            HttpServletRequest request,
+            boolean useProxy,
+            String originalUrlHeaderSetting,
+            String originalQueryStringHeaderSetting)
+    {
+        String scheme = request.getScheme();
+        String host = clientRequestHostAndPort(request, useProxy);
+        String path = clientRequestPath(request, originalUrlHeaderSetting);
+        String query = clientRequestQuery(request, originalQueryStringHeaderSetting);
+        return scheme + "://" + host + path + query;
+    }
+
+    private static String clientRequestedHostAndPort(HttpServletRequest request, boolean useProxy) {
+        String host;
+        if (useProxy && request.getHeader("X-Forwarded-Host") != null) {
+            host = request.getHeader("X-Forwarded-Host");
+        } else {
+            host = request.getServerName();
+        }
+        int port;
+        if (useProxy) {
+            if (request.getHeader("X-Forwarded-Port") == null || request.getHeader("X-Forwarded-Port").isEmpty()) {
+                port = 80;
+            } else {
+                port = Integer.parseInt(request.getHeader("X-Forwarded-Port"));
+            }
+        } else {
+            port = request.getServerPort();
+        }
+        if (port != 80 && port != 443) {
+            return host + ":" + port;
+        } else {
+            return host;
+        }
+    }
+
+    private static String clientRequestedPath(HttpServletRequest request, String originalUrlHeaderSetting) {
+        String path = null;
+        if (!originalUrlHeaderSetting.isEmpty()) {
+            path = request.getHeader(originalUrlHeaderSetting);
+        }
+        if (path == null || path.isEmpty()) {
+            path = (String) request.getAttribute("javax.servlet.forward.request_uri");
+        }
+        if (path == null || path.isEmpty()) {
+            path = request.getRequestURI();
+        }
+        return path;
+    }
+
+    private static String clientRequestedQuery(HttpServletRequest request, String originalQueryStringHeaderSetting) {
+        String query;
+        if (originalQueryStringHeaderSetting.isEmpty()) {
+            query = request.getAttribute("javax.servlet.forward.query_string");
+            if (query == null || query.isEmpty()) {
+                query = request.getQueryString();
+            }
+        } else {
+            query = request.getHeader(originalQueryStringHeaderSetting);
+        }
+
+        if (query == null || query.isEmpty()) {
+            return "";
+        } else {
+            return "?" + query;
+        }
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -14,27 +14,22 @@ final class UrlResolver {
     }
 
     private static String clientRequestHostAndPort(HttpServletRequest request, boolean useProxy) {
-        String host;
-        int port;
+        String host = null;
+        Integer port = null;
         if (useProxy) {
             /* request.getHeader returns String or null */
-            String forwardedHost = request.getHeader("X-Forwarded-Host");
-            if (forwardedHost != null) {
-                host = forwardedHost;
-            } else {
-                /* X-Fowarded-Host is required for `useProxy`. Set empty string to avoid crashing. */
-                host = "";
-            }
+            host = request.getHeader("X-Forwarded-Host");
             /* request.getHeader returns String or null */
             String forwardedPort = request.getHeader("X-Forwarded-Port");
-            if (forwardedPort == null || forwardedPort.isEmpty()) {
-                port = 80;
-            } else {
+            if (forwardedPort != null && !forwardedPort.isEmpty()) {
                 port = Integer.parseInt(forwardedPort);
             }
-        } else {
+        }
+        if (host == null) {
             /* request.getServerName returns String */
             host = request.getServerName();
+        }
+        if (port == null) {
             /* request.getServerPort returns int */
             port = request.getServerPort();
         }
@@ -47,17 +42,21 @@ final class UrlResolver {
     }
 
     private static String clientRequestPath(HttpServletRequest request, String originalUrlHeaderSetting) {
-        String path;
+        String path = null;
         if (!originalUrlHeaderSetting.isEmpty()) {
             /* request.getHeader returns String or null */
             path = request.getHeader(originalUrlHeaderSetting);
-        } else {
-            /* request.getAttribute returns Object */
-            path = (String) request.getAttribute("javax.servlet.forward.request_uri").toString();
-            if (path == null || path.isEmpty()) {
-                /* request.getRequestURI returns String */
-                path = request.getRequestURI();
+        }
+        if (path == null) {
+            /* request.getAttribute returns Object or null */
+            Object forwardedPath = request.getAttribute("javax.servlet.forward.request_uri");
+            if (forwardedPath != null) {
+                path = forwardedPath.toString();
             }
+        }
+        if (path == null) {
+            /* request.getRequestURI returns String */
+            path = request.getRequestURI();
         }
 
         if (path == null) {
@@ -68,16 +67,20 @@ final class UrlResolver {
     }
 
     private static String clientRequestQuery(HttpServletRequest request, String originalQueryStringHeaderSetting) {
-        String query;
+        String query = null;
         if (!originalQueryStringHeaderSetting.isEmpty()) {
             query = request.getHeader(originalQueryStringHeaderSetting);
-        } else {
-            /* request.getAttribute returns Object */
-            query = request.getAttribute("javax.servlet.forward.query_string").toString();
-            if (query == null || query.isEmpty()) {
-                /* request.getQueryString returns String or null */
-                query = request.getQueryString();
+        }
+        if (query == null) {
+            /* request.getAttribute returns Object or null */
+            Object forwardedQuery = request.getAttribute("javax.servlet.forward.query_string");
+            if (forwardedQuery != null) {
+                query = forwardedQuery.toString();
             }
+        }
+        if (query == null) {
+            /* request.getQueryString returns String or null */
+            query = request.getQueryString();
         }
 
         if (query == null || query.isEmpty()) {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -17,20 +17,20 @@ final class UrlResolver {
         String host = null;
         Integer port = null;
         if (useProxy) {
-            /* request.getHeader returns String or null */
+            // request.getHeader returns String or null
             host = request.getHeader("X-Forwarded-Host");
-            /* request.getHeader returns String or null */
+            // request.getHeader returns String or null
             String forwardedPort = request.getHeader("X-Forwarded-Port");
             if (forwardedPort != null && !forwardedPort.isEmpty()) {
                 port = Integer.parseInt(forwardedPort);
             }
         }
         if (host == null) {
-            /* request.getServerName returns String */
+            // request.getServerName returns String
             host = request.getServerName();
         }
         if (port == null) {
-            /* request.getServerPort returns int */
+            // request.getServerPort returns int
             port = request.getServerPort();
         }
 
@@ -44,18 +44,18 @@ final class UrlResolver {
     private static String clientRequestPath(HttpServletRequest request, String originalUrlHeaderSetting) {
         String path = null;
         if (!originalUrlHeaderSetting.isEmpty()) {
-            /* request.getHeader returns String or null */
+            // request.getHeader returns String or null
             path = request.getHeader(originalUrlHeaderSetting);
         }
         if (path == null) {
-            /* request.getAttribute returns Object or null */
+            // request.getAttribute returns Object or null
             Object forwardedPath = request.getAttribute("javax.servlet.forward.request_uri");
             if (forwardedPath != null) {
                 path = forwardedPath.toString();
             }
         }
         if (path == null) {
-            /* request.getRequestURI returns String */
+            // request.getRequestURI returns String
             path = request.getRequestURI();
         }
 
@@ -72,14 +72,14 @@ final class UrlResolver {
             query = request.getHeader(originalQueryStringHeaderSetting);
         }
         if (query == null) {
-            /* request.getAttribute returns Object or null */
+            // request.getAttribute returns Object or null
             Object forwardedQuery = request.getAttribute("javax.servlet.forward.query_string");
             if (forwardedQuery != null) {
                 query = forwardedQuery.toString();
             }
         }
         if (query == null) {
-            /* request.getQueryString returns String or null */
+            // request.getQueryString returns String or null
             query = request.getQueryString();
         }
 

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -85,8 +85,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;
@@ -99,8 +99,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("ja.example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;
@@ -113,8 +113,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("wovn=ja").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;
@@ -128,8 +128,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("def=456&wovn=ja&abc=123").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;
@@ -143,8 +143,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(8080).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;
@@ -160,8 +160,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_URL")).andReturn("/foo/bar").atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_QUERY_STRING")).andReturn("baz=123").atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -79,36 +79,42 @@ public class HeadersTest extends TestCase {
     }
     private static HttpServletRequest mockRequestPath(String path, String host) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn(host);
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;
     }
     private static HttpServletRequest mockRequestSubdomain() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("ja.example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("ja.example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;
     }
     private static HttpServletRequest mockRequestQuery() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("wovn=ja").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -116,12 +122,14 @@ public class HeadersTest extends TestCase {
 
     private static HttpServletRequest mockRequestQueryParameter() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("def=456&wovn=ja&abc=123").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -129,12 +137,14 @@ public class HeadersTest extends TestCase {
 
     private static HttpServletRequest mockRequestServerPort() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(8080).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -142,7 +152,7 @@ public class HeadersTest extends TestCase {
 
     private static HttpServletRequest mockRequestOriginalHeaders() {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
@@ -150,6 +160,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_URL")).andReturn("/foo/bar").atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_QUERY_STRING")).andReturn("baz=123").atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -83,10 +83,10 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn(host);
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -97,10 +97,10 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn("ja.example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("ja.example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -113,8 +113,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("wovn=ja").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -128,8 +128,8 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("def=456&wovn=ja&abc=123").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -141,10 +141,10 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(8080).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;
@@ -156,12 +156,12 @@ public class HeadersTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_URL")).andReturn("/foo/bar").atLeastOnce();
         EasyMock.expect(mock.getHeader("REDIRECT_QUERY_STRING")).andReturn("baz=123").atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -185,8 +185,8 @@ public class HtmlConverterTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -183,10 +183,10 @@ public class HtmlConverterTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn(host);
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -179,12 +179,14 @@ public class HtmlConverterTest extends TestCase {
 
     private static HttpServletRequest mockRequestPath(String path, String host) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn(host);
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
 
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -95,12 +95,14 @@ public class InterceptorTest extends TestCase {
 
     private HttpServletRequest mockRequestPath(String path) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -99,10 +99,10 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -101,8 +101,8 @@ public class InterceptorTest extends TestCase {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -52,8 +52,8 @@ public class TestUtil {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.expect(mock.getRequestDispatcher(replacedPath == null ? EasyMock.anyString() : replacedPath)).andReturn(dispatcher);
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -52,8 +52,8 @@ public class TestUtil {
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.expect(mock.getRequestDispatcher(replacedPath == null ? EasyMock.anyString() : replacedPath)).andReturn(dispatcher);
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -46,12 +46,14 @@ public class TestUtil {
 
     public static HttpServletRequest mockRequestPath(String path, String replacedPath, RequestDispatcherMock dispatcher) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https");
+        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
         EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
         EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
         EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.expect(mock.getRequestDispatcher(replacedPath == null ? EasyMock.anyString() : replacedPath)).andReturn(dispatcher);
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class UrlResolverTest extends TestCase {
-    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__returnUrl() {
+    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__returnUrl() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("http").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -24,7 +24,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("http://site.com/page/index.html?user=Elvis", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__nonDefaultPort__NoQuery__returnUrl() {
+    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__nonDefaultPort__NoQuery__returnUrl() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -40,7 +40,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://site.com:8080/", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__defaultSettings__requestForwardedInternally__returnOriginalUrl() {
+    public void testComputeClientRequestUrl__defaultSettings__requestForwardedInternally__returnOriginalUrl() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -56,7 +56,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://site.com/search?user=Elvis&q=korean+food", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__useProxy__proxyHeadersNotSet__returnUrlAsNormal() {
+    public void testComputeClientRequestUrl__useProxy__proxyHeadersNotSet__returnUrlAsNormal() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -76,7 +76,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://site.com/en/tokyo", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__useProxy__proxyHeadersPresent__returnUrlByHttpHeaders() {
+    public void testComputeClientRequestUrl__useProxy__proxyHeadersPresent__returnUrlByHttpHeaders() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -96,7 +96,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://global.co.jp:777/en/tokyo", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnUrlAsNormal() {
+    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnUrlAsNormal() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
@@ -117,7 +117,7 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://site.com/en/global/?q=original", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersSet__returnPathAndQueryFromHeaders() {
+    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersSet__returnPathAndQueryFromHeaders() throws ConfigurationError {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);

--- a/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
@@ -10,13 +10,13 @@ import org.easymock.EasyMock;
 public class UrlResolverTest extends TestCase {
     public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__returnUrl() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("http").times(1);
-        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
-        EasyMock.expect(r.getServerPort()).andReturn(443).times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
-        EasyMock.expect(r.getRequestURI()).andReturn("/page/index.html").times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
-        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(1);
+        EasyMock.expect(r.getScheme()).andReturn("http").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(443).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/page/index.html").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -26,13 +26,13 @@ public class UrlResolverTest extends TestCase {
 
     public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__nonDefaultPort__NoQuery__returnUrl() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
-        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
-        EasyMock.expect(r.getServerPort()).andReturn(8080).times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
-        EasyMock.expect(r.getRequestURI()).andReturn("/").times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
-        EasyMock.expect(r.getQueryString()).andReturn(null).times(1);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(8080).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -42,13 +42,13 @@ public class UrlResolverTest extends TestCase {
 
     public void testComputeClientRequestUrl__defaultSettings__requestForwardedInternally__returnOriginalUrl() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
-        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
-        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/search").times(1);
-        EasyMock.expect(r.getRequestURI()).andReturn("/internal/search/korean+food/index.html").times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(1);
-        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(1);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/internal/search/korean+food/index.html").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/search").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -58,13 +58,15 @@ public class UrlResolverTest extends TestCase {
 
     public void testComputeClientRequestUrl__useProxy__returnUrlByHttpHeaders() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
-        EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn("global.co.jp").times(1);
-        EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn("777").times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
-        EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
-        EasyMock.expect(r.getQueryString()).andReturn(null).times(1);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn("global.co.jp").times(0,1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn("777").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
@@ -76,11 +78,15 @@ public class UrlResolverTest extends TestCase {
 
     public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnEmptyPathAndQuery() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
-        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
-        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
-        EasyMock.expect(r.getHeader("X-My-Url")).andReturn(null).times(1);
-        EasyMock.expect(r.getHeader("X-My-Query")).andReturn(null).times(1);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/internal/forward/index.html").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn("q=internal").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getHeader("X-My-Url")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getHeader("X-My-Query")).andReturn(null).times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
@@ -93,11 +99,15 @@ public class UrlResolverTest extends TestCase {
 
     public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersSet__returnPathAndQueryFromHeaders() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
-        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
-        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
-        EasyMock.expect(r.getHeader("X-My-Url")).andReturn("/global/").times(1);
-        EasyMock.expect(r.getHeader("X-My-Query")).andReturn("wovn=vi").times(1);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/internal/forward/index.html").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn("q=internal").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getHeader("X-My-Url")).andReturn("/global/").times(0,1);
+        EasyMock.expect(r.getHeader("X-My-Query")).andReturn("wovn=vi").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{

--- a/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
@@ -15,8 +15,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(443).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/page/index.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -31,8 +31,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(8080).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -45,7 +45,7 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
-        EasyMock.expect(r.getRequestURI()).andReturn("/internal/search/korean+food/index.html").times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/internal/find.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
         EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/search").times(0,1);
         EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(0,1);
@@ -56,15 +56,35 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://site.com/search?user=Elvis&q=korean+food", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__useProxy__returnUrlByHttpHeaders() {
+    public void testComputeClientRequestUrl__useProxy__proxyHeadersNotSet__returnUrlAsNormal() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn(null).times(0,1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("useProxy", "true");
+        }});
+
+        assertEquals("https://site.com/en/tokyo", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__useProxy__proxyHeadersPresent__returnUrlByHttpHeaders() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn("global.co.jp").times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn("777").times(0,1);
         EasyMock.replay(r);
@@ -76,14 +96,14 @@ public class UrlResolverTest extends TestCase {
         assertEquals("https://global.co.jp:777/en/tokyo", UrlResolver.computeClientRequestUrl(r, s));
     }
 
-    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnEmptyPathAndQuery() {
+    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnUrlAsNormal() {
         HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
         EasyMock.expect(r.getScheme()).andReturn("https").times(0,1);
         EasyMock.expect(r.getServerName()).andReturn("site.com").times(0,1);
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/internal/forward/index.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=internal").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/global/").times(0,1);
         EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.expect(r.getHeader("X-My-Url")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-My-Query")).andReturn(null).times(0,1);
@@ -94,7 +114,7 @@ public class UrlResolverTest extends TestCase {
             put("originalQueryStringHeader", "X-My-Query");
         }});
 
-        assertEquals("https://site.com", UrlResolver.computeClientRequestUrl(r, s));
+        assertEquals("https://site.com/en/global/?q=original", UrlResolver.computeClientRequestUrl(r, s));
     }
 
     public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersSet__returnPathAndQueryFromHeaders() {

--- a/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
@@ -1,0 +1,110 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.HashMap;
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.TestCase;
+
+import org.easymock.EasyMock;
+
+public class UrlResolverTest extends TestCase {
+    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__returnUrl() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("http").times(1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
+        EasyMock.expect(r.getServerPort()).andReturn(443).times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/page/index.html").times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
+        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings();
+
+        assertEquals("http://site.com/page/index.html?user=Elvis", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__defaultSettings__requestNotForwarded__nonDefaultPort__NoQuery__returnUrl() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
+        EasyMock.expect(r.getServerPort()).andReturn(8080).times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/").times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
+        EasyMock.expect(r.getQueryString()).andReturn(null).times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings();
+
+        assertEquals("https://site.com:8080/", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__defaultSettings__requestForwardedInternally__returnOriginalUrl() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/search").times(1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/internal/search/korean+food/index.html").times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(1);
+        EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings();
+
+        assertEquals("https://site.com/search?user=Elvis&q=korean+food", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__useProxy__returnUrlByHttpHeaders() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn("global.co.jp").times(1);
+        EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn("777").times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("").times(1);
+        EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(1);
+        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("").times(1);
+        EasyMock.expect(r.getQueryString()).andReturn(null).times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("useProxy", "true");
+        }});
+
+        assertEquals("https://global.co.jp:777/en/tokyo", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersNotSet__returnEmptyPathAndQuery() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
+        EasyMock.expect(r.getHeader("X-My-Url")).andReturn(null).times(1);
+        EasyMock.expect(r.getHeader("X-My-Query")).andReturn(null).times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("originalUrlHeader", "X-My-Url");
+            put("originalQueryStringHeader", "X-My-Query");
+        }});
+
+        assertEquals("https://site.com", UrlResolver.computeClientRequestUrl(r, s));
+    }
+
+    public void testComputeClientRequestUrl__customHeaderPathAndQuery__customHeadersSet__returnPathAndQueryFromHeaders() {
+        HttpServletRequest r = EasyMock.createMock(HttpServletRequest.class);
+        EasyMock.expect(r.getScheme()).andReturn("https").times(1);
+        EasyMock.expect(r.getServerName()).andReturn("site.com").times(1);
+        EasyMock.expect(r.getServerPort()).andReturn(80).times(1);
+        EasyMock.expect(r.getHeader("X-My-Url")).andReturn("/global/").times(1);
+        EasyMock.expect(r.getHeader("X-My-Query")).andReturn("wovn=vi").times(1);
+        EasyMock.replay(r);
+
+        Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("originalUrlHeader", "X-My-Url");
+            put("originalQueryStringHeader", "X-My-Query");
+        }});
+
+        assertEquals("https://site.com/global/?wovn=vi", UrlResolver.computeClientRequestUrl(r, s));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -23,8 +23,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/en/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
         return mock;
     }
@@ -41,8 +41,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
         return mock;
     }
@@ -59,8 +59,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -18,13 +18,13 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getRequestURI()).andReturn("/en/test").atLeastOnce();
         EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer("/en/test")).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getServletPath()).andReturn("/en/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
         return mock;
     }
@@ -36,13 +36,13 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer("/test")).atLeastOnce();
         EasyMock.expect(mock.getServerName()).andReturn("en.example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
+        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
         EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
         return mock;
     }
@@ -59,8 +59,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -23,6 +23,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/en/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
         return mock;
     }
@@ -39,6 +41,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
         return mock;
     }
@@ -55,6 +59,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
         EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
         EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn("").anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn("").anyTimes();
         EasyMock.replay(mock);
         return mock;
     }


### PR DESCRIPTION
Create static class UrlResolver for correctly computing client request URL. The priority for URL fields to use for this purpose is
1. HTTP headers
2. Internal servlet container request forwarding attributes
3. Current request values

Using values from HTTP headers is dependent on user configuration (such as `useProxy` setting). If configuration is set to use HTTP headers but the relevant HTTP headers are not set, UrlResolver will resolve the URL normally.

Current requestLang is determined based on the client request URL.