### PR TITLE
Always forward to path in default language

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -18,7 +18,11 @@ class Headers {
     /* The URL that the client originally requested */
     private final String clientRequestUrlInDefaultLanguage;
 
+    /* Should send HTTP 302 redirect to page in default language */
     private final boolean shouldRedirectToDefaultLang;
+    /* Should forward the request internally to equivalent path in default language */
+    private boolean shouldForwardToPathInDefaultLanguage;
+
     private final boolean isValidRequest;
 
     Headers(HttpServletRequest request, Settings settings, UrlLanguagePatternHandler urlLanguagePatternHandler) {
@@ -37,6 +41,13 @@ class Headers {
             this.urlContext = new UrlContext(new URL(currentContextUrlInDefaultLanguage));
         } catch (MalformedURLException e) {
             this.urlContext = null;
+        }
+
+        try {
+            String currentContextPath = new URL(currentContextUrl).getPath();
+            this.shouldForwardToPathInDefaultLanguage = !currentContextPath.equalsIgnoreCase(this.getCurrentContextPathInDefaultLanguage());
+        } catch (MalformedURLException e) {
+            this.shouldForwardToPathInDefaultLanguage = false;
         }
 
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
@@ -101,6 +112,10 @@ class Headers {
 
     public boolean getShouldRedirectToDefaultLang() {
         return this.shouldRedirectToDefaultLang;
+    }
+
+    public boolean getShouldForwardToPathInDefaultLanguage() {
+        return this.shouldForwardToPathInDefaultLanguage;
     }
 
     public boolean getIsValidRequest() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -45,7 +45,7 @@ class Headers {
 
         try {
             String currentContextPath = new URL(currentContextUrl).getPath();
-            this.shouldForwardToPathInDefaultLanguage = !currentContextPath.equalsIgnoreCase(this.getCurrentContextPathInDefaultLanguage());
+            this.shouldForwardToPathInDefaultLanguage = !currentContextPath.equalsIgnoreCase(this.getCurrentContextUrlInDefaultLanguage().getPath());
         } catch (MalformedURLException e) {
             this.shouldForwardToPathInDefaultLanguage = false;
         }
@@ -106,8 +106,8 @@ class Headers {
         return UrlPath.getPath(this.clientRequestUrlInDefaultLanguage);
     }
 
-    public String getCurrentContextPathInDefaultLanguage() {
-        return this.urlContext.getURL().getPath();
+    public URL getCurrentContextUrlInDefaultLanguage() {
+        return this.urlContext.getURL();
     }
 
     public boolean getShouldRedirectToDefaultLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -21,7 +21,7 @@ class Headers {
     /* Should send HTTP 302 redirect to page in default language */
     private final boolean shouldRedirectToDefaultLang;
     /* Should forward the request internally to equivalent path in default language */
-    private boolean shouldForwardToPathInDefaultLanguage;
+    private boolean isPathInDefaultLanguage;
 
     private final boolean isValidRequest;
 
@@ -45,9 +45,9 @@ class Headers {
 
         try {
             String currentContextPath = new URL(currentContextUrl).getPath();
-            this.shouldForwardToPathInDefaultLanguage = !currentContextPath.equalsIgnoreCase(this.getCurrentContextUrlInDefaultLanguage().getPath());
+            this.isPathInDefaultLanguage = currentContextPath.equalsIgnoreCase(this.getCurrentContextUrlInDefaultLanguage().getPath());
         } catch (MalformedURLException e) {
-            this.shouldForwardToPathInDefaultLanguage = false;
+            this.isPathInDefaultLanguage = false;
         }
 
         this.shouldRedirectToDefaultLang = settings.urlPattern.equals("path") && this.requestLang.equals(settings.defaultLang);
@@ -114,8 +114,8 @@ class Headers {
         return this.shouldRedirectToDefaultLang;
     }
 
-    public boolean getShouldForwardToPathInDefaultLanguage() {
-        return this.shouldForwardToPathInDefaultLanguage;
+    public boolean getIsPathInDefaultLanguage() {
+        return this.isPathInDefaultLanguage;
     }
 
     public boolean getIsValidRequest() {

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -20,7 +20,7 @@ class Headers {
 
     /* Should send HTTP 302 redirect to page in default language */
     private final boolean shouldRedirectToDefaultLang;
-    /* Should forward the request internally to equivalent path in default language */
+    /* Is current context URL path the same as the equivalent path in default language */
     private boolean isPathInDefaultLanguage;
 
     private final boolean isValidRequest;

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -68,17 +68,6 @@ public class WovnHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     @Override
-    public String getRequestURI() {
-        String uri = super.getRequestURI();
-        if (!headers.settings.urlPattern.equals("subdomain")) {
-            if (uri != null && uri.length() > 0) {
-                uri = headers.removeLang(uri, null);
-            }
-        }
-        return uri;
-    }
-
-    @Override
     public StringBuffer getRequestURL() {
         String url = super.getRequestURL().toString();
         url = this.headers.removeLang(url, null);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -60,17 +60,14 @@ public class WovnHttpServletRequest extends HttpServletRequestWrapper {
 
     @Override
     public String getServerName() {
-        String serverName = super.getServerName();
-        if (headers.settings.urlPattern.equals("subdomain")) {
-            serverName = headers.removeLang(serverName, null);
-        }
-        return serverName;
+        // `currentContextUrlInDefaultLanguage` is computed directly from `request.getRequestURL()`
+        // This implementation assumes that `getServerName()` will always give the hostname of `request.getRequestURL()`
+        return headers.getCurrentContextUrlInDefaultLanguage().getHost();
     }
 
     @Override
     public StringBuffer getRequestURL() {
-        String url = super.getRequestURL().toString();
-        url = this.headers.removeLang(url, null);
-        return new StringBuffer(url);
+        // `currentContextUrlInDefaultLanguage` is computed directly from `request.getRequestURL()`
+        return new StringBuffer(headers.getCurrentContextUrlInDefaultLanguage().toString());
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -84,13 +84,4 @@ public class WovnHttpServletRequest extends HttpServletRequestWrapper {
         url = this.headers.removeLang(url, null);
         return new StringBuffer(url);
     }
-
-    @Override
-    public String getServletPath() {
-        String path = super.getServletPath();
-        if (this.headers.settings.urlPattern.equals("path")) {
-            path = this.headers.removeLang(path, null);
-        }
-        return path;
-    }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -62,7 +62,11 @@ public class WovnServletFilter implements Filter {
         } else {
             /* Strip language code and pass through the request and response untouched */
             WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
-            chain.doFilter(wovnRequest, response);
+            if (headers.getShouldForwardToPathInDefaultLanguage()) {
+                wovnRequest.getRequestDispatcher(headers.getCurrentContextPathInDefaultLanguage()).forward(wovnRequest, response);
+            } else {
+                chain.doFilter(wovnRequest, response);
+            }
         }
     }
 
@@ -77,7 +81,7 @@ public class WovnServletFilter implements Filter {
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");
 
-        if (settings.urlPattern.equals("path") && headers.getRequestLang().length() > 0) {
+        if (headers.getShouldForwardToPathInDefaultLanguage()) {
             wovnRequest.getRequestDispatcher(headers.getCurrentContextPathInDefaultLanguage()).forward(wovnRequest, wovnResponse);
         } else {
             chain.doFilter(wovnRequest, wovnResponse);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -62,10 +62,10 @@ public class WovnServletFilter implements Filter {
         } else {
             /* Strip language code and pass through the request and response untouched */
             WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
-            if (headers.getShouldForwardToPathInDefaultLanguage()) {
-                wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, response);
-            } else {
+            if (headers.getIsPathInDefaultLanguage()) {
                 chain.doFilter(wovnRequest, response);
+            } else {
+                wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, response);
             }
         }
     }
@@ -81,10 +81,10 @@ public class WovnServletFilter implements Filter {
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");
 
-        if (headers.getShouldForwardToPathInDefaultLanguage()) {
-            wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
-        } else {
+        if (headers.getIsPathInDefaultLanguage()) {
             chain.doFilter(wovnRequest, wovnResponse);
+        } else {
+            wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
         }
 
         String originalBody = wovnResponse.toString();

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -48,7 +48,7 @@ public class WovnServletFilter implements Filter {
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
         boolean canTranslateRequest = !requestOptions.getDisableMode() &&
-                                      !this.fileExtensionMatcher.isFile(headers.getCurrentContextPathInDefaultLanguage());
+                                      !this.fileExtensionMatcher.isFile(headers.getCurrentContextUrlInDefaultLanguage().getPath());
 
         if (isRequestAlreadyProcessed || !headers.getIsValidRequest()) {
             /* Do nothing */
@@ -63,7 +63,7 @@ public class WovnServletFilter implements Filter {
             /* Strip language code and pass through the request and response untouched */
             WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest((HttpServletRequest)request, headers);
             if (headers.getShouldForwardToPathInDefaultLanguage()) {
-                wovnRequest.getRequestDispatcher(headers.getCurrentContextPathInDefaultLanguage()).forward(wovnRequest, response);
+                wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, response);
             } else {
                 chain.doFilter(wovnRequest, response);
             }
@@ -82,7 +82,7 @@ public class WovnServletFilter implements Filter {
         responseHeaders.setApiStatus("Unused");
 
         if (headers.getShouldForwardToPathInDefaultLanguage()) {
-            wovnRequest.getRequestDispatcher(headers.getCurrentContextPathInDefaultLanguage()).forward(wovnRequest, wovnResponse);
+            wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
         } else {
             chain.doFilter(wovnRequest, wovnResponse);
         }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -136,45 +136,6 @@ public class WovnHttpServletRequestTest extends TestCase {
         assertEquals("example.com", wovnRequest.getServerName());
     }
 
-    public void testGetRequestURIWithPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
-        FilterConfig mockConfig = mockConfigPath();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getRequestURI());
-    }
-
-    public void testGetRequestURIWithSubDomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestSubDomain();
-        FilterConfig mockConfig = mockConfigSubDomain();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getRequestURI());
-    }
-
-    public void testGetRequestURIWithQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQuery();
-        FilterConfig mockConfig = mockConfigQuery();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getRequestURI());
-    }
-
     public void testGetRequestURLWithPath() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath();
         FilterConfig mockConfig = mockConfigPath();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -214,45 +214,6 @@ public class WovnHttpServletRequestTest extends TestCase {
         assertEquals("https://example.com/test", wovnRequest.getRequestURL().toString());
     }
 
-    public void testGetServletPathWithPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
-        FilterConfig mockConfig = mockConfigPath();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getServletPath());
-    }
-
-    public void testGetServletPathWithSubDomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestSubDomain();
-        FilterConfig mockConfig = mockConfigSubDomain();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getServletPath());
-    }
-
-    public void testGetServletPathWithQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQuery();
-        FilterConfig mockConfig = mockConfigQuery();
-
-        Settings settings = new Settings(mockConfig);
-        UrlLanguagePatternHandler urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
-        Headers headers = new Headers(mockRequest, settings, urlLanguagePatternHandler);
-
-        WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
-
-        assertEquals("/test", wovnRequest.getServletPath());
-    }
-
     public void testWovnLangHeaderWithPath() throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath();
         FilterConfig mockConfig = mockConfigPath();

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -16,15 +16,15 @@ import org.easymock.EasyMock;
 
 public class WovnServletFilterTest extends TestCase {
     public void testHtml() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/");
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", pathOption);
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("/", mock.req.getRequestURI());
     }
 
     public void testHtmlWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/");
+        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/", pathOption);
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
-        assertEquals("/", mock.req.getRequestURI());
+        assertEquals("https://example.com/", mock.req.getRequestURL().toString());
     }
 
     public void testHtmlWithQueryLang() throws ServletException, IOException {
@@ -40,27 +40,27 @@ public class WovnServletFilterTest extends TestCase {
     }
 
     public void testCss() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/dir/style.css");
+        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/dir/style.css", pathOption);
         assertEquals("text/css", mock.res.getContentType());
         assertEquals("/dir/style.css", mock.req.getRequestURI());
     }
 
     public void testCssWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css");
+        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css", pathOption);
         assertEquals("text/css", mock.res.getContentType());
-        assertEquals("/style.css", mock.req.getRequestURI());
+        assertEquals("https://example.com/style.css", mock.req.getRequestURL().toString());
     }
 
     public void testImage() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/image.png");
+        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/image.png", pathOption);
         assertEquals("image/png", mock.res.getContentType());
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
     public void testImageWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png");
+        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png", pathOption);
         assertEquals("image/png", mock.res.getContentType());
-        assertEquals("/image.png", mock.req.getRequestURI());
+        assertEquals("https://example.com/image.png", mock.req.getRequestURL().toString());
     }
 
     public void testProcessRequestOnce__RequestNotProcessed__ProcessRequest() throws ServletException, IOException {
@@ -92,6 +92,10 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals(true, responseObjectPassedToFilterChain instanceof HttpServletResponse);
         assertEquals(false, responseObjectPassedToFilterChain instanceof WovnHttpServletResponse);
     }
+
+    private final HashMap<String, String> pathOption = new HashMap<String, String>() {{
+        put("urlPattern", "path");
+    }};
 
     private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
         put("urlPattern", "query");

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -58,7 +58,7 @@ public class WovnServletFilterTest extends TestCase {
     }
 
     public void testImageWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "image.png");
+        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png");
         assertEquals("image/png", mock.res.getContentType());
         assertEquals("/image.png", mock.req.getRequestURI());
     }


### PR DESCRIPTION
Currently when we intercept a request, we sometimes forward it with a different path (internally in the servlet container). This happens when the request path is different from the path in default language, such as when receiving `site.com/en/page.html` and `urlPattern = path`. We will forward that request to `site.com/page.html`.

However when we _don't_ need to translate the incoming request, such as for an image resource, we currently never forward it. Instead, the wrapper for the request object will try to hide language codes when accessing information about the path.

Hiding language codes from the getters on the request object is difficult because of how the servlet context influences the correct response, particularly for getters on the URL path. This stackoverflow post illustrates the meaning of some of these getters https://stackoverflow.com/a/21046620.

### Solution
Whenever the request has a path that is different from the equivalent path in default language, we want to forward it to the default language. That way, the servlet container will create the correct request object, and we do not have to wrap the getters for path information.

We still want to wrap the information about hostname, so we keep the `@Override` functions for `getServerName` and `getRequestURL`.