### PR TITLE
Ignore URL language codes that are not declared in supportedLangs

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -19,7 +19,7 @@ class Headers {
     private final String clientRequestUrlInDefaultLanguage;
 
     /* Should send HTTP 302 redirect to page in default language */
-    private final boolean shouldRedirectToDefaultLang;
+    private final boolean shouldRedirectExplicitDefaultLangUrl;
     /* Is current context URL path the same as the equivalent path in default language */
     private boolean isPathInDefaultLanguage;
 
@@ -51,7 +51,7 @@ class Headers {
             this.isPathInDefaultLanguage = false;
         }
 
-        this.shouldRedirectToDefaultLang = this.urlLanguagePatternHandler.shouldRedirectToDefaultLang(clientRequestUrl);
+        this.shouldRedirectExplicitDefaultLangUrl = this.urlLanguagePatternHandler.shouldRedirectExplicitDefaultLangUrl(clientRequestUrl);
 
         this.isValidRequest = this.urlContext != null && this.urlLanguagePatternHandler.canInterceptUrl(clientRequestUrl);
     }
@@ -101,8 +101,8 @@ class Headers {
         return this.urlContext.getURL();
     }
 
-    public boolean getShouldRedirectToDefaultLang() {
-        return this.shouldRedirectToDefaultLang;
+    public boolean getShouldRedirectExplicitDefaultLangUrl() {
+        return this.shouldRedirectExplicitDefaultLangUrl;
     }
 
     public boolean getIsPathInDefaultLanguage() {

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -16,10 +16,9 @@ class Interceptor {
     }
 
     String translate(String body) {
-        String lang = headers.getRequestLang();
-        boolean canTranslate = lang.length() > 0 && !lang.equals(settings.defaultLang.code);
-        if (canTranslate) {
-            return apiTranslate(lang, body);
+        Lang lang = headers.getRequestLang();
+        if (lang != settings.defaultLang) {
+            return apiTranslate(lang.code, body);
         } else {
             return localTranslate(settings.defaultLang.code, body);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -1,14 +1,19 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
     private String sitePrefixPath;
     private Pattern getLangPattern;
     private Pattern matchSitePrefixPathPattern;
 
-    PathUrlLanguagePatternHandler(String sitePrefixPath) {
+    PathUrlLanguagePatternHandler(Lang defaultLang, ArrayList<Lang> supportedLangs, String sitePrefixPath) {
+        this.defaultLang = defaultLang;
+        this.supportedLangs = supportedLangs;
         this.sitePrefixPath = sitePrefixPath;
         this.getLangPattern = this.buildGetLangPattern(sitePrefixPath);
         this.matchSitePrefixPathPattern = this.buildMatchSitePrefixPathPattern(sitePrefixPath);

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -44,7 +44,7 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
      * Redirect to same URL without language code if the language code
      * found in the URL path is for default language
      */
-    public boolean shouldRedirectToDefaultLang(String url) {
+    public boolean shouldRedirectExplicitDefaultLangUrl(String url) {
         Lang pathLang = this.getLangMatch(url, this.getLangPattern);
         return pathLang == this.defaultLang;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -19,8 +19,9 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         this.matchSitePrefixPathPattern = this.buildMatchSitePrefixPathPattern(sitePrefixPath);
     }
 
-    String getLang(String url) {
-        return this.getLangMatch(url, this.getLangPattern);
+    Lang getLang(String url) {
+        Lang lang = this.getLangMatch(url, this.getLangPattern);
+        return (lang != null && this.supportedLangs.contains(lang)) ? lang : null;
     }
 
     String removeLang(String url, String lang) {
@@ -37,6 +38,15 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
 
     public boolean canInterceptUrl(String url) {
         return this.matchSitePrefixPathPattern.matcher(url).lookingAt();
+    }
+
+    /*
+     * Redirect to same URL without language code if the language code
+     * found in the URL path is for default language
+     */
+    public boolean shouldRedirectToDefaultLang(String url) {
+        Lang pathLang = this.getLangMatch(url, this.getLangPattern);
+        return pathLang == this.defaultLang;
     }
 
     private Pattern buildGetLangPattern(String sitePrefixPath) {

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -16,8 +16,9 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         this.hasQueryPattern = Pattern.compile("\\?");
     }
 
-    String getLang(String url) {
-        return this.getLangMatch(url, this.getLangPattern);
+    Lang getLang(String url) {
+        Lang lang = this.getLangMatch(url, this.getLangPattern);
+        return (lang != null && this.supportedLangs.contains(lang)) ? lang : null;
     }
 
     String removeLang(String url, String lang) {

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -1,12 +1,17 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
     private Pattern getLangPattern;
     private Pattern hasQueryPattern;
 
-    QueryUrlLanguagePatternHandler() {
+    QueryUrlLanguagePatternHandler(Lang defaultLang, ArrayList<Lang> supportedLangs) {
+        this.defaultLang = defaultLang;
+        this.supportedLangs = supportedLangs;
         this.getLangPattern = this.buildGetLangPattern();
         this.hasQueryPattern = Pattern.compile("\\?");
     }

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -1,11 +1,16 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
     private Pattern getLangPattern;
 
-    SubdomainUrlLanguagePatternHandler() {
+    SubdomainUrlLanguagePatternHandler(Lang defaultLang, ArrayList<Lang> supportedLangs) {
+        this.defaultLang = defaultLang;
+        this.supportedLangs = supportedLangs;
         this.getLangPattern = this.buildGetLangPattern();
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -14,8 +14,9 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         this.getLangPattern = this.buildGetLangPattern();
     }
 
-    String getLang(String url) {
-        return this.getLangMatch(url, this.getLangPattern);
+    Lang getLang(String url) {
+        Lang lang = this.getLangMatch(url, this.getLangPattern);
+        return (lang != null && this.supportedLangs.contains(lang)) ? lang : null;
     }
 
     String removeLang(String url, String lang) {
@@ -43,4 +44,3 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return p;
     }
 }
-

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -4,7 +4,11 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 abstract class UrlLanguagePatternHandler {
-    abstract String getLang(String url);
+    /*
+     * Return the language declared by the url,
+     * or null if the url does not specify a valid language
+     */
+    abstract Lang getLang(String url);
 
     abstract String removeLang(String url, String lang);
 
@@ -14,15 +18,16 @@ abstract class UrlLanguagePatternHandler {
         return true;
     }
 
-    protected String getLangMatch(String url, Pattern pattern) {
+    public boolean shouldRedirectToDefaultLang(String url) {
+        return false;
+    }
+
+    protected Lang getLangMatch(String url, Pattern pattern) {
         Matcher matcher = pattern.matcher(url);
         if (matcher.find()) {
             String langMatch = matcher.group(1);
-            Lang lang = Lang.get(langMatch);
-            if (lang != null) {
-                return lang.code;
-            }
+            return Lang.get(langMatch);
         }
-        return "";
+        return null;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -18,7 +18,7 @@ abstract class UrlLanguagePatternHandler {
         return true;
     }
 
-    public boolean shouldRedirectToDefaultLang(String url) {
+    public boolean shouldRedirectExplicitDefaultLangUrl(String url) {
         return false;
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -1,19 +1,21 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
+
 final class UrlLanguagePatternHandlerFactory {
     private UrlLanguagePatternHandlerFactory() {}
 
     public static UrlLanguagePatternHandler create(Settings settings) throws ConfigurationError {
-        return create(settings.urlPattern, settings.sitePrefixPath);
+        return create(settings.defaultLang, settings.supportedLangs, settings.urlPattern, settings.sitePrefixPath);
     }
 
-    public static UrlLanguagePatternHandler create(String urlPattern, String sitePrefixPath) throws ConfigurationError {
+    public static UrlLanguagePatternHandler create(Lang defaultLang, ArrayList<Lang> supportedLangs, String urlPattern, String sitePrefixPath) throws ConfigurationError {
         if ("path".equalsIgnoreCase(urlPattern)) {
-            return new PathUrlLanguagePatternHandler(sitePrefixPath);
+            return new PathUrlLanguagePatternHandler(defaultLang, supportedLangs, sitePrefixPath);
         } else if ("query".equalsIgnoreCase(urlPattern)) {
-            return new QueryUrlLanguagePatternHandler();
+            return new QueryUrlLanguagePatternHandler(defaultLang, supportedLangs);
         } else if ("subdomain".equalsIgnoreCase(urlPattern)) {
-            return new SubdomainUrlLanguagePatternHandler();
+            return new SubdomainUrlLanguagePatternHandler(defaultLang, supportedLangs);
         } else {
             throw new ConfigurationError("Invalid url pattern: " + urlPattern);
         }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -19,7 +19,7 @@ public class WovnHttpServletRequest extends HttpServletRequestWrapper {
         headers = h;
 
         this.customHeaders = new HashMap<String, String>() {{
-            put("X-Wovn-Lang", headers.langCode());
+            put("X-Wovn-Lang", headers.getRequestLang().code);
         }};
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -53,7 +53,7 @@ public class WovnServletFilter implements Filter {
         if (isRequestAlreadyProcessed || !headers.getIsValidRequest()) {
             /* Do nothing */
             chain.doFilter(request, response);
-        } else if (headers.getShouldRedirectToDefaultLang()) {
+        } else if (headers.getShouldRedirectExplicitDefaultLangUrl()) {
             /* Send HTTP 302 redirect to equivalent URL without default language code */
             ((HttpServletResponse) response).sendRedirect(headers.getClientRequestUrlInDefaultLanguage());
         } else if (canTranslateRequest) {

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -9,6 +9,11 @@ import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 
 public class HeadersTest extends TestCase {
+    private Lang japanese;
+
+    protected void setUp() throws Exception {
+        this.japanese = Lang.get("ja");
+    }
 
     private static FilterConfig mockConfigPath() {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
@@ -25,6 +30,8 @@ public class HeadersTest extends TestCase {
     private static FilterConfig mockConfigQuery() {
         HashMap<String, String> parameters = new HashMap<String, String>() {{
             put("urlPattern", "query");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,ja,zh-CHS");
         }};
         return TestUtil.makeConfigWithValidDefaults(parameters);
     }
@@ -56,7 +63,7 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getRequestLang());
+        assertEquals(this.japanese, h.getRequestLang());
     }
 
     public void testGetRequestLangSubdomain() throws ConfigurationError {
@@ -67,7 +74,7 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getRequestLang());
+        assertEquals(this.japanese, h.getRequestLang());
     }
 
     public void testGetRequestLangQuery() throws ConfigurationError {
@@ -78,7 +85,7 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("ja", h.getRequestLang());
+        assertEquals(this.japanese, h.getRequestLang());
     }
 
     public void testRemoveLangPath() throws ConfigurationError {
@@ -210,7 +217,7 @@ public class HeadersTest extends TestCase {
         assertEquals("http://example.com/global/ja/", h.locationWithLangCode("http://example.com/global/"));
         assertEquals("https://example.com/global/ja/", h.locationWithLangCode("https://example.com/global/"));
         assertEquals("https://example.com/global/ja/", h.locationWithLangCode("https://example.com/global/ja/"));
-        assertEquals("https://example.com/global/th/", h.locationWithLangCode("https://example.com/global/th/"));
+        assertEquals("https://example.com/global/ja/th/", h.locationWithLangCode("https://example.com/global/th/")); // `th` not in supportedLangs
         assertEquals("https://example.com/global/ja/tokyo/", h.locationWithLangCode("https://example.com/global/tokyo/"));
         assertEquals("https://example.com/global/ja/file.html", h.locationWithLangCode("https://example.com/global/file.html"));
         assertEquals("https://example.com/global/ja/file.html", h.locationWithLangCode("https://example.com/pics/../global/file.html"));

--- a/src/test/java/com/github/wovnio/wovnjava/LangTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/LangTest.java
@@ -19,6 +19,7 @@ public class LangTest extends TestCase {
 
     public void testGetLang__invalidCode() {
         assertEquals(null, Lang.get("jp"));
+        assertEquals(null, Lang.get(""));
     }
 
     public void testGetLang__null() {

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -6,66 +6,92 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class PathUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang english;
+    private Lang japanese;
+    private Lang french;
+
     private Lang defaultLang;
     private ArrayList<Lang> supportedLangs;
 
     protected void setUp() throws Exception {
-        this.defaultLang = Lang.get("en");
+        this.english = Lang.get("en");
+        this.japanese = Lang.get("ja");
+        this.french = Lang.get("fr");
+
+        this.defaultLang = this.english;
         this.supportedLangs = new ArrayList<Lang>();
-        this.supportedLangs.add(Lang.get("en"));
-        this.supportedLangs.add(Lang.get("ja"));
+        this.supportedLangs.add(this.english);
+        this.supportedLangs.add(this.japanese);
+        this.supportedLangs.add(this.french);
     }
 
     private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {
         return new PathUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs, sitePrefixPath);
     }
 
-    public void testGetLang__NonMatchingPath__ReturnEmptyLang() {
+    public void testGetLang__NonMatchingPath__ReturnNull() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
-        assertEquals("", sut.getLang(""));
-        assertEquals("", sut.getLang("/"));
-        assertEquals("", sut.getLang("?query"));
-        assertEquals("", sut.getLang("/page"));
-        assertEquals("", sut.getLang("site.com/page/index.html"));
-        assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
-        assertEquals("", sut.getLang("/page?wovn=en"));
-        assertEquals("", sut.getLang("site.com/French/"));
-        assertEquals("", sut.getLang("http://site.com/Suomi/page/index.html"));
+        assertEquals(null, sut.getLang(""));
+        assertEquals(null, sut.getLang("/"));
+        assertEquals(null, sut.getLang("?query"));
+        assertEquals(null, sut.getLang("/page"));
+        assertEquals(null, sut.getLang("site.com/page/index.html"));
+        assertEquals(null, sut.getLang("en.site.com/pre/fix/index.html"));
+        assertEquals(null, sut.getLang("/page?wovn=en"));
+        assertEquals(null, sut.getLang("site.com/French/"));
+        assertEquals(null, sut.getLang("http://site.com/Suomi/page/index.html"));
     }
 
-    public void testGetLang__MatchingPath__ReturnLangCode() {
+    public void testGetLang__MatchingPath__ValidSupportedLang__ReturnTargetLangObject() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
-        assertEquals("fr", sut.getLang("/fr"));
-        assertEquals("fr", sut.getLang("/fr/"));
-        assertEquals("fr", sut.getLang("/fr?wovn=en"));
-        assertEquals("fr", sut.getLang("/fr/?wovn=en"));
-        assertEquals("fr", sut.getLang("http://site.com/fr/page"));
-        assertEquals("fr", sut.getLang("https://site.com/fr/page/index.html"));
-        assertEquals("fr", sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
+        assertEquals(this.french, sut.getLang("/fr"));
+        assertEquals(this.french, sut.getLang("/fr/"));
+        assertEquals(this.french, sut.getLang("/fr?wovn=en"));
+        assertEquals(this.french, sut.getLang("/fr/?wovn=en"));
+        assertEquals(this.french, sut.getLang("http://site.com/fr/page"));
+        assertEquals(this.french, sut.getLang("https://site.com/fr/page/index.html"));
+        assertEquals(this.french, sut.getLang("en.site.com/fr/page/index.html?wovn=es"));
     }
 
-    public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnEmptyLang() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
-        assertEquals("", sut.getLang("site.com/fr"));
-        assertEquals("", sut.getLang("en.site.com/en/?wovn=en"));
-        assertEquals("", sut.getLang("/es/pre/fix/page/index.html"));
-        assertEquals("", sut.getLang("/pre/fr/fix/page/index.html"));
-        assertEquals("", sut.getLang("/pre/en/fix/page/index.html"));
-        assertEquals("", sut.getLang("/pre/fix/page/en/index.html"));
-        assertEquals("", sut.getLang("/pre/fix/french/page/index.html"));
-        assertEquals("", sut.getLang("https://en.site.com/en/page/"));
+    public void testGetLang__MatchingPath__NotSupportedLang__ReturnNull() {
+        PathUrlLanguagePatternHandler sut = createWithParams("");
+        assertEquals(null, sut.getLang("/no"));
+        assertEquals(null, sut.getLang("/sv/"));
+        assertEquals(null, sut.getLang("/pl?wovn=en"));
+        assertEquals(null, sut.getLang("/th/?wovn=en"));
+        assertEquals(null, sut.getLang("http://site.com/vi/page"));
+        assertEquals(null, sut.getLang("https://site.com/es/page/index.html"));
+        assertEquals(null, sut.getLang("en.site.com/it/page/index.html?wovn=es"));
     }
 
-    public void testGetLang__SitePrefixPath__MatchingPath__ReturnLangCode() {
+    public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnNull() {
         PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
-        assertEquals("fr", sut.getLang("site.com/pre/fix/fr"));
-        assertEquals("fr", sut.getLang("site.com/pre/fix/fr/"));
-        assertEquals("fr", sut.getLang("site.com/pre/fix/fr?query"));
-        assertEquals("fr", sut.getLang("site.com/pre/fix/fr/?query"));
-        assertEquals("fr", sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
-        assertEquals("fr", sut.getLang("/pre/fix/fr/index.html"));
-        assertEquals("fr", sut.getLang("/pre/fix/fr/page/index.html"));
-        assertEquals("fr", sut.getLang("https://en.site.com/pre/fix/fr/page/"));
+        assertEquals(null, sut.getLang("site.com/fr"));
+        assertEquals(null, sut.getLang("en.site.com/en/?wovn=en"));
+        assertEquals(null, sut.getLang("/es/pre/fix/page/index.html"));
+        assertEquals(null, sut.getLang("/pre/fr/fix/page/index.html"));
+        assertEquals(null, sut.getLang("/pre/en/fix/page/index.html"));
+        assertEquals(null, sut.getLang("/pre/fix/page/en/index.html"));
+        assertEquals(null, sut.getLang("/pre/fix/french/page/index.html"));
+        assertEquals(null, sut.getLang("https://en.site.com/en/page/"));
+    }
+
+    public void testGetLang__SitePrefixPath__MatchingPath__ValidSupportedLang__ReturnTargetLangObject() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        assertEquals(this.french, sut.getLang("site.com/pre/fix/fr"));
+        assertEquals(this.french, sut.getLang("site.com/pre/fix/fr/"));
+        assertEquals(this.french, sut.getLang("site.com/pre/fix/fr?query"));
+        assertEquals(this.french, sut.getLang("site.com/pre/fix/fr/?query"));
+        assertEquals(this.french, sut.getLang("en.site.com/pre/fix/fr/index.html?wovn=es"));
+        assertEquals(this.french, sut.getLang("/pre/fix/fr/index.html"));
+        assertEquals(this.french, sut.getLang("/pre/fix/fr/page/index.html"));
+        assertEquals(this.french, sut.getLang("https://en.site.com/pre/fix/fr/page/"));
+    }
+
+    public void testGetLang__SitePrefixPath__MatchingPath__NotSupportedLang__ReturnNull() {
+        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        assertEquals(null, sut.getLang("site.com/pre/fix/vi"));
+        assertEquals(null, sut.getLang("https://en.site.com/pre/fix/th/page/"));
     }
 
     public void testRemoveLang__NonMatchingPath__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -225,4 +225,17 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("http://site.com/home", sut.insertLang("http://site.com/home", "ja"));
         assertEquals("https://fr.site.co.uk?query", sut.insertLang("https://fr.site.co.uk?query", "ja"));
     }
+
+    public void testShouldRedirectExplicitDefaultLangUrl() {
+        PathUrlLanguagePatternHandler sut = create("");
+        assertEquals(true, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/en"));
+        assertEquals(true, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/en/"));
+        assertEquals(true, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/en/home"));
+
+        assertEquals(false, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/ja"));
+        assertEquals(false, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/ja/home"));
+        assertEquals(false, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/path/en/home"));
+        assertEquals(false, sut.shouldRedirectExplicitDefaultLangUrl("http://en.site.com/home"));
+        assertEquals(false, sut.shouldRedirectExplicitDefaultLangUrl("http://site.com/home?wovn=en"));
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -25,12 +25,12 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         this.supportedLangs.add(this.french);
     }
 
-    private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {
+    private PathUrlLanguagePatternHandler create(String sitePrefixPath) {
         return new PathUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs, sitePrefixPath);
     }
 
     public void testGetLang__NonMatchingPath__ReturnNull() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals(null, sut.getLang(""));
         assertEquals(null, sut.getLang("/"));
         assertEquals(null, sut.getLang("?query"));
@@ -43,7 +43,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__MatchingPath__ValidSupportedLang__ReturnTargetLangObject() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals(this.french, sut.getLang("/fr"));
         assertEquals(this.french, sut.getLang("/fr/"));
         assertEquals(this.french, sut.getLang("/fr?wovn=en"));
@@ -54,7 +54,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__MatchingPath__NotSupportedLang__ReturnNull() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals(null, sut.getLang("/no"));
         assertEquals(null, sut.getLang("/sv/"));
         assertEquals(null, sut.getLang("/pl?wovn=en"));
@@ -65,7 +65,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__SitePrefixPath__NonMatchingPath__ReturnNull() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals(null, sut.getLang("site.com/fr"));
         assertEquals(null, sut.getLang("en.site.com/en/?wovn=en"));
         assertEquals(null, sut.getLang("/es/pre/fix/page/index.html"));
@@ -77,7 +77,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__SitePrefixPath__MatchingPath__ValidSupportedLang__ReturnTargetLangObject() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals(this.french, sut.getLang("site.com/pre/fix/fr"));
         assertEquals(this.french, sut.getLang("site.com/pre/fix/fr/"));
         assertEquals(this.french, sut.getLang("site.com/pre/fix/fr?query"));
@@ -89,13 +89,13 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__SitePrefixPath__MatchingPath__NotSupportedLang__ReturnNull() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals(null, sut.getLang("site.com/pre/fix/vi"));
         assertEquals(null, sut.getLang("https://en.site.com/pre/fix/th/page/"));
     }
 
     public void testRemoveLang__NonMatchingPath__DoNotModify() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals("", sut.removeLang("", "ja"));
         assertEquals("?query", sut.removeLang("?query", "ja"));
         assertEquals("/", sut.removeLang("/", "ja"));
@@ -114,7 +114,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__MatchingSupportedLang__RemoveLangCode() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals("", sut.removeLang("/ja", "ja"));
         assertEquals("/", sut.removeLang("/ja/", "ja"));
         assertEquals("?query", sut.removeLang("/ja?query", "ja"));
@@ -133,7 +133,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__SitePrefixPath__NonMatchingPath__DoNotModify() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("/", sut.removeLang("/", "ja"));
         assertEquals("site.com", sut.removeLang("site.com", "ja"));
         assertEquals("site.com?query", sut.removeLang("site.com?query", "ja"));
@@ -149,7 +149,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__SitePrefixPath__MatchingSupportedLang__RemoveLangCode() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("/pre/fix", sut.removeLang("/pre/fix/ja", "ja"));
         assertEquals("/pre/fix?query", sut.removeLang("/pre/fix/ja?query", "ja"));
         assertEquals("/pre/fix/", sut.removeLang("/pre/fix/ja/", "ja"));
@@ -161,7 +161,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__EmptyLanguage__DoNotModify() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals("/", sut.removeLang("/", ""));
         assertEquals("site.com?wovn=en", sut.removeLang("site.com?wovn=en", ""));
         assertEquals("site.com/no/index.html", sut.removeLang("site.com/no/index.html", ""));
@@ -169,7 +169,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testIsMatchSitePrefixPath__DefaultSettings() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals(true, sut.canInterceptUrl(""));
         assertEquals(true, sut.canInterceptUrl("?query"));
         assertEquals(true, sut.canInterceptUrl("/pre/fix/ja"));
@@ -181,7 +181,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testIsMatchSitePrefixPath__UsingSitePrefixPath() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals(false, sut.canInterceptUrl(""));
         assertEquals(false, sut.canInterceptUrl("site.com"));
         assertEquals(false, sut.canInterceptUrl("site.com?query"));
@@ -198,7 +198,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testInsertLang__DefaultSettings() {
-        PathUrlLanguagePatternHandler sut = createWithParams("");
+        PathUrlLanguagePatternHandler sut = create("");
         assertEquals("/ja", sut.insertLang("", "ja"));
         assertEquals("/ja/", sut.insertLang("/", "ja"));
         assertEquals("/ja/path/index.html", sut.insertLang("/path/index.html", "ja"));
@@ -208,7 +208,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testInsertLang__UsingSitePrefixPath__MatchesSitePrefixPath() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("/pre/fix/ja", sut.insertLang("/pre/fix", "ja"));
         assertEquals("/pre/fix/ja/", sut.insertLang("/pre/fix/", "ja"));
         assertEquals("/pre/fix/ja/path/index.html", sut.insertLang("/pre/fix/path/index.html", "ja"));
@@ -217,7 +217,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testInsertLang__UsingSitePrefixPath__SitePrefixPathNotMatched() {
-        PathUrlLanguagePatternHandler sut = createWithParams("/pre/fix");
+        PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("", sut.insertLang("", "ja"));
         assertEquals("/", sut.insertLang("/", "ja"));
         assertEquals("/path/index.html", sut.insertLang("/path/index.html", "ja"));

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -1,9 +1,25 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
+
 import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class PathUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
+
+    protected void setUp() throws Exception {
+        this.defaultLang = Lang.get("en");
+        this.supportedLangs = new ArrayList<Lang>();
+        this.supportedLangs.add(Lang.get("en"));
+        this.supportedLangs.add(Lang.get("ja"));
+    }
+
+    private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {
+        return new PathUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs, sitePrefixPath);
+    }
+
     public void testGetLang__NonMatchingPath__ReturnEmptyLang() {
         PathUrlLanguagePatternHandler sut = createWithParams("");
         assertEquals("", sut.getLang(""));
@@ -182,9 +198,5 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("site.com/", sut.insertLang("site.com/", "ja"));
         assertEquals("http://site.com/home", sut.insertLang("http://site.com/home", "ja"));
         assertEquals("https://fr.site.co.uk?query", sut.insertLang("https://fr.site.co.uk?query", "ja"));
-    }
-
-    private PathUrlLanguagePatternHandler createWithParams(String sitePrefixPath) {
-        return new PathUrlLanguagePatternHandler(sitePrefixPath);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -6,38 +6,59 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class QueryUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang english;
+    private Lang japanese;
+    private Lang french;
+
     private Lang defaultLang;
     private ArrayList<Lang> supportedLangs;
 
     protected void setUp() throws Exception {
-        this.defaultLang = Lang.get("en");
+        this.english = Lang.get("en");
+        this.japanese = Lang.get("ja");
+        this.french = Lang.get("fr");
+
+        this.defaultLang = this.english;
         this.supportedLangs = new ArrayList<Lang>();
-        this.supportedLangs.add(Lang.get("en"));
-        this.supportedLangs.add(Lang.get("ja"));
+        this.supportedLangs.add(this.english);
+        this.supportedLangs.add(this.japanese);
+        this.supportedLangs.add(this.french);
     }
 
-    public void testGetLang__NonMatchingQuery__ReturnEmptyLang() {
+    public void testGetLang__NonMatchingQuery__ReturnNull() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("", sut.getLang("/"));
-        assertEquals("", sut.getLang("/en"));
-        assertEquals("", sut.getLang("/en/page?wovn&en"));
-        assertEquals("", sut.getLang("site.com/page/index.html"));
-        assertEquals("", sut.getLang("en.site.com/pre/fix/index.html"));
-        assertEquals("", sut.getLang("/page?language=en"));
-        assertEquals("", sut.getLang("/en/?wovn=Nederlands"));
-        assertEquals("", sut.getLang("http://site.com?wovn="));
+        assertEquals(null, sut.getLang("/"));
+        assertEquals(null, sut.getLang("/en"));
+        assertEquals(null, sut.getLang("/en/page?wovn&en"));
+        assertEquals(null, sut.getLang("site.com/page/index.html"));
+        assertEquals(null, sut.getLang("en.site.com/pre/fix/index.html"));
+        assertEquals(null, sut.getLang("/page?language=en"));
+        assertEquals(null, sut.getLang("/en/?wovn=Nederlands"));
+        assertEquals(null, sut.getLang("http://site.com?wovn="));
     }
 
-    public void testGetLang__MatchingQuery__ReturnLangCode() {
+    public void testGetLang__MatchingQuery__ValidSupportedLang__ReturnTargetLangObject() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("fr", sut.getLang("?wovn=fr"));
-        assertEquals("fr", sut.getLang("/?wovn=fr"));
-        assertEquals("fr", sut.getLang("/en/?wovn=fr"));
-        assertEquals("fr", sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
-        assertEquals("fr", sut.getLang("site.com?wovn=fr"));
-        assertEquals("fr", sut.getLang("site.com/?lang=en&wovn=fr"));
-        assertEquals("fr", sut.getLang("http://site.com/?wovn=fr"));
-        assertEquals("fr", sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
+        assertEquals(this.french, sut.getLang("?wovn=fr"));
+        assertEquals(this.french, sut.getLang("/?wovn=fr"));
+        assertEquals(this.french, sut.getLang("/en/?wovn=fr"));
+        assertEquals(this.french, sut.getLang("/en/?lang=es&wovn=fr&country=vi"));
+        assertEquals(this.french, sut.getLang("site.com?wovn=fr"));
+        assertEquals(this.french, sut.getLang("site.com/?lang=en&wovn=fr"));
+        assertEquals(this.french, sut.getLang("http://site.com/?wovn=fr"));
+        assertEquals(this.french, sut.getLang("en.site.com/es/page/index.html?wovn=fr"));
+    }
+
+    public void testGetLang__MatchingQuery__NotSupportedLang__ReturnNull() {
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
+        assertEquals(null, sut.getLang("?wovn=th"));
+        assertEquals(null, sut.getLang("/?wovn=vi"));
+        assertEquals(null, sut.getLang("/en/?wovn=sv"));
+        assertEquals(null, sut.getLang("/en/?lang=es&wovn=pl&country=vi"));
+        assertEquals(null, sut.getLang("site.com?wovn=no"));
+        assertEquals(null, sut.getLang("site.com/?lang=es&wovn=ar"));
+        assertEquals(null, sut.getLang("http://site.com/?wovn=it"));
+        assertEquals(null, sut.getLang("en.site.com/es/page/index.html?wovn=ar"));
     }
 
     public void testRemoveLang__NonMatchingQuery__DoNotModify() {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -1,11 +1,23 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
+
 import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class QueryUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
+
+    protected void setUp() throws Exception {
+        this.defaultLang = Lang.get("en");
+        this.supportedLangs = new ArrayList<Lang>();
+        this.supportedLangs.add(Lang.get("en"));
+        this.supportedLangs.add(Lang.get("ja"));
+    }
+
     public void testGetLang__NonMatchingQuery__ReturnEmptyLang() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("", sut.getLang("/"));
         assertEquals("", sut.getLang("/en"));
         assertEquals("", sut.getLang("/en/page?wovn&en"));
@@ -17,7 +29,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__MatchingQuery__ReturnLangCode() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("fr", sut.getLang("?wovn=fr"));
         assertEquals("fr", sut.getLang("/?wovn=fr"));
         assertEquals("fr", sut.getLang("/en/?wovn=fr"));
@@ -29,7 +41,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__NonMatchingQuery__DoNotModify() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.removeLang("/", "ja"));
         assertEquals("/page/index.html", sut.removeLang("/page/index.html", "ja"));
         assertEquals("?wovn=en", sut.removeLang("?wovn=en", "ja"));
@@ -39,7 +51,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__MatchingQuery__RemoveLangCode() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("", sut.removeLang("?wovn=ja", "ja"));
         assertEquals("/?search=pizza&lang=ja", sut.removeLang("/?search=pizza&wovn=ja&lang=ja", "ja"));
         assertEquals("site.com/page/index.html?wovn", sut.removeLang("site.com/page/index.html?wovn&wovn=ja", "ja"));
@@ -47,7 +59,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__EmptyLanguage__DoNotModify() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.removeLang("/", ""));
         assertEquals("site.com?wovn=en", sut.removeLang("site.com?wovn=en", ""));
         assertEquals("site.com/no/index.html", sut.removeLang("site.com/no/index.html", ""));
@@ -55,7 +67,7 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testInsertLang() {
-        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler();
+        QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/?wovn=ja", sut.insertLang("/", "ja"));
         assertEquals("/path/index.html?wovn=ja", sut.insertLang("/path/index.html", "ja"));
         assertEquals("site.com/home?q=123&wovn=ja", sut.insertLang("site.com/home?q=123", "ja"));

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -1,11 +1,23 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
+
 import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang defaultLang;
+    private ArrayList<Lang> supportedLangs;
+
+    protected void setUp() throws Exception {
+        this.defaultLang = Lang.get("en");
+        this.supportedLangs = new ArrayList<Lang>();
+        this.supportedLangs.add(Lang.get("en"));
+        this.supportedLangs.add(Lang.get("ja"));
+    }
+
     public void testGetLang__NonMatchingSubdomain__ReturnEmptyLang() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("", sut.getLang("/"));
         assertEquals("", sut.getLang("/en"));
         assertEquals("", sut.getLang("/en/page"));
@@ -17,7 +29,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testGetLang__MatchingSubdomain__ReturnLangCode() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("en", sut.getLang("en.site.com"));
         assertEquals("es", sut.getLang("es.site.com/"));
         assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
@@ -26,7 +38,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.removeLang("/", "en"));
         assertEquals("/en/path/index.php", sut.removeLang("/en/path/index.php", "en"));
         assertEquals("?lang=english", sut.removeLang("?lang=english", "en"));
@@ -37,7 +49,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__MatchingSubdomain__RemoveLangCode() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("site.com", sut.removeLang("en.site.com", "en"));
         assertEquals("site.com/", sut.removeLang("es.site.com/", "es"));
         assertEquals("http://site.com/", sut.removeLang("http://es.site.com/", "es"));
@@ -45,7 +57,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testRemoveLang__EmptyLanguage__DoNotModify() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.removeLang("/", ""));
         assertEquals("site.com?wovn=en", sut.removeLang("site.com?wovn=en", ""));
         assertEquals("site.com/no/index.html", sut.removeLang("site.com/no/index.html", ""));
@@ -53,7 +65,7 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
     }
 
     public void testInsertLang() {
-        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler();
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.insertLang("/", "ja"));
         assertEquals("/path/index.html", sut.insertLang("/path/index.html", "ja"));
         assertEquals("ja.site.com?q=none", sut.insertLang("site.com?q=none", "ja"));

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -6,35 +6,53 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang english;
+    private Lang japanese;
+    private Lang french;
+
     private Lang defaultLang;
     private ArrayList<Lang> supportedLangs;
 
     protected void setUp() throws Exception {
-        this.defaultLang = Lang.get("en");
+        this.english = Lang.get("en");
+        this.japanese = Lang.get("ja");
+        this.french = Lang.get("fr");
+
+        this.defaultLang = this.english;
         this.supportedLangs = new ArrayList<Lang>();
-        this.supportedLangs.add(Lang.get("en"));
-        this.supportedLangs.add(Lang.get("ja"));
+        this.supportedLangs.add(this.english);
+        this.supportedLangs.add(this.japanese);
+        this.supportedLangs.add(this.french);
     }
 
-    public void testGetLang__NonMatchingSubdomain__ReturnEmptyLang() {
+    public void testGetLang__NonMatchingSubdomain__ReturnNull() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("", sut.getLang("/"));
-        assertEquals("", sut.getLang("/en"));
-        assertEquals("", sut.getLang("/en/page"));
-        assertEquals("", sut.getLang("site.com/page/index.html"));
-        assertEquals("", sut.getLang("site.com/en/pre/fix/index.html"));
-        assertEquals("", sut.getLang("/page?language=en&wovn=fr"));
-        assertEquals("", sut.getLang("deutsch.site.com/page"));
-        assertEquals("", sut.getLang("http://site.com"));
+        assertEquals(null, sut.getLang("/"));
+        assertEquals(null, sut.getLang("/en"));
+        assertEquals(null, sut.getLang("/en/page"));
+        assertEquals(null, sut.getLang("site.com/page/index.html"));
+        assertEquals(null, sut.getLang("site.com/en/pre/fix/index.html"));
+        assertEquals(null, sut.getLang("/page?language=en&wovn=fr"));
+        assertEquals(null, sut.getLang("deutsch.site.com/page"));
+        assertEquals(null, sut.getLang("http://site.com"));
     }
 
-    public void testGetLang__MatchingSubdomain__ReturnLangCode() {
+    public void testGetLang__MatchingSubdomain__ValidSupportedLang__ReturnTargetLangObject() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("en", sut.getLang("en.site.com"));
-        assertEquals("es", sut.getLang("es.site.com/"));
-        assertEquals("fr", sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
-        assertEquals("en", sut.getLang("http://en.site.com/"));
-        assertEquals("en", sut.getLang("https://en.site.com?wovn=fr"));
+        assertEquals(this.english, sut.getLang("en.site.com"));
+        assertEquals(this.japanese, sut.getLang("ja.site.com/"));
+        assertEquals(this.french, sut.getLang("fr.site.com/en/page/index.html?lang=it&wovn=en"));
+        assertEquals(this.french, sut.getLang("http://fr.site.com/"));
+        assertEquals(this.japanese, sut.getLang("https://ja.site.com?wovn=fr"));
+    }
+
+    public void testGetLang__MatchingSubdomain__NotSupportedLang__ReturnNull() {
+        SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
+        assertEquals(null, sut.getLang("th.site.com"));
+        assertEquals(null, sut.getLang("es.site.com/"));
+        assertEquals(null, sut.getLang("sv.site.com/en/page/index.html?lang=it&wovn=en"));
+        assertEquals(null, sut.getLang("http://it.site.com/"));
+        assertEquals(null, sut.getLang("https://vi.site.com?wovn=fr"));
     }
 
     public void testRemoveLang__NonMatchingSubdomain__DoNotModify() {


### PR DESCRIPTION
When checking language code of a URL, ignore any language code that is not declared by the user in `supportedLangs` setting.

For example, if supported languages include only English and Japanese, do not consider the `/th/` in `http://site.com/th/page` as a Thai language code.

Also, refactor `getLang` to return Lang object instead of String, or null if no language code is found.