### PR TITLE
Remove secretKey setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,11 @@ originalUrlHeader         |          | ''
 originalQueryStringHeader |          | ''
 ignoreClasses             |          | ''
 
-* A required parameter with a default setting does not need to be set within the web.xml. (Only the projectToken and secretKey parameters must be set in order for the library to work)
+* A required parameter with a default setting does not need to be set within the web.xml. (Only the projectToken parameter must be set in order for the library to work)
 
 ### 2.1. projectToken
 
 Set your WOVN.io Account's project token. This parameter is required.
-
-### 2.2. secretKey
-
-This parameter is currently in development and is not being used. However, it is a required parameter, so make to sure to include a value in it (e.g. "secret").
 
 ### 2.3. urlPattern
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,10 +62,6 @@ WOVN.io Java ライブラリを使用するためには、WOVN.io のアカウ�
     <param-name>projectToken</param-name>
     <param-value>2Wle3</param-value><!-- ユーザートークンを設定してください。 -->
   </init-param>
-  <init-param>
-    <param-name>secretKey</param-name>
-    <param-value>secret</param-value><!-- シークレットキーとして何か適当な値を指定してください。 -->
-  </init-param>
 </filter>
 
 <filter-mapping>
@@ -80,8 +76,7 @@ WOVN.io Java ライブラリに設定可能なパラメータは以下の通り�
 
 パラメータ名              | 必須かどうか | 初期値
 ------------------------- | ------------ | ------------
-projectToken                 | yes          | ''
-secretKey                 | yes          | ''
+projectToken              | yes          | ''
 urlPattern                | yes          | 'path'
 query                     |              | ''
 defaultLang               | yes          | 'en'
@@ -90,15 +85,11 @@ debugMode                 |              | '0'
 originalUrlHeader         |              | ''
 originalQueryStringHeader |              | ''
 
-※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（projectToken と secretKey だけ指定すればライブラリを動作させることができます）
+※ 初期値が設定されている必須パラメータは、web.xml で設定しなくても大丈夫です。（projectToken だけ指定すればライブラリを動作させることができます）
 
 ### 2.1. projectToken
 
 あなたの WOVN.io アカウントのユーザートークンを設定してください。このパラメータは必須です。
-
-### 2.2. secretKey
-
-このパラメータは開発中で、現在は未使用です。必須パラメータですので「secret」など、何かしらの文字を設定してください。
 
 ### 2.3. urlPattern
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -18,7 +18,6 @@ class Settings {
     String projectToken = "";
     boolean hasSitePrefixPath = false;
     String sitePrefixPath = "";
-    String secretKey = "";
     String urlPattern = "path";
     ArrayList<String> query;
     String snippetUrl = "//j.wovn.io/1";
@@ -65,11 +64,6 @@ class Settings {
             } else {
                 this.sitePrefixPath = p;
             }
-        }
-
-        p = config.getInitParameter("secretKey");
-        if (p != null && p.length() > 0) {
-            this.secretKey = p;
         }
 
         p = config.getInitParameter("urlPattern");
@@ -216,10 +210,6 @@ class Settings {
         if (projectToken == null || projectToken.length() < 5 || projectToken.length() > 6) {
             valid = false;
             errors.add("Project token is not valid: " + projectToken);
-        }
-        if (secretKey == null || secretKey.length() == 0) {
-            valid = false;
-            errors.add("Secret key is not configured.");
         }
         if (urlPattern == null || urlPattern.length() == 0) {
             valid = false;

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -14,7 +14,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
         }};
         return TestUtil.makeConfig(parameters);
     }
@@ -22,7 +21,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "subdomain");
         }};
         return TestUtil.makeConfig(parameters);
@@ -31,7 +29,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
         }};
         return TestUtil.makeConfig(parameters);
@@ -41,7 +38,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("query", "abc");
         }};
@@ -52,7 +48,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("query", "AAA");
         }};
@@ -63,7 +58,6 @@ public class HeadersTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("query", "baz");
             put("originalUrlHeader", "REDIRECT_URL");
             put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -19,7 +19,6 @@ public class SettingsTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("query", "foo,bar");
             put("apiUrl", "https://example.com/v0/values");
@@ -35,7 +34,6 @@ public class SettingsTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "3elW2");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("query", "foo,bar");
             put("apiUrl", "https://example.com/v0/values");
@@ -51,7 +49,6 @@ public class SettingsTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
         }};
         return TestUtil.makeConfig(parameters);
@@ -64,7 +61,6 @@ public class SettingsTest extends TestCase {
 
         assertNotNull(s);
         assertEquals("", s.projectToken);
-        assertEquals("", s.secretKey);
         assertEquals("path", s.urlPattern);
         assertEquals(new ArrayList<String>(), s.query);
         assertEquals("https://wovn.global.ssl.fastly.net/v0/", s.apiUrl);
@@ -83,7 +79,6 @@ public class SettingsTest extends TestCase {
 
         assertNotNull(s);
         assertEquals("2Wle3", s.projectToken);
-        assertEquals("secret", s.secretKey);
         assertEquals("query", s.urlPattern);
         ArrayList<String> query = new ArrayList<String>();
         query.add("foo");
@@ -121,7 +116,6 @@ public class SettingsTest extends TestCase {
     public void testSettings__invalidDefaultLang() throws ConfigurationError {
         HashMap<String, String> parametersWithInvalidDefaultLang = new HashMap<String, String>() {{
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("supportedLangs", "en,ja");
             put("defaultLang", "INVALID");
@@ -138,7 +132,6 @@ public class SettingsTest extends TestCase {
     public void testSettings__invalidSupportedLangs() throws ConfigurationError {
         HashMap<String, String> parametersWithInvalidSupportedLangs = new HashMap<String, String>() {{
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
             put("defaultLang", "en");
             put("supportedLangs", "en,japan,korean");
@@ -200,7 +193,6 @@ public class SettingsTest extends TestCase {
 
         assertNotNull(s);
         assertEquals("3elW2", s.projectToken);
-        assertEquals("secret", s.secretKey);
         assertEquals("query", s.urlPattern);
         ArrayList<String> query = new ArrayList<String>();
         query.add("foo");

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -21,7 +21,7 @@ public class TestUtil {
 
     public static FilterConfig makeConfig(HashMap<String, String> option) {
         FilterConfig mock = EasyMock.createMock(FilterConfig.class);
-        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "secretKey", "urlPattern", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses", "devMode", "enableFlushBuffer"};
+        String[] keys = {"userToken", "projectToken", "sitePrefixPath", "urlPattern", "query", "apiUrl", "defaultLang", "supportedLangs", "testMode", "testUrl", "useProxy", "debugMode", "originalUrlHeader", "originalQueryStringHeader", "strictHtmlCheck", "deleteInvalidClosingTag", "deleteInvalidUTF8", "connectTimeout", "readTimeout", "ignoreClasses", "devMode", "enableFlushBuffer"};
         for (int i=0; i<keys.length; ++i) {
             String key = keys[i];
             String val = option.get(key);

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -69,7 +69,6 @@ public class WovnHttpServletRequestTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
         }};
         return TestUtil.makeConfig(parameters);
     }
@@ -78,7 +77,6 @@ public class WovnHttpServletRequestTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "subdomain");
         }};
         return TestUtil.makeConfig(parameters);
@@ -88,7 +86,6 @@ public class WovnHttpServletRequestTest extends TestCase {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("secretKey", "secret");
             put("urlPattern", "query");
         }};
         return TestUtil.makeConfig(parameters);


### PR DESCRIPTION
The `secretKey` setting has never been used and is not needed, so we remove it.
Existing configuration files do not need to be changed.