### PR TITLE
Process each request only once

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -36,12 +36,21 @@ public class WovnServletFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
-        ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+        boolean requestAlreadyHandled = false;
+            // request.getHeader returns String or null
+        if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
+            ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+        } else {
+            requestAlreadyHandled = true;
+        }
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
-        boolean canProcessRequest = !requestOptions.getDisableMode() && headers.getIsValidPath() && htmlChecker.canTranslatePath(headers.pathName);
+        boolean canProcessRequest = !requestAlreadyHandled &&
+                                    !requestOptions.getDisableMode() &&
+                                    headers.getIsValidPath() &&
+                                    htmlChecker.canTranslatePath(headers.pathName);
 
         if (headers.getShouldRedirectToDefaultLang()) {
             /* Send 302 redirect to equivalent URL without default language code */

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -36,18 +36,21 @@ public class WovnServletFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
-        boolean requestAlreadyHandled = false;
-            // request.getHeader returns String or null
-        if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
+        boolean isRequestAlreadyProcessed = false;
+        String wovnjavaheader = ((HttpServletResponse)response).getHeader("X-Wovn-Handler");
+        System.out.println("Header X-Wovn-Handler: " + wovnjavaheader);
+        //if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
+        if (wovnjavaheader == null) {
             ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         } else {
-            requestAlreadyHandled = true;
+            isRequestAlreadyProcessed = true;
         }
+        System.out.println("isRequestAlreadyProcessed: " + isRequestAlreadyProcessed);
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
-        boolean canProcessRequest = !requestAlreadyHandled &&
+        boolean canProcessRequest = !isRequestAlreadyProcessed &&
                                     !requestOptions.getDisableMode() &&
                                     headers.getIsValidPath() &&
                                     htmlChecker.canTranslatePath(headers.pathName);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -34,13 +34,12 @@ public class WovnServletFilter implements Filter {
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
-    {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
         boolean isRequestAlreadyProcessed = false;
-        if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
-            ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
-        } else {
+        if (((HttpServletResponse)response).containsHeader("X-Wovn-Handler")) {
             isRequestAlreadyProcessed = true;
+        } else {
+            ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         }
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -37,15 +37,11 @@ public class WovnServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException
     {
         boolean isRequestAlreadyProcessed = false;
-        String wovnjavaheader = ((HttpServletResponse)response).getHeader("X-Wovn-Handler");
-        System.out.println("Header X-Wovn-Handler: " + wovnjavaheader);
-        //if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
-        if (wovnjavaheader == null) {
+        if (((HttpServletResponse)response).getHeader("X-Wovn-Handler") == null) {
             ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         } else {
             isRequestAlreadyProcessed = true;
         }
-        System.out.println("isRequestAlreadyProcessed: " + isRequestAlreadyProcessed);
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -61,6 +61,7 @@ public class TestUtil {
 
     public static HttpServletResponse mockResponse(String contentType, String encoding) throws IOException {
         return mockResponse(contentType, encoding, false);
+    }
 
     public static HttpServletResponse mockResponse(String contentType, String encoding, boolean isPreviouslyProcessed) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -75,9 +75,9 @@ public class TestUtil {
         mock.setHeader(EasyMock.anyString(), EasyMock.anyString());
         EasyMock.expectLastCall().atLeastOnce();
         if (isPreviouslyProcessed) {
-            EasyMock.expect(mock.getHeader("X-Wovn-Handler")).andReturn("wovnjava").times(0,1);
+            EasyMock.expect(mock.containsHeader("X-Wovn-Handler")).andReturn(true).times(0,1);
         } else {
-            EasyMock.expect(mock.getHeader("X-Wovn-Handler")).andReturn(null).times(0,1);
+            EasyMock.expect(mock.containsHeader("X-Wovn-Handler")).andReturn(false).times(0,1);
         }
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -13,7 +13,7 @@ import org.easymock.EasyMock;
 
 
 public class TestUtil {
-    private static final HashMap<String, String> emptyOption = new HashMap<String, String>();
+    public static final HashMap<String, String> emptyOption = new HashMap<String, String>();
 
     public static FilterConfig makeConfig() {
         return makeConfig(emptyOption);
@@ -60,6 +60,9 @@ public class TestUtil {
     }
 
     public static HttpServletResponse mockResponse(String contentType, String encoding) throws IOException {
+        return mockResponse(contentType, encoding, false);
+
+    public static HttpServletResponse mockResponse(String contentType, String encoding, boolean isPreviouslyProcessed) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
         mock.setContentLength(EasyMock.anyInt());
         EasyMock.expectLastCall();
@@ -70,6 +73,11 @@ public class TestUtil {
         EasyMock.expect(mock.getCharacterEncoding()).andReturn(encoding);
         mock.setHeader(EasyMock.anyString(), EasyMock.anyString());
         EasyMock.expectLastCall().atLeastOnce();
+        if (isPreviouslyProcessed) {
+            EasyMock.expect(mock.getHeader("X-Wovn-Handler")).andReturn("wovnjava").times(0,1);
+        } else {
+            EasyMock.expect(mock.getHeader("X-Wovn-Handler")).andReturn(null).times(0,1);
+        }
         EasyMock.replay(mock);
         return mock;
     }
@@ -92,9 +100,13 @@ public class TestUtil {
     }
 
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
+        return doServletFilter(contentType, path, forwardPath, option, false);
+    }
+
+    public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option, boolean isPreviouslyProcessed) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
-        HttpServletResponse res = mockResponse(contentType, "");
+        HttpServletResponse res = mockResponse(contentType, "", isPreviouslyProcessed);
         FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -62,6 +62,22 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
+    //public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
+    public void testProcessRequestOnce__RequestNotProcessed() {
+        RequestDispatcherMock dispatcher = new RequestDispatcherMock();
+        HttpServletRequest req = TestUtil.mockRequestPath("/", "/", dispatcher);
+        HttpServletResponse res = TestUtil.mockResponse("text/html", "", "");
+        FilterConfig filterConfig = makeConfig(option);
+        FilterChainMock filterChain = new FilterChainMock();
+        WovnServletFilter filter = new WovnServletFilter();
+        filter.init(filterConfig);
+        filter.doFilter(req, res, filterChain);
+        filterChain.req = filterChain.req == null ? dispatcher.req : filterChain.req;
+        filterChain.res = filterChain.res == null ? dispatcher.res : filterChain.res;
+        return filterChain;
+
+    }
+
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
         put("urlPattern", "query");
     }};

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -62,11 +62,27 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
+    public void testProcessRequestOnce__RequestNotProcessed() throws ServletException, IOException {
+        HashMap<String, String> config = new HashMap<String, String>() {{
+            put("urlPattern", "path");
+            put("defaultLang", "ja");
+            put("location", "https://example.com/ja/search/");
+        }};
+        boolean requestIsAlreadyProcessed = false;
+        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", TestUtil.emptyOption, requestIsAlreadyProcessed);
+        HttpServletResponse res = (HttpServletResponse)mock.res;
+        // WovnServletFilter will always set API status HTTP header when processing the request
+        assertEquals(true, res.getHeader("X-Wovn-Api-Status") != null); // Cannot check this because `getHeader` is mocked
+    }
+    /*
+     */
+
+    /*
     //public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option) throws ServletException, IOException {
     public void testProcessRequestOnce__RequestNotProcessed() {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
         HttpServletRequest req = TestUtil.mockRequestPath("/", "/", dispatcher);
-        HttpServletResponse res = TestUtil.mockResponse("text/html", "", "");
+        HttpServletResponse res = TestUtil.mockResponse("text/html; charset=utf-8", "", "");
         FilterConfig filterConfig = makeConfig(option);
         FilterChainMock filterChain = new FilterChainMock();
         WovnServletFilter filter = new WovnServletFilter();
@@ -77,6 +93,12 @@ public class WovnServletFilterTest extends TestCase {
         return filterChain;
 
     }
+    public void blrblrblr() throws ServletException, IOException {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/");
+        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
+        assertEquals("/", mock.req.getRequestURI());
+    }
+    */
 
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
         put("urlPattern", "query");


### PR DESCRIPTION
WovnServletFilter may intercept a single request multiple times if the request is forwarded internally within the servlet container. For instance, this forwarding happens when WovnServletFilter forwards a request with language code to the same request without language code.

WovnServletFilter will always set HTTP header `X-Wovn-Handler` when intercepting a request. Therefore, with these changes we will check if that header is set on the response object before processing the request. If the header is set, we will ignore it and pass it through untouched.

This change is more important now than before because we now calculate the request language etc based on the client requested URL, not the current servlet URL.