### PR TITLE
Do nothing for invalid or previously processed requests

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -71,7 +71,8 @@ class Headers {
 
         boolean shouldAddLanguageCode = url != null
                                         && this.urlContext.isSameHost(url)
-                                        && this.urlLanguagePatternHandler.getLang(url.toString()).isEmpty();
+                                        && this.urlLanguagePatternHandler.getLang(url.toString()).isEmpty()
+                                        && this.urlLanguagePatternHandler.canInterceptUrl(url.toString());
 
         if (!shouldAddLanguageCode) return location;
 

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -30,7 +30,7 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return this.matchSitePrefixPathPattern.matcher(url).replaceFirst("$1$2$3/" + lang + "$4");
     }
 
-    public boolean isMatchingSitePrefixPath(String url) {
+    public boolean canInterceptUrl(String url) {
         return this.matchSitePrefixPathPattern.matcher(url).lookingAt();
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -10,7 +10,7 @@ abstract class UrlLanguagePatternHandler {
 
     abstract String insertLang(String url, String lang);
 
-    public boolean isMatchingSitePrefixPath(String url) {
+    public boolean canInterceptUrl(String url) {
         return true;
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -337,6 +337,7 @@ public class HeadersTest extends TestCase {
     private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath(requestPath);
         HashMap<String, String> option = new HashMap<String, String>() {{
+            put("urlPattern", "path");
             put("sitePrefixPath", sitePrefixPath);
         }};
         Settings s = TestUtil.makeSettings(option);

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -319,7 +319,7 @@ public class HeadersTest extends TestCase {
         assertEquals("https://example.com/th/", h.locationWithLangCode("https://example.com/th/"));
     }
 
-    public void testIsValidPath() throws ConfigurationError {
+    public void testGetIsValidRequest() throws ConfigurationError {
         Headers h;
         h = makeHeaderWithSitePrefixPath("/", "global");
         assertEquals(false, h.getIsValidRequest());

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -322,16 +322,16 @@ public class HeadersTest extends TestCase {
     public void testIsValidPath() throws ConfigurationError {
         Headers h;
         h = makeHeaderWithSitePrefixPath("/", "global");
-        assertEquals(false, h.getIsValidPath());
+        assertEquals(false, h.getIsValidRequest());
 
         h = makeHeaderWithSitePrefixPath("/global", "global");
-        assertEquals(true, h.getIsValidPath());
+        assertEquals(true, h.getIsValidRequest());
 
         h = makeHeaderWithSitePrefixPath("/global/ja/foo", "global");
-        assertEquals(true, h.getIsValidPath());
+        assertEquals(true, h.getIsValidRequest());
 
         h = makeHeaderWithSitePrefixPath("/ja/global/foo", "global");
-        assertEquals(false, h.getIsValidPath());
+        assertEquals(false, h.getIsValidRequest());
     }
 
     private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -128,31 +128,31 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testIsMatchSitePrefixPath__DefaultSettings() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
-        assertEquals(true, sut.isMatchingSitePrefixPath(""));
-        assertEquals(true, sut.isMatchingSitePrefixPath("?query"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix/ja"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix/ja?query"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("http://www.site.com"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("https://site.com/pre/fix/en/"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("site.com/no/page/index.html"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("site.com/no/page/index.html?query"));
+        assertEquals(true, sut.canInterceptUrl(""));
+        assertEquals(true, sut.canInterceptUrl("?query"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix/ja"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix/ja?query"));
+        assertEquals(true, sut.canInterceptUrl("http://www.site.com"));
+        assertEquals(true, sut.canInterceptUrl("https://site.com/pre/fix/en/"));
+        assertEquals(true, sut.canInterceptUrl("site.com/no/page/index.html"));
+        assertEquals(true, sut.canInterceptUrl("site.com/no/page/index.html?query"));
     }
 
     public void testIsMatchSitePrefixPath__UsingSitePrefixPath() {
         PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
-        assertEquals(false, sut.isMatchingSitePrefixPath(""));
-        assertEquals(false, sut.isMatchingSitePrefixPath("site.com"));
-        assertEquals(false, sut.isMatchingSitePrefixPath("site.com?query"));
-        assertEquals(false, sut.isMatchingSitePrefixPath("www.site.com/pre"));
-        assertEquals(false, sut.isMatchingSitePrefixPath("http://www.site.com/en/pre/fix"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix/"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix?query"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix/?query"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("/pre/fix/ja"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("https://site.com/pre/fix/en/"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("site.com/pre/fix/page/index.html"));
-        assertEquals(true, sut.isMatchingSitePrefixPath("site.com/pre/fix/page/index.html?query"));
+        assertEquals(false, sut.canInterceptUrl(""));
+        assertEquals(false, sut.canInterceptUrl("site.com"));
+        assertEquals(false, sut.canInterceptUrl("site.com?query"));
+        assertEquals(false, sut.canInterceptUrl("www.site.com/pre"));
+        assertEquals(false, sut.canInterceptUrl("http://www.site.com/en/pre/fix"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix/"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix?query"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix/?query"));
+        assertEquals(true, sut.canInterceptUrl("/pre/fix/ja"));
+        assertEquals(true, sut.canInterceptUrl("https://site.com/pre/fix/en/"));
+        assertEquals(true, sut.canInterceptUrl("site.com/pre/fix/page/index.html"));
+        assertEquals(true, sut.canInterceptUrl("site.com/pre/fix/page/index.html?query"));
     }
 
     public void testInsertLang__DefaultSettings() {


### PR DESCRIPTION
For some received requests, the filter needs to do nothing.

If the request has already been processed by wovnjava (and redirected, such that we receive it a second time), we should do nothing. We can assume that all necessary URL manipulation etc is already taken care of.

Also, if the request URL does not match the set of URLs that wovnjava is configured to process, we should not attempt to manipulate the URL by removing language code. We should instead do nothing. Such requests may happen if `sitePrefixPath` is set, and it will be relevant for Custom Domain.

This PR also changes a couple of names to be more general, so that we can more easily apply them to Custom Domain.