### PR TITLE
Centralize mock for HttpServletRequest

### DIFF
--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -53,7 +53,7 @@ public class ApiTest extends TestCase {
         }});
         UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
 
-        HttpServletRequest request = TestUtil.mockRequestPath("/ja/somepage/"); // mocks "https://example.com"
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/ja/somepage/");
         ResponseHeaders responseHeaders = mockResponseHeaders();
 
         Headers headers = new Headers(request, settings, urlLanguagePatternHandler);

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -37,105 +37,8 @@ public class HeadersTest extends TestCase {
         return TestUtil.makeConfigWithValidDefaults(parameters);
     }
 
-    private static HttpServletRequest mockRequestPath() {
-        return mockRequestPath("/ja/test");
-    }
-    private static HttpServletRequest mockRequestPath(String path) {
-        return mockRequestPath(path, "example.com");
-    }
-    private static HttpServletRequest mockRequestPath(String path, String host) {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn(host);
-        EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-    private static HttpServletRequest mockRequestSubdomain() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("ja.example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("ja.example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-    private static HttpServletRequest mockRequestQuery() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("wovn=ja").atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-
-    private static HttpServletRequest mockRequestQueryParameter() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("def=456&wovn=ja&abc=123").atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-
-    private static HttpServletRequest mockRequestServerPort() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(8080).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-    }
-
-    private static HttpServletRequest mockRequestOriginalHeaders() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn("/ja/test").atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getHeader("REDIRECT_URL")).andReturn("/foo/bar").atLeastOnce();
-        EasyMock.expect(mock.getHeader("REDIRECT_QUERY_STRING")).andReturn("baz=123").atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
-
-    }
-
     public void testHeaders() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/test");
         FilterConfig mockConfig = mockConfigPath();
 
         Settings s = new Settings(mockConfig);
@@ -146,7 +49,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testGetRequestLangPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/test");
         FilterConfig mockConfig = mockConfigPath();
 
         Settings s = new Settings(mockConfig);
@@ -157,7 +60,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testGetRequestLangSubdomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestSubdomain();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://ja.example.com/test");
         FilterConfig mockConfig = mockConfigSubdomain();
 
         Settings s = new Settings(mockConfig);
@@ -168,7 +71,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testGetRequestLangQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQuery();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/test?wovn=ja");
         FilterConfig mockConfig = mockConfigQuery();
 
         Settings s = new Settings(mockConfig);
@@ -179,7 +82,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testRemoveLangPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/test");
         FilterConfig mockConfig = mockConfigPath();
 
         Settings s = new Settings(mockConfig);
@@ -189,7 +92,7 @@ public class HeadersTest extends TestCase {
         assertEquals("example.com/test", h.removeLang("example.com/ja/test", null));
     }
     public void testRemoveLangSubdomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestSubdomain();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://ja.example.com/test");
         FilterConfig mockConfig = mockConfigSubdomain();
 
         Settings s = new Settings(mockConfig);
@@ -199,7 +102,7 @@ public class HeadersTest extends TestCase {
         assertEquals("example.com/test", h.removeLang("ja.example.com/test", null));
     }
     public void testRemoveLangQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQuery();
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/test?wovn=ja");
         FilterConfig mockConfig = mockConfigQuery();
 
         Settings s = new Settings(mockConfig);
@@ -216,7 +119,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithDefaultLangCode() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/signin");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/signin");
         FilterConfig mockConfig = mockConfigPath();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -227,7 +130,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/ja/dir/signin");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/dir/signin");
         FilterConfig mockConfig = mockConfigPath();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -244,7 +147,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithPathAndTrailingSlash() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/ja/dir/signin/");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/dir/signin/");
         FilterConfig mockConfig = mockConfigPath();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -256,7 +159,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithPathAndTopLevel() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/location.jsp?wovn=ja");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/location.jsp?wovn=ja");
         FilterConfig mockConfig = mockConfigQuery();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -265,7 +168,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/dir/signin?wovn=ja");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/dir/signin?wovn=ja");
         FilterConfig mockConfig = mockConfigQuery();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -284,7 +187,7 @@ public class HeadersTest extends TestCase {
     }
 
     public void testLocationWithSubdomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath("/dir/signin", "ja.example.com");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://ja.example.com/dir/signin");
         FilterConfig mockConfig = mockConfigSubdomain();
         Settings s = new Settings(mockConfig);
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
@@ -335,7 +238,7 @@ public class HeadersTest extends TestCase {
     }
 
     private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath(requestPath);
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com" + requestPath);
         HashMap<String, String> option = new HashMap<String, String>() {{
             put("urlPattern", "path");
             put("sitePrefixPath", sitePrefixPath);
@@ -353,7 +256,7 @@ public class HeadersTest extends TestCase {
             put("sitePrefixPath", "/home");
         }});
         UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-		HttpServletRequest request = TestUtil.mockRequestPath("/home?user=123");
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123");
         Headers sut = new Headers(request, settings, patternHandler);
 
 		HashMap<String, String> hreflangs = sut.getHreflangUrlMap();
@@ -371,7 +274,7 @@ public class HeadersTest extends TestCase {
             put("urlPattern", "query");
         }});
         UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-		HttpServletRequest request = TestUtil.mockRequestPath("/home?user=123");
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123");
         Headers sut = new Headers(request, settings, patternHandler);
 
 		HashMap<String, String> hreflangs = sut.getHreflangUrlMap();
@@ -388,7 +291,7 @@ public class HeadersTest extends TestCase {
             put("urlPattern", "subdomain");
         }});
         UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-		HttpServletRequest request = TestUtil.mockRequestPath("/home?user=123");
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123");
         Headers sut = new Headers(request, settings, patternHandler);
 
 		HashMap<String, String> hreflangs = sut.getHreflangUrlMap();

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -116,7 +116,7 @@ public class HtmlConverterTest extends TestCase {
             put("sitePrefixPath", "global");
         }};
         Settings settings = TestUtil.makeSettings(option);
-        HttpServletRequest mockRequest = mockRequestPath("/global/tokyo/", "site.com");
+        HttpServletRequest mockRequest = MockHttpServletRequest.create("https://site.com/global/tokyo/");
         UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
         Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
         HtmlConverter converter = new HtmlConverter(settings, original);
@@ -175,20 +175,5 @@ public class HtmlConverterTest extends TestCase {
 
     private String stripExtraSpaces(String html) {
         return html.replaceAll("\\s +", "").replaceAll(">\\s+<", "><");
-    }
-
-    private static HttpServletRequest mockRequestPath(String path, String host) {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn(host);
-        EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn(host).atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-
-        return mock;
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -2,7 +2,6 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.lang.IllegalArgumentException;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -23,7 +22,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/ja/", originalHtml, settings, mockApiSuccess(), mockResponseHeadersSuccess());
+        String html = translate("https://example.com/ja/", originalHtml, settings, mockApiSuccess(), mockResponseHeadersSuccess());
         String expect = "replaced html";
         assertEquals(expect, stripExtraSpaces(html));
     }
@@ -35,7 +34,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/ja/", originalHtml, settings, mockApiTimeout(), mockResponseHeadersTimeout());
+        String html = translate("https://example.com/ja/", originalHtml, settings, mockApiTimeout(), mockResponseHeadersTimeout());
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
                         "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
@@ -53,7 +52,7 @@ public class InterceptorTest extends TestCase {
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,fr");
         }});
-        String html = translate("/", originalHtml, settings, null, null);
+        String html = translate("https://example.com/", originalHtml, settings, null, null);
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
                         "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
@@ -64,8 +63,8 @@ public class InterceptorTest extends TestCase {
         assertEquals(expect, stripExtraSpaces(html));
     }
 
-    private String translate(String path, String html, Settings settings, Api api, ResponseHeaders responseHeaders) throws NoSuchMethodException, IllegalAccessException, IOException, ServletException, ConfigurationError {
-        HttpServletRequest request = mockRequestPath(path);
+    private String translate(String url, String html, Settings settings, Api api, ResponseHeaders responseHeaders) throws NoSuchMethodException, IllegalAccessException, IOException, ServletException, ConfigurationError {
+        HttpServletRequest request = MockHttpServletRequest.create(url);
         UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
         Interceptor interceptor = new Interceptor(new Headers(request, settings, urlLanguagePatternHandler), settings, api, responseHeaders);
         return interceptor.translate(html);
@@ -89,20 +88,6 @@ public class InterceptorTest extends TestCase {
         } catch (ApiException _) {
             throw new RuntimeException("Fail create mock");
         }
-        EasyMock.replay(mock);
-        return mock;
-    }
-
-    private HttpServletRequest mockRequestPath(String path) {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
@@ -1,0 +1,68 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.Vector;
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.lang.IllegalArgumentException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.RequestDispatcher;
+
+import org.easymock.EasyMock;
+
+public class MockHttpServletRequest {
+    private static int DefaultTestPort = 443;
+
+    public static HttpServletRequest create(String urlString) {
+        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
+        stubLocation(mock, parseURL(urlString));
+        stubHeaders(mock);
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    public static HttpServletRequest createWithForwardingDispatcher(String urlString, String forwardingPath, RequestDispatcher dispatcher) {
+        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
+        stubLocation(mock, parseURL(urlString));
+        stubHeaders(mock);
+        EasyMock.expect(mock.getRequestDispatcher(forwardingPath)).andReturn(dispatcher);
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private static URL parseURL(String urlString) {
+        URL url;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Malformed url: " + urlString);
+        }
+        return url;
+    }
+
+    private static void stubLocation(HttpServletRequest mock, URL url) {
+        boolean isPortDeclared = url.getPort() != -1;
+        int port = isPortDeclared ? url.getPort() : MockHttpServletRequest.DefaultTestPort;
+
+        EasyMock.expect(mock.getScheme()).andReturn(url.getProtocol()).anyTimes();
+        EasyMock.expect(mock.getRequestURI()).andReturn(url.getPath()).anyTimes();
+        EasyMock.expect(mock.getServletPath()).andReturn(url.getPath()).anyTimes();
+        EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer(url.toString())).anyTimes();
+        EasyMock.expect(mock.getServerName()).andReturn(url.getHost()).anyTimes();
+        EasyMock.expect(mock.getQueryString()).andReturn(url.getQuery()).anyTimes();
+        EasyMock.expect(mock.getServerPort()).andReturn(port).anyTimes();
+        EasyMock.expect(mock.getRemoteHost()).andReturn(url.getHost()).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+    }
+
+    private static void stubHeaders(HttpServletRequest mock) {
+        /* `X-Wovn-Lang` is a Header value that we mock with our HttpServletRequestWrapper (unless the Header value already exists) */
+        EasyMock.expect(mock.getHeader("X-Wovn-Lang")).andReturn(null).anyTimes();
+
+        /* Stub `X-Header-Test` for testing behavior of an existing Header value */
+        EasyMock.expect(mock.getHeader("X-Header-Test")).andReturn("x-header-test-value").anyTimes();
+        Vector headersVector = new Vector<String>();
+        headersVector.add("X-Header-Test");
+        EasyMock.expect(mock.getHeaderNames()).andReturn(headersVector.elements()).anyTimes();
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -57,25 +57,6 @@ public class TestUtil {
         return new Settings(makeConfigWithValidDefaults(options));
     }
 
-    public static HttpServletRequest mockRequestPath(String path) {
-        return mockRequestPath(path, null, new RequestDispatcherMock());
-    }
-
-    public static HttpServletRequest mockRequestPath(String path, String replacedPath, RequestDispatcherMock dispatcher) {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com");
-        EasyMock.expect(mock.getRequestURI()).andReturn(path).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("").atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getRequestDispatcher(replacedPath == null ? EasyMock.anyString() : replacedPath)).andReturn(dispatcher);
-        EasyMock.replay(mock);
-        return mock;
-    }
-
     public static HttpServletResponse mockResponse(String contentType, String encoding) throws IOException {
         return mockResponse(contentType, encoding, false);
     }
@@ -123,7 +104,8 @@ public class TestUtil {
 
     public static FilterChainMock doServletFilter(String contentType, String path, String forwardPath, HashMap<String, String> option, boolean isPreviouslyProcessed) throws ServletException, IOException {
         RequestDispatcherMock dispatcher = new RequestDispatcherMock();
-        HttpServletRequest req = mockRequestPath(path, forwardPath, dispatcher);
+        String requestUrl = "https://example.com" + path;
+        HttpServletRequest req = MockHttpServletRequest.createWithForwardingDispatcher(requestUrl, forwardPath, dispatcher);
         HttpServletResponse res = mockResponse(contentType, "", isPreviouslyProcessed);
         FilterConfig filterConfig = makeConfigWithValidDefaults(option);
         FilterChainMock filterChain = new FilterChainMock();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -2,7 +2,8 @@ package com.github.wovnio.wovnjava;
 
 import junit.framework.TestCase;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Enumeration;
 
 import org.easymock.EasyMock;
 
@@ -12,57 +13,15 @@ import javax.servlet.http.HttpServletRequest;
 public class WovnHttpServletRequestTest extends TestCase {
 
     private static HttpServletRequest mockRequestPath() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getRequestURI()).andReturn("/en/test").atLeastOnce();
-        EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer("/en/test")).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getServletPath()).andReturn("/en/test").atLeastOnce();
-        EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
-        EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-        return mock;
+        return MockHttpServletRequest.create("https://example.com/en/test");
     }
 
     private static HttpServletRequest mockRequestSubDomain() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("en.example.com").atLeastOnce();
-        EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer("/test")).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("en.example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn(null).atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
-        EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-        return mock;
+        return MockHttpServletRequest.create("https://en.example.com/test");
     }
 
     private static HttpServletRequest mockRequestQuery() {
-        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
-        EasyMock.expect(mock.getScheme()).andReturn("https").atLeastOnce();
-        EasyMock.expect(mock.getRemoteHost()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getRequestURI()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getRequestURL()).andReturn(new StringBuffer("/test")).atLeastOnce();
-        EasyMock.expect(mock.getServerName()).andReturn("example.com").atLeastOnce();
-        EasyMock.expect(mock.getQueryString()).andReturn("wovn=en").atLeastOnce();
-        EasyMock.expect(mock.getServerPort()).andReturn(443).atLeastOnce();
-        EasyMock.expect(mock.getServletPath()).andReturn("/test").atLeastOnce();
-        EasyMock.expect(mock.getHeaderNames()).andReturn(new Vector<String>().elements());
-        EasyMock.expect(mock.getHeader("X-Header-Key")).andReturn("x-header-value");
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
-        EasyMock.replay(mock);
-        return mock;
+        return MockHttpServletRequest.create("https://example.com/test?wovn=en");
     }
 
     private static FilterConfig mockConfigPath() {
@@ -226,7 +185,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("/test", wovnRequest.getRequestURL().toString());
+        assertEquals("https://example.com/test", wovnRequest.getRequestURL().toString());
     }
 
     public void testGetRequestURLWithSubDomain() throws ConfigurationError {
@@ -239,7 +198,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("/test", wovnRequest.getRequestURL().toString());
+        assertEquals("https://example.com/test", wovnRequest.getRequestURL().toString());
     }
 
     public void testGetRequestURLWithQuery() throws ConfigurationError {
@@ -252,7 +211,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("/test", wovnRequest.getRequestURL().toString());
+        assertEquals("https://example.com/test", wovnRequest.getRequestURL().toString());
     }
 
     public void testGetServletPathWithPath() throws ConfigurationError {
@@ -305,9 +264,11 @@ public class WovnHttpServletRequestTest extends TestCase {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
         assertEquals("en", wovnRequest.getHeader("X-Wovn-Lang"));
-        assertEquals("x-header-value", wovnRequest.getHeader("X-Header-Key"));
+        assertEquals("x-header-test-value", wovnRequest.getHeader("X-Header-Test"));
 
         Enumeration<String> reqHeaders = wovnRequest.getHeaderNames();
+        assertEquals(true, reqHeaders.hasMoreElements());
+        assertEquals("X-Header-Test", reqHeaders.nextElement());
         assertEquals(true, reqHeaders.hasMoreElements());
         assertEquals("X-Wovn-Lang", reqHeaders.nextElement());
     }
@@ -323,9 +284,11 @@ public class WovnHttpServletRequestTest extends TestCase {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
         assertEquals("en", wovnRequest.getHeader("X-Wovn-Lang"));
-        assertEquals("x-header-value", wovnRequest.getHeader("X-Header-Key"));
+        assertEquals("x-header-test-value", wovnRequest.getHeader("X-Header-Test"));
 
         Enumeration<String> reqHeaders = wovnRequest.getHeaderNames();
+        assertEquals(true, reqHeaders.hasMoreElements());
+        assertEquals("X-Header-Test", reqHeaders.nextElement());
         assertEquals(true, reqHeaders.hasMoreElements());
         assertEquals("X-Wovn-Lang", reqHeaders.nextElement());
     }


### PR DESCRIPTION
* Create a class for mocking HttpServletRequest objects in our tests. Remove the other `mockRequestPath` methods spread across our tests.
* Reduce implied defaults by making tests declare the full URL of the mocked request.