### PR TITLE
Remove query setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Parameter Name            | Required | Default Setting
 ------------------------- | -------- | ------------
 projectToken              | yes      | ''
 urlPattern                | yes      | 'path'
-query                     |          | ''
 defaultLang               | yes      | 'en'
 useProxy                  |          | 'false'
 debugMode                 |          | 'false'
@@ -106,22 +105,6 @@ parameters  | Translated page's URL           | Notes
 ※ The previously mentioned URL's are examples of the following URL translated via the WOVN.io library. As can be seen, depending on the URL Parameter the url will change.
 
     https://wovn.io/contact
-
-### 2.4. query
-
-When WOVN.io identifies a page for translation, it ignores the query parameter. If you want to include a query parameter within the URL, you must set it using the "query" parameter. (You must set this on WOVN.io's side)
-
-    https://wovn.io/ja/contact?os=mac&keyboard=us
-
-If the defualt_lang is 'en', and the query is \[\] (unset), the above URL will be modified into the following URL to search for the page's translation.
-
-    https://wovn.io/contact
-
-If the default_lang is 'en', and the query is set to ['os'], the above URL will be modified into the following URL to search for the page's translation.
-
-    https://wovn.io/contact?os=mac
-
-If you want to set multiple queries, you can separate them via a comma.
 
 ### 2.5. defaultLang
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -78,7 +78,6 @@ WOVN.io Java ライブラリに設定可能なパラメータは以下の通り�
 ------------------------- | ------------ | ------------
 projectToken              | yes          | ''
 urlPattern                | yes          | 'path'
-query                     |              | ''
 defaultLang               | yes          | 'en'
 useProxy                  |              | 'false'
 debugMode                 |              | '0'

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -111,29 +111,8 @@ class Headers {
         }
         this.url += this.removeLang(this.query, this.langCode());
         this.url = this.url.length() == 0 ? "/" : this.url;
-        if (this.settings.query.size() > 0) {
-            ArrayList<String> queryVals = new ArrayList<String>();
-            for (String q : this.settings.query) {
-                Pattern p = Pattern.compile("(^|&)(" + q + "[^&]+)(&|$)");
-                Matcher m = p.matcher(this.query);
-                if (m.find() && m.group(2) != null && m.group(2).length() > 0) {
-                    queryVals.add(m.group(2));
-                }
-            }
-            if (queryVals.isEmpty()) {
-                // ignore all query parameters.
-                this.query = "";
-            } else {
-                this.query = "?";
-                Collections.sort(queryVals);
-                for (String q : queryVals) {
-                    this.query += q + "&";
-                }
-                // remove last ampersand.
-                this.query = Pattern.compile("&$").matcher(this.query).replaceFirst("");
-            }
-        } else {
-            this.query = "";
+        if (!this.query.isEmpty() && !this.query.startsWith("?")) {
+            this.query = "?" + this.query;
         }
         this.query = this.removeLang(this.query, this.langCode());
         this.pathNameKeepTrailingSlash = this.pathName;

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -19,7 +19,6 @@ class Settings {
     boolean hasSitePrefixPath = false;
     String sitePrefixPath = "";
     String urlPattern = "path";
-    ArrayList<String> query;
     String snippetUrl = "//j.wovn.io/1";
     String apiUrl = DefaultApiUrl;
     String defaultLang = "en";
@@ -39,7 +38,6 @@ class Settings {
     Settings(FilterConfig config) throws ConfigurationError {
         super();
 
-        this.query = new ArrayList<String>();
         this.supportedLangs = new ArrayList<String>();
         this.ignoreClasses = new ArrayList<String>();
 
@@ -69,11 +67,6 @@ class Settings {
         p = config.getInitParameter("urlPattern");
         if (p != null && p.length() > 0) {
             this.urlPattern = p;
-        }
-
-        p = config.getInitParameter("query");
-        if (p != null && p.length() > 0) {
-            this.query = getArrayParameter(p);
         }
 
         p = config.getInitParameter("apiUrl");
@@ -243,9 +236,6 @@ class Settings {
         MessageDigest md = MessageDigest.getInstance("MD5");
         md.update(projectToken.getBytes());
         md.update(urlPattern.getBytes());
-        for (String q : query) {
-            md.update(q.getBytes());
-        }
         md.update(sitePrefixPath.getBytes());
         md.update(defaultLang.getBytes());
         for (String lang : supportedLangs) {

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -34,31 +34,10 @@ public class HeadersTest extends TestCase {
         return TestUtil.makeConfig(parameters);
     }
 
-    private static FilterConfig mockConfigQueryParameter() {
-        HashMap<String, String> parameters = new HashMap<String, String>() {{
-            put("userToken", "2Wle3");
-            put("projectToken", "2Wle3");
-            put("urlPattern", "query");
-            put("query", "abc");
-        }};
-        return TestUtil.makeConfig(parameters);
-    }
-
-    private static FilterConfig mockConfigQueryParameterAAA() {
-        HashMap<String, String> parameters = new HashMap<String, String>() {{
-            put("userToken", "2Wle3");
-            put("projectToken", "2Wle3");
-            put("urlPattern", "query");
-            put("query", "AAA");
-        }};
-        return TestUtil.makeConfig(parameters);
-    }
-
     private static FilterConfig mockConfigOriginalHeaders() {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
-            put("query", "baz");
             put("originalUrlHeader", "REDIRECT_URL");
             put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");
         }};
@@ -173,7 +152,7 @@ public class HeadersTest extends TestCase {
         assertNotNull(h);
     }
 
-    public void testHeadersWithoutQueryParameter() throws ConfigurationError {
+    public void testHeadersWithQueryParameters() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestQueryParameter();
         FilterConfig mockConfig = mockConfigQuery();
 
@@ -182,19 +161,7 @@ public class HeadersTest extends TestCase {
         Headers h = new Headers(mockRequest, s, ulph);
 
         assertNotNull(h);
-        assertEquals("", h.query);
-    }
-
-    public void testHeadersWithQueryParameter() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQueryParameter();
-        FilterConfig mockConfig = mockConfigQueryParameter();
-
-        Settings s = new Settings(mockConfig);
-        UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
-        Headers h = new Headers(mockRequest, s, ulph);
-
-        assertNotNull(h);
-        assertEquals("?abc=123", h.query);
+        assertEquals("?def=456&abc=123", h.query);
     }
 
     public void testGetRequestLangPath() throws ConfigurationError {
@@ -259,17 +226,6 @@ public class HeadersTest extends TestCase {
         Headers h = new Headers(mockRequest, s, ulph);
 
         assertEquals("example.com/test", h.removeLang("example.com/test?wovn=ja", null));
-    }
-
-    public void testNotMatchQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQueryParameter();
-        FilterConfig mockConfig = mockConfigQueryParameterAAA();
-
-        Settings s = new Settings(mockConfig);
-        UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
-        Headers h = new Headers(mockRequest, s, ulph);
-
-        assertEquals("", h.query);
     }
 
     public void testServerPort() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -20,7 +20,6 @@ public class SettingsTest extends TestCase {
             put("userToken", "2Wle3");
             put("projectToken", "2Wle3");
             put("urlPattern", "query");
-            put("query", "foo,bar");
             put("apiUrl", "https://example.com/v0/values");
             put("defaultLang", "ja");
             put("supportedLangs", "en,ja");
@@ -35,7 +34,6 @@ public class SettingsTest extends TestCase {
             put("userToken", "2Wle3");
             put("projectToken", "3elW2");
             put("urlPattern", "query");
-            put("query", "foo,bar");
             put("apiUrl", "https://example.com/v0/values");
             put("defaultLang", "ja");
             put("supportedLangs", "en,ja");
@@ -62,7 +60,6 @@ public class SettingsTest extends TestCase {
         assertNotNull(s);
         assertEquals("", s.projectToken);
         assertEquals("path", s.urlPattern);
-        assertEquals(new ArrayList<String>(), s.query);
         assertEquals("https://wovn.global.ssl.fastly.net/v0/", s.apiUrl);
         assertEquals("en", s.defaultLang);
         ArrayList<String> supportedLangs = new ArrayList<String>();
@@ -80,10 +77,6 @@ public class SettingsTest extends TestCase {
         assertNotNull(s);
         assertEquals("2Wle3", s.projectToken);
         assertEquals("query", s.urlPattern);
-        ArrayList<String> query = new ArrayList<String>();
-        query.add("foo");
-        query.add("bar");
-        assertEquals(query, s.query);
         assertEquals("https://example.com/v0/values", s.apiUrl);
         assertEquals("ja", s.defaultLang);
         ArrayList<String> supportedLangs = new ArrayList<String>();
@@ -194,10 +187,6 @@ public class SettingsTest extends TestCase {
         assertNotNull(s);
         assertEquals("3elW2", s.projectToken);
         assertEquals("query", s.urlPattern);
-        ArrayList<String> query = new ArrayList<String>();
-        query.add("foo");
-        query.add("bar");
-        assertEquals(query, s.query);
         assertEquals("https://example.com/v0/values", s.apiUrl);
         assertEquals("ja", s.defaultLang);
         ArrayList<String> supportedLangs = new ArrayList<String>();


### PR DESCRIPTION
The purpose of the `query` setting is to identify unique pages when the specified query parameters are different. This is a setting that the customer configures for their Wovn project.

The standard behavior for our products is to include all query parameters in the request for page data, and the server will identify the page correctly. Therefore, wovnjava does not need to concern itself with the details of query parameter filtering, and we can remove the setting.

Existing configuration files do not need to be changed.

**Old behavior:** Send only the query parameters required to identify the page
**New behavior:** Send all query parameters always, and let the server pick query parameters for page identification