### PR TITLE
[Misc] Remove references to HTTP header "Location"

### DIFF
--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -59,12 +59,11 @@ public class TestUtil {
         return mock;
     }
 
-    public static HttpServletResponse mockResponse(String contentType, String encoding, String location) throws IOException {
+    public static HttpServletResponse mockResponse(String contentType, String encoding) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
         mock.setContentLength(EasyMock.anyInt());
         EasyMock.expectLastCall();
         mock.setCharacterEncoding("utf-8");
-        EasyMock.expect(mock.getHeader("Location")).andReturn(location);
         EasyMock.expectLastCall();
         EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));
         EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();
@@ -95,7 +94,7 @@ public class TestUtil {
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
-        HttpServletResponse res = mockResponse(contentType, "", option.getOrDefault("location", ""));
+        HttpServletResponse res = mockResponse(contentType, "");
         FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -62,17 +62,6 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
-    public void testLocation() throws ServletException, IOException {
-        HashMap<String, String> testQuery = new HashMap<String, String>() {{
-            put("urlPattern", "query");
-            put("defaultLang", "ja");
-            put("location", "https://example.com/search/?abc=123&wovn=ja");
-        }};
-        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/?abc=123&wovn=ja", testQuery);
-        HttpServletResponse res = (HttpServletResponse)mock.res;
-        assertEquals("https://example.com/search/?abc=123&wovn=ja", res.getHeader("Location"));
-    }
-
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
         put("urlPattern", "query");
     }};


### PR DESCRIPTION
HTTP Header `Location` is currently not used, but it is being mocked and "tested"