### PR TITLE
Base UrlContext on the current servlet context URL

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -17,8 +17,6 @@ class Headers {
     private final String requestLang;
     /* The URL that the client originally requested */
     private final String clientRequestUrlInDefaultLanguage;
-    /* The path of the current servlet context */
-    private final String currentContextPathInDefaultLanguage;
 
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidRequest;
@@ -29,18 +27,17 @@ class Headers {
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
         String clientRequestUrl = UrlResolver.computeClientRequestUrl(request, settings);
-
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
 
+        String currentContextUrl = request.getRequestURL().toString();
+        String currentContextUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(currentContextUrl, this.requestLang);
+
         try {
-            this.urlContext = new UrlContext(new URL(this.clientRequestUrlInDefaultLanguage));
+            this.urlContext = new UrlContext(new URL(currentContextUrlInDefaultLanguage));
         } catch (MalformedURLException e) {
             this.urlContext = null;
         }
-
-        String currentContextPath = request.getRequestURI();
-        this.currentContextPathInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(currentContextPath, this.requestLang);
 
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
 
@@ -99,7 +96,7 @@ class Headers {
     }
 
     public String getCurrentContextPathInDefaultLanguage() {
-        return this.currentContextPathInDefaultLanguage;
+        return this.urlContext.getURL().getPath();
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
@@ -12,6 +12,10 @@ class UrlContext {
         this.context = currentLocation;
     }
 
+    public URL getURL() {
+        return this.context;
+    }
+
     public URL resolve(String location) {
         try {
             URL url = new URL(this.context, location);


### PR DESCRIPTION
### Internal forwarding
UrlContext is used as base URL for forwarding relative URLs internally.

We intercept the forwarding call because we want to make sure to strip Wovn language code from the current URL context, such that it is as transparent as possible to introduce wovnjava to an existing server.

Currently, UrlContext is based on the client request URL. However, if the request has been altered by a reverse proxy, the current URL context may be different from the original request, and our "base URL" may be incorrect at the point where the internal forwarding happens.

### Solution
I want to change the UrlContext object to be based on the location of the current internal context.

In summary, when manipulating a request URL that may have changed, I think we should
1) Determine the language of the request from the original URL sent by the client.
2) "Strip language" only from the current context URL, if possible.

_Note: We will not try to hide language code from the original URL sent by the client._

### Examples
**Example 1)** Successfully stripping language code from path

| url pattern | client request URL | URL received by wovnjava from reverse proxy |
|---|---|---|
| `path` | `http://site.com/en/cat.png` | `http://internal.site.com/en/cat.png` |

In this case, we determine from the client request URL that the language is `/en/`, and we can successfully strip that language code from the current context URL, such that the servlet below wovnjava will receive a request for the URL `http://internal.site.com/cat.png`.


**Example 2)** Not possible to strip language code from current context

| url pattern | client request URL | URL received by wovnjava from reverse proxy |
|---|---|---|
| `subdomain` | `http://en.site.com/cat.png` | `http://internal.site.com/cat.png` |

In this case, we determine from the client request URL that the language is `/en/`, but we _cannot_ successfully strip that language code from the current context URL. Therefore, we pass the URL as-is to the servlet below wovnjava, which will receive a request for the URL `http://internal.site.com/cat.png`.


