### PR TITLE
[Fix] Send correct client request URL in translation API request

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -132,7 +132,7 @@ class Api {
 
     private String getApiBody(String lang, String body) throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder();
-        appendKeyValue(sb, "url=", headers.getUrlWithoutLanguageCode());
+        appendKeyValue(sb, "url=", headers.getClientRequestUrlWithoutLangCode());
         appendKeyValue(sb, "&token=", settings.projectToken);
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
@@ -155,7 +155,7 @@ class Api {
         appendValue(sb, "&body_hash=");
         appendValue(sb, hash(body.getBytes()));
         appendValue(sb, "&path=");
-        appendValue(sb, headers.pathName);
+        appendValue(sb, headers.pathName); // TODO: fix now!
         appendValue(sb, "&lang=");
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -155,7 +155,7 @@ class Api {
         appendValue(sb, "&body_hash=");
         appendValue(sb, hash(body.getBytes()));
         appendValue(sb, "&path=");
-        appendValue(sb, headers.getClientRequestPathAndQueryWithoutLangCode());
+        appendValue(sb, headers.getClientRequestPathWithoutLangCode());
         appendValue(sb, "&lang=");
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -155,7 +155,7 @@ class Api {
         appendValue(sb, "&body_hash=");
         appendValue(sb, hash(body.getBytes()));
         appendValue(sb, "&path=");
-        appendValue(sb, headers.pathName); // TODO: fix now!
+        appendValue(sb, headers.getClientRequestPathAndQueryWithoutLangCode());
         appendValue(sb, "&lang=");
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -24,7 +24,6 @@ class Headers {
 
     private final String requestLang;
     private final String clientRequestUrlWithoutLangCode;
-    private final String clientRequestPathWithoutLangCode;
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidPath;
 
@@ -37,7 +36,6 @@ class Headers {
 
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlWithoutLangCode = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
-        this.clientRequestPathWithoutLangCode = UrlPath.getPath(this.clientRequestUrlWithoutLangCode);
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
         this.isValidPath = this.urlLanguagePatternHandler.isMatchingSitePrefixPath(clientRequestUrl);
 
@@ -238,7 +236,7 @@ class Headers {
     }
 
     public String getClientRequestPathWithoutLangCode() {
-        return this.clientRequestPathWithoutLangCode;
+        return UrlPath.getPath(this.clientRequestUrlWithoutLangCode);
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -24,7 +24,7 @@ class Headers {
 
     private final String requestLang;
     private final String clientRequestUrlWithoutLangCode;
-    private final String clientRequestPathAndQueryWithoutLangCode;
+    private final String clientRequestPathWithoutLangCode;
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidPath;
 
@@ -37,7 +37,7 @@ class Headers {
 
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlWithoutLangCode = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
-        this.clientRequestPathAndQueryWithoutLangCode = UrlPath.getPathAndQuery(this.clientRequestUrlWithoutLangCode);
+        this.clientRequestPathWithoutLangCode = UrlPath.getPath(this.clientRequestUrlWithoutLangCode);
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
         this.isValidPath = this.urlLanguagePatternHandler.isMatchingSitePrefixPath(clientRequestUrl);
 
@@ -237,8 +237,8 @@ class Headers {
         return this.clientRequestUrlWithoutLangCode;
     }
 
-    public String getClientRequestPathAndQueryWithoutLangCode() {
-        return this.clientRequestPathAndQueryWithoutLangCode;
+    public String getClientRequestPathWithoutLangCode() {
+        return this.clientRequestPathWithoutLangCode;
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -23,6 +23,7 @@ class Headers {
 
     private final String requestLang;
     private final String clientRequestUrlWithoutLangCode;
+    private final String clientRequestPathAndQueryWithoutLangCode;
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidPath;
 
@@ -35,6 +36,7 @@ class Headers {
 
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlWithoutLangCode = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
+        this.clientRequestPathAndQueryWithoutLangCode = UrlPath.getPathAndQuery(this.clientRequestUrlWithoutLangCode);
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
         this.isValidPath = this.urlLanguagePatternHandler.isMatchingSitePrefixPath(clientRequestUrl);
 
@@ -270,6 +272,10 @@ class Headers {
 
     public String getClientRequestUrlWithoutLangCode() {
         return this.clientRequestUrlWithoutLangCode;
+    }
+
+    public String getClientRequestPathAndQueryWithoutLangCode() {
+        return this.clientRequestPathAndQueryWithoutLangCode;
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
@@ -3,6 +3,14 @@ package com.github.wovnio.wovnjava;
 final class UrlPath {
     private UrlPath() {}
 
+    public static String getPathAndQuery(String url) {
+        Pattern schemePattern = Pattern.compile("^[a-zA-Z]://");
+        Pattern hostPattern = Pattern.compile("^[^/?]*");
+        String hostPathQuery = schemePattern.matcher(url).replaceFirst("");
+        String pathQuery = hostPattern.matcher(url).replaceFirst("");
+        return pathQuery;
+    }
+
     public static String removeFile(String path) {
         if (path.endsWith("/")) {
             return path;

--- a/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
@@ -5,10 +5,11 @@ import java.util.regex.Pattern;
 final class UrlPath {
     private UrlPath() {}
 
-    public static String getPathAndQuery(String url) {
+    public static String getPath(String url) {
         String hostPathQuery = Pattern.compile("^https?://").matcher(url).replaceFirst("");
         String pathQuery = Pattern.compile("^[^/?]*").matcher(hostPathQuery).replaceFirst("");
-        return pathQuery;
+        String path = Pattern.compile("\\?.*$").matcher(pathQuery).replaceFirst("");
+        return path;
     }
 
     public static String removeFile(String path) {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlPath.java
@@ -1,13 +1,13 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.regex.Pattern;
+
 final class UrlPath {
     private UrlPath() {}
 
     public static String getPathAndQuery(String url) {
-        Pattern schemePattern = Pattern.compile("^[a-zA-Z]://");
-        Pattern hostPattern = Pattern.compile("^[^/?]*");
-        String hostPathQuery = schemePattern.matcher(url).replaceFirst("");
-        String pathQuery = hostPattern.matcher(url).replaceFirst("");
+        String hostPathQuery = Pattern.compile("^https?://").matcher(url).replaceFirst("");
+        String pathQuery = Pattern.compile("^[^/?]*").matcher(hostPathQuery).replaceFirst("");
         return pathQuery;
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/UrlPathTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlPathTest.java
@@ -5,6 +5,26 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class UrlPathTest extends TestCase {
+    public void testGetPathAndQuery() {
+        assertEquals("", UrlPath.getPathAndQuery(""));
+        assertEquals("/", UrlPath.getPathAndQuery("/"));
+        assertEquals("?query", UrlPath.getPathAndQuery("?query"));
+        assertEquals("/path/a.html", UrlPath.getPathAndQuery("/path/a.html"));
+        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("/path/a.html?query"));
+
+        assertEquals("", UrlPath.getPathAndQuery("site.com"));
+        assertEquals("/", UrlPath.getPathAndQuery("site.com/"));
+        assertEquals("?query", UrlPath.getPathAndQuery("site.com?query"));
+        assertEquals("/path/a.html", UrlPath.getPathAndQuery("site.com/path/a.html"));
+        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("site.com/path/a.html?query"));
+
+        assertEquals("", UrlPath.getPathAndQuery("http://site.com"));
+        assertEquals("/", UrlPath.getPathAndQuery("http://site.com/"));
+        assertEquals("?query", UrlPath.getPathAndQuery("http://site.com?query"));
+        assertEquals("/path/a.html", UrlPath.getPathAndQuery("http://site.com/path/a.html"));
+        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("http://site.com/path/a.html?query"));
+    }
+
     public void testRemoveFile() {
         assertEquals("/", UrlPath.removeFile(""));
         assertEquals("/", UrlPath.removeFile("/"));

--- a/src/test/java/com/github/wovnio/wovnjava/UrlPathTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlPathTest.java
@@ -6,23 +6,23 @@ import org.easymock.EasyMock;
 
 public class UrlPathTest extends TestCase {
     public void testGetPathAndQuery() {
-        assertEquals("", UrlPath.getPathAndQuery(""));
-        assertEquals("/", UrlPath.getPathAndQuery("/"));
-        assertEquals("?query", UrlPath.getPathAndQuery("?query"));
-        assertEquals("/path/a.html", UrlPath.getPathAndQuery("/path/a.html"));
-        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("/path/a.html?query"));
+        assertEquals("", UrlPath.getPath(""));
+        assertEquals("/", UrlPath.getPath("/"));
+        assertEquals("", UrlPath.getPath("?query"));
+        assertEquals("/path/a.html", UrlPath.getPath("/path/a.html"));
+        assertEquals("/path/a.html", UrlPath.getPath("/path/a.html?query"));
 
-        assertEquals("", UrlPath.getPathAndQuery("site.com"));
-        assertEquals("/", UrlPath.getPathAndQuery("site.com/"));
-        assertEquals("?query", UrlPath.getPathAndQuery("site.com?query"));
-        assertEquals("/path/a.html", UrlPath.getPathAndQuery("site.com/path/a.html"));
-        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("site.com/path/a.html?query"));
+        assertEquals("", UrlPath.getPath("site.com"));
+        assertEquals("/", UrlPath.getPath("site.com/"));
+        assertEquals("", UrlPath.getPath("site.com?query"));
+        assertEquals("/path/a.html", UrlPath.getPath("site.com/path/a.html"));
+        assertEquals("/path/a.html", UrlPath.getPath("site.com/path/a.html?query"));
 
-        assertEquals("", UrlPath.getPathAndQuery("http://site.com"));
-        assertEquals("/", UrlPath.getPathAndQuery("http://site.com/"));
-        assertEquals("?query", UrlPath.getPathAndQuery("http://site.com?query"));
-        assertEquals("/path/a.html", UrlPath.getPathAndQuery("http://site.com/path/a.html"));
-        assertEquals("/path/a.html?query", UrlPath.getPathAndQuery("http://site.com/path/a.html?query"));
+        assertEquals("", UrlPath.getPath("http://site.com"));
+        assertEquals("/", UrlPath.getPath("http://site.com/"));
+        assertEquals("", UrlPath.getPath("http://site.com?query"));
+        assertEquals("/path/a.html", UrlPath.getPath("http://site.com/path/a.html"));
+        assertEquals("/path/a.html", UrlPath.getPath("http://site.com/path/a.html?query"));
     }
 
     public void testRemoveFile() {


### PR DESCRIPTION
Update translation API request to use the computed client request URL to identify which page is being translated.

The API request puts this information in two places. It sends the full URL in the API body, and it sends just the path in the cache key. We therefore have to extract the path part, and a new helper function is added for this purpose.

We use quite a bit of regex manipulation for URLs at this point. A lot of it is unavoidable, of course, and I'm trying to think about how to keep it to a minimum. That said, as long as any regex manipulation is tested in isolation, it feels manageable.