### PR TITLE
Rename URL variables to be generic

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -132,7 +132,7 @@ class Api {
 
     private String getApiBody(String lang, String body) throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder();
-        appendKeyValue(sb, "url=", headers.getClientRequestUrlWithoutLangCode());
+        appendKeyValue(sb, "url=", headers.getClientRequestUrlInDefaultLanguage());
         appendKeyValue(sb, "&token=", settings.projectToken);
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
@@ -155,7 +155,7 @@ class Api {
         appendValue(sb, "&body_hash=");
         appendValue(sb, hash(body.getBytes()));
         appendValue(sb, "&path=");
-        appendValue(sb, headers.getClientRequestPathWithoutLangCode());
+        appendValue(sb, headers.getClientRequestPathInDefaultLanguage());
         appendValue(sb, "&lang=");
         appendValue(sb, lang);
         appendValue(sb, "&version=wovnjava_");

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -16,9 +16,7 @@ class Headers {
     /* The language code found in the client request URL */
     private final String requestLang;
     /* The URL that the client originally requested */
-    private final String clientRequestUrlWithoutLangCode;
-    /* The path of the current servlet context */
-    private final String currentRequestPathWithoutLangCode;
+    private final String clientRequestUrlInDefaultLanguage;
 
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidRequest;
@@ -29,18 +27,17 @@ class Headers {
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
         String clientRequestUrl = UrlResolver.computeClientRequestUrl(request, settings);
-
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
-        this.clientRequestUrlWithoutLangCode = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
+        this.clientRequestUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
+
+        String currentContextUrl = request.getRequestURL().toString();
+        String currentContextUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(currentContextUrl, this.requestLang);
 
         try {
-            this.urlContext = new UrlContext(new URL(this.clientRequestUrlWithoutLangCode));
+            this.urlContext = new UrlContext(new URL(currentContextUrlInDefaultLanguage));
         } catch (MalformedURLException e) {
             this.urlContext = null;
         }
-
-        String currentRequestPath = request.getRequestURI();
-        this.currentRequestPathWithoutLangCode = this.urlLanguagePatternHandler.removeLang(currentRequestPath, this.requestLang);
 
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
 
@@ -90,16 +87,16 @@ class Headers {
         return this.requestLang;
     }
 
-    public String getClientRequestUrlWithoutLangCode() {
-        return this.clientRequestUrlWithoutLangCode;
+    public String getClientRequestUrlInDefaultLanguage() {
+        return this.clientRequestUrlInDefaultLanguage;
     }
 
-    public String getClientRequestPathWithoutLangCode() {
-        return UrlPath.getPath(this.clientRequestUrlWithoutLangCode);
+    public String getClientRequestPathInDefaultLanguage() {
+        return UrlPath.getPath(this.clientRequestUrlInDefaultLanguage);
     }
 
-    public String getCurrentRequestPathWithoutLangCode() {
-        return this.currentRequestPathWithoutLangCode;
+    public String getCurrentContextPathInDefaultLanguage() {
+        return this.urlContext.getURL().getPath();
     }
 
     public boolean getShouldRedirectToDefaultLang() {
@@ -114,11 +111,11 @@ class Headers {
         HashMap<String, String> hreflangs = new HashMap<String, String>();
         for (String supportedLang : this.settings.supportedLangs) {
             String hreflangCode = Lang.get(supportedLang).codeISO639_1;
-            String url = this.urlLanguagePatternHandler.insertLang(this.clientRequestUrlWithoutLangCode, supportedLang);
+            String url = this.urlLanguagePatternHandler.insertLang(this.clientRequestUrlInDefaultLanguage, supportedLang);
             hreflangs.put(hreflangCode, url);
         }
         String hreflangCodeDefaultLang = Lang.get(this.settings.defaultLang).codeISO639_1;
-        String urlDefaultLang = this.clientRequestUrlWithoutLangCode;
+        String urlDefaultLang = this.clientRequestUrlInDefaultLanguage;
         hreflangs.put(hreflangCodeDefaultLang, urlDefaultLang);
         return hreflangs;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -17,6 +17,8 @@ class Headers {
     private final String requestLang;
     /* The URL that the client originally requested */
     private final String clientRequestUrlInDefaultLanguage;
+    /* The path of the current servlet context */
+    private final String currentContextPathInDefaultLanguage;
 
     private final boolean shouldRedirectToDefaultLang;
     private final boolean isValidRequest;
@@ -27,17 +29,18 @@ class Headers {
         this.urlLanguagePatternHandler = urlLanguagePatternHandler;
 
         String clientRequestUrl = UrlResolver.computeClientRequestUrl(request, settings);
+
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(clientRequestUrl, this.requestLang);
 
-        String currentContextUrl = request.getRequestURL().toString();
-        String currentContextUrlInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(currentContextUrl, this.requestLang);
-
         try {
-            this.urlContext = new UrlContext(new URL(currentContextUrlInDefaultLanguage));
+            this.urlContext = new UrlContext(new URL(this.clientRequestUrlInDefaultLanguage));
         } catch (MalformedURLException e) {
             this.urlContext = null;
         }
+
+        String currentContextPath = request.getRequestURI();
+        this.currentContextPathInDefaultLanguage = this.urlLanguagePatternHandler.removeLang(currentContextPath, this.requestLang);
 
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
 
@@ -96,7 +99,7 @@ class Headers {
     }
 
     public String getCurrentContextPathInDefaultLanguage() {
-        return this.urlContext.getURL().getPath();
+        return this.currentContextPathInDefaultLanguage;
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
@@ -12,10 +12,6 @@ class UrlContext {
         this.context = currentLocation;
     }
 
-    public URL getURL() {
-        return this.context;
-    }
-
     public URL resolve(String location) {
         try {
             URL url = new URL(this.context, location);

--- a/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlContext.java
@@ -12,6 +12,10 @@ class UrlContext {
         this.context = currentLocation;
     }
 
+    public URL getURL() {
+        return this.context;
+    }
+
     public URL resolve(String location) {
         try {
             URL url = new URL(this.context, location);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -48,14 +48,14 @@ public class WovnServletFilter implements Filter {
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
         boolean canTranslateRequest = !requestOptions.getDisableMode() &&
-                                      !this.fileExtensionMatcher.isFile(headers.getCurrentRequestPathWithoutLangCode());
+                                      !this.fileExtensionMatcher.isFile(headers.getCurrentContextPathInDefaultLanguage());
 
         if (isRequestAlreadyProcessed || !headers.getIsValidRequest()) {
             /* Do nothing */
             chain.doFilter(request, response);
         } else if (headers.getShouldRedirectToDefaultLang()) {
             /* Send HTTP 302 redirect to equivalent URL without default language code */
-            ((HttpServletResponse) response).sendRedirect(headers.getClientRequestUrlWithoutLangCode());
+            ((HttpServletResponse) response).sendRedirect(headers.getClientRequestUrlInDefaultLanguage());
         } else if (canTranslateRequest) {
             /* Strip language code, pass on request, and attempt to translate the resulting response */
             tryTranslate(headers, requestOptions, (HttpServletRequest)request, (HttpServletResponse)response, chain);
@@ -78,7 +78,7 @@ public class WovnServletFilter implements Filter {
         responseHeaders.setApiStatus("Unused");
 
         if (settings.urlPattern.equals("path") && headers.getRequestLang().length() > 0) {
-            wovnRequest.getRequestDispatcher(headers.getCurrentRequestPathWithoutLangCode()).forward(wovnRequest, wovnResponse);
+            wovnRequest.getRequestDispatcher(headers.getCurrentContextPathInDefaultLanguage()).forward(wovnRequest, wovnResponse);
         } else {
             chain.doFilter(wovnRequest, wovnResponse);
         }


### PR DESCRIPTION
With Custom Domain, URLs in default language may include language code. This PR simply renames some variables to suit the new assumptions about the nature of our URLs.