### PR TITLE
Create FileExtensionMatcher and clean up Headers

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
@@ -1,0 +1,33 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class FileExtensionMatcher {
+    private final Pattern TEXT_FILE_PATTERN;
+    private final Pattern IMAGE_FILE_PATTERN;
+    private final Pattern AUDIO_FILE_PATTERN;
+    private final Pattern VIDEO_FILE_PATTERN;
+    private final Pattern DOC_FILE_PATTERN;
+
+    FileExtensionMatcher() {
+        this.TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
+        this.IMAGE_FILE_PATTERN = Pattern.compile("(\\.(jpe|jpe?g|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
+        this.AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
+        this.VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
+        this.DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|7z|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
+    }
+
+    public boolean isFile(String path) {
+        // Reduce strings for performance and keep a simple case
+        path = path.replaceFirst("^.*/", "/"); // strip directries
+        path = path.replaceFirst("[?#].*$", ""); // strip query or/and hash
+        path = path.toLowerCase();
+
+        return TEXT_FILE_PATTERN.matcher(path).find()
+            || IMAGE_FILE_PATTERN.matcher(path).find()
+            || AUDIO_FILE_PATTERN.matcher(path).find()
+            || VIDEO_FILE_PATTERN.matcher(path).find()
+            || DOC_FILE_PATTERN.matcher(path).find();
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -6,31 +6,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class HtmlChecker {
-    public boolean canTranslate(String contentType, String path, String html) {
+    public boolean canTranslate(String contentType, String html) {
         return canTranslateContentType(contentType) &&
-            canTranslatePath(path) &&
             canTranslateContent(html);
     }
 
     public boolean canTranslateContentType(String type) {
         return type == null || type.toLowerCase().contains("html");
-    }
-
-    public boolean canTranslatePath(String path) {
-        if (path == null) {
-            return true;
-        }
-
-        // Reduce strings for performance and keep a simple case
-        path = path.replaceFirst("^.*/", "/"); // strip directries
-        path = path.replaceFirst("[?#].*$", ""); // strip query or/and hash
-        path = path.toLowerCase();
-
-        return !TEXT_FILE_PATTERN.matcher(path).find()
-            && !IMAGE_FILE_PATTERN.matcher(path).find()
-            && !AUDIO_FILE_PATTERN.matcher(path).find()
-            && !VIDEO_FILE_PATTERN.matcher(path).find()
-            && !DOC_FILE_PATTERN.matcher(path).find();
     }
 
     public boolean canTranslateContent(String html) {
@@ -59,12 +41,4 @@ class HtmlChecker {
     }
 
     private final int BUFFER_SIZE = 256;
-
-    private final Pattern TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
-
-    // The pattern come from WOVN.php/src/wovnio/wovnphp/Utils.php
-    private final Pattern IMAGE_FILE_PATTERN = Pattern.compile("(\\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
-    private final Pattern AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
-    private final Pattern VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");
-    private final Pattern DOC_FILE_PATTERN = Pattern.compile("(\\.((g|7)?zip|7z|tar|gz|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))$");
 }

--- a/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
@@ -12,7 +12,6 @@ public class FileExtensionMatcherTest extends TestCase {
     public void testIsFile() {
         assertIsFile(false, "");
         assertIsFile(false, "/");
-        assertIsFile(false, "/");
         assertIsFile(false, "html");
         assertIsFile(false, "jp");
         assertIsFile(true, "png");

--- a/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
@@ -1,0 +1,53 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+
+public class FileExtensionMatcherTest extends TestCase {
+    private FileExtensionMatcher sut;
+
+    protected void setUp() {
+        this.sut = new FileExtensionMatcher();
+    }
+
+    public void testIsFile() {
+        assertIsFile(false, "");
+        assertIsFile(false, "/");
+        assertIsFile(false, "/");
+        assertIsFile(false, "html");
+        assertIsFile(false, "jp");
+        assertIsFile(true, "png");
+        assertIsFile(true, "jpg");
+        assertIsFile(true, "gif");
+        assertIsFile(true, "mp3");
+        assertIsFile(true, "mp4");
+        assertIsFile(true, "zip");
+        assertIsFile(true, "7zip");
+        assertIsFile(true, "7z");
+        assertIsFile(true, "gzip");
+        assertIsFile(true, "tar");
+        assertIsFile(true, "gz");
+        assertIsFile(true, "rar");
+        assertIsFile(true, "pdf");
+        assertIsFile(true, "js");
+        assertIsFile(true, "css");
+        assertIsFile(false, "unknown");
+    }
+
+    private void assertIsFile(boolean expect, String ext) {
+        assertEquals(expect, this.sut.isFile("foo." + ext));
+        assertEquals(expect, this.sut.isFile("/foo." + ext));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "?query=1"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "?query=file.html"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "?query=file.png"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "#hash"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "#hash.html"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "#hash.png"));
+        assertEquals(expect, this.sut.isFile("/dir/foo." + ext + "#hash.png?query=file.png&upload=file.html"));
+        assertEquals(false, this.sut.isFile("foo" + ext));
+        assertEquals(false, this.sut.isFile("/foo." + ext + "unknown"));
+        assertEquals(false, this.sut.isFile("/foo." + ext + "/"));
+        assertEquals(expect, this.sut.isFile("/foo.html/bar." + ext));
+        assertEquals(expect, this.sut.isFile("/foo.png/bar." + ext));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -145,18 +145,6 @@ public class HeadersTest extends TestCase {
         assertNotNull(h);
     }
 
-    public void testHeadersWithQueryParameters() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQueryParameter();
-        FilterConfig mockConfig = mockConfigQuery();
-
-        Settings s = new Settings(mockConfig);
-        UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
-        Headers h = new Headers(mockRequest, s, ulph);
-
-        assertNotNull(h);
-        assertEquals("?def=456&abc=123", h.query);
-    }
-
     public void testGetRequestLangPath() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath();
         FilterConfig mockConfig = mockConfigPath();
@@ -219,17 +207,6 @@ public class HeadersTest extends TestCase {
         Headers h = new Headers(mockRequest, s, ulph);
 
         assertEquals("example.com/test", h.removeLang("example.com/test?wovn=ja", null));
-    }
-
-    public void testServerPort() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestServerPort();
-        FilterConfig mockConfig = mockConfigPath();
-
-        Settings s = new Settings(mockConfig);
-        UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
-        Headers h = new Headers(mockRequest, s, ulph);
-
-        assertEquals("example.com:8080/test", h.pageUrl);
     }
 
     public void testSitePrefixPath() throws ConfigurationError {
@@ -365,19 +342,6 @@ public class HeadersTest extends TestCase {
         Settings s = TestUtil.makeSettings(option);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         return new Headers(mockRequest, s, ulph);
-    }
-
-    public void testOriginalHeaders() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestOriginalHeaders();
-        FilterConfig mockConfig = mockConfigOriginalHeaders();
-
-        Settings s = new Settings(mockConfig);
-        UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
-        Headers h = new Headers(mockRequest, s, ulph);
-
-        assertEquals("/foo/bar", h.pathName);
-        assertEquals("?baz=123", h.query);
-        assertEquals("example.com/foo/bar?baz=123", h.pageUrl);
     }
 
     public void testGetHreflangUrlMap__PathPattern() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -2,7 +2,6 @@ package com.github.wovnio.wovnjava;
 
 import junit.framework.TestCase;
 
-
 public class HtmlCheckerTest extends TestCase {
     private final HtmlChecker htmlChecker = new HtmlChecker();
 
@@ -12,29 +11,6 @@ public class HtmlCheckerTest extends TestCase {
         assertEquals(true, htmlChecker.canTranslateContentType("text/html"));
         assertEquals(true, htmlChecker.canTranslateContentType("text/xhtml"));
         assertEquals(false, htmlChecker.canTranslateContentType("text/plain"));
-    }
-
-    public void testCanTranslatePath() {
-        assertCanTranslatePath(true, null);
-        assertCanTranslatePath(true, "");
-        assertCanTranslatePath(true, "/");
-        assertCanTranslatePath(true, "html");
-        assertCanTranslatePath(false, "png");
-        assertCanTranslatePath(false, "jpg");
-        assertCanTranslatePath(false, "gif");
-        assertCanTranslatePath(false, "mp3");
-        assertCanTranslatePath(false, "mp4");
-        assertCanTranslatePath(false, "zip");
-        assertCanTranslatePath(false, "7zip");
-        assertCanTranslatePath(false, "7z");
-        assertCanTranslatePath(false, "gzip");
-        assertCanTranslatePath(false, "tar");
-        assertCanTranslatePath(false, "gz");
-        assertCanTranslatePath(false, "rar");
-        assertCanTranslatePath(false, "pdf");
-        assertCanTranslatePath(false, "js");
-        assertCanTranslatePath(false, "css");
-        assertCanTranslatePath(true, "unknown");
     }
 
     public void testCanTranslate() {
@@ -73,24 +49,6 @@ public class HtmlCheckerTest extends TestCase {
         assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">");
         assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">");
         assertCanTranslate(true, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">");
-    }
-
-    private void assertCanTranslatePath(boolean expect, String ext) {
-        assertEquals(expect, htmlChecker.canTranslatePath("foo." + ext));
-        assertEquals(expect, htmlChecker.canTranslatePath("/foo." + ext));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=1"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=file.html"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "?query=file.png"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.html"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.png"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/dir/foo." + ext + "#hash.png?query=file.png&upload=file.html"));
-        assertEquals(true, htmlChecker.canTranslatePath("foo" + ext));
-        assertEquals(true, htmlChecker.canTranslatePath("/foo." + ext + "unknown"));
-        assertEquals(true, htmlChecker.canTranslatePath("/foo." + ext + "/"));
-        assertEquals(expect, htmlChecker.canTranslatePath("/foo.html/bar." + ext));
-        assertEquals(expect, htmlChecker.canTranslatePath("/foo.png/bar." + ext));
     }
 
     private void assertCanTranslate(boolean expect, String prefix) {


### PR DESCRIPTION
This PR makes two structural changes. The primary purpose is to clean `Headers.java` of legacy URL parsing code.

### Clean up legacy code in `Headers.java`
The Headers class has several fields and a lot of code related to request URL that we are removing.
```java
    String host;
    String pathName;
    String pathNameKeepTrailingSlash;
    String protocol;
    String pageUrl;
    String query;
    String url;
```
Only two of these fields are still in use outside of Headers, `pathName` and `pathNameKeepTrailingSlash`. They are used for purposes that need the _location of the current servlet context_.

For all other request URL handling, we need the _location originally requested by the client_. This URL handling is already moved to `UrlResolver.java` (and is now stored in Headers as `clientRequestUrlWithoutLangCode`).

Instead of the old `pathName` and `pathNameKeepTrailingSlash`, we now store `currentRequestPathWithoutLangCode` that is simply computed from `HttpServletRequest.getRequestURI()`.

That means we can remove all the old URL processing code that still resides in Headers' constructor.

### Create `FileExtensionMatcher.java`
`currentRequestPathWithoutLangCode` described above is used for checking if the request is for a file type that we cannot translate. This regex processing is currently included in `HtmlChecker.java`.

This PR simply moves the file extension regex processing out of HtmlChecker and into a dedicated file, since it's a separate concern from checking HTML content.

Regex processing remains the same except for one adjustment to image file extension matching: `(?!jp$)jpe?g?` is changed to `jpe|jpe?g` to match the same adjustment made to our other products.