### PR TITLE
Always send complete URLs to UrlLanguagePatternHandlers

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -78,11 +78,15 @@ class Headers {
         return this.urlLanguagePatternHandler.insertLang(url.toString(), this.requestLang.code);
     }
 
-    String removeLang(String uri, String lang) {
-        if (lang == null || lang.length() == 0) {
-            lang = this.requestLang.code;
+    URL convertToDefaultLanguage(URL url) {
+        String uri = url.toString();
+        String lang = this.requestLang.code;
+        String urlInDefaultLang = this.urlLanguagePatternHandler.removeLang(uri, lang);
+        try {
+            return new URL(urlInDefaultLang);
+        } catch (MalformedURLException e) {
+            return url;
         }
-        return this.urlLanguagePatternHandler.removeLang(uri, lang);
     }
 
     public Lang getRequestLang() {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Collections;
 import java.util.List;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 public class WovnHttpServletRequest extends HttpServletRequestWrapper {
     private Headers headers;
@@ -52,10 +54,13 @@ public class WovnHttpServletRequest extends HttpServletRequestWrapper {
     @Override
     public String getRemoteHost() {
         String host = super.getRemoteHost();
-        if (headers.settings.urlPattern.equals("subdomain")) {
-            host = headers.removeLang(host, null);
+        URL url;
+        try {
+            url = headers.convertToDefaultLanguage(new URL("http://" + host));
+            return url.getHost();
+        } catch (MalformedURLException e) {
+            return host;
         }
-        return host;
     }
 
     @Override

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -1,12 +1,13 @@
 package com.github.wovnio.wovnjava;
 
-import junit.framework.TestCase;
-
-import org.easymock.EasyMock;
-
 import java.util.HashMap;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
 
 public class HeadersTest extends TestCase {
     private Lang japanese;
@@ -88,7 +89,7 @@ public class HeadersTest extends TestCase {
         assertEquals(this.japanese, h.getRequestLang());
     }
 
-    public void testRemoveLangPath() throws ConfigurationError {
+    public void testConvertToDefaultLanguage__PathPattern() throws ConfigurationError, MalformedURLException {
         HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/test");
         FilterConfig mockConfig = mockConfigPath();
 
@@ -96,9 +97,10 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("example.com/test", h.removeLang("example.com/ja/test", null));
+        URL url = new URL("http://example.com/ja/test");
+        assertEquals("http://example.com/test", h.convertToDefaultLanguage(url).toString());
     }
-    public void testRemoveLangSubdomain() throws ConfigurationError {
+    public void testConvertToDefaultLanguage__SubdomainPattern() throws ConfigurationError, MalformedURLException {
         HttpServletRequest mockRequest = MockHttpServletRequest.create("https://ja.example.com/test");
         FilterConfig mockConfig = mockConfigSubdomain();
 
@@ -106,9 +108,10 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("example.com/test", h.removeLang("ja.example.com/test", null));
+        URL url = new URL("http://ja.example.com/test");
+        assertEquals("http://example.com/test", h.convertToDefaultLanguage(url).toString());
     }
-    public void testRemoveLangQuery() throws ConfigurationError {
+    public void testConvertToDefaultLanguage__QueryPattern() throws ConfigurationError, MalformedURLException {
         HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/test?wovn=ja");
         FilterConfig mockConfig = mockConfigQuery();
 
@@ -116,13 +119,19 @@ public class HeadersTest extends TestCase {
         UrlLanguagePatternHandler ulph = UrlLanguagePatternHandlerFactory.create(s);
         Headers h = new Headers(mockRequest, s, ulph);
 
-        assertEquals("example.com/test", h.removeLang("example.com/test?wovn=ja", null));
+        URL url = new URL("http://example.com/test?wovn=ja");
+        assertEquals("http://example.com/test", h.convertToDefaultLanguage(url).toString());
     }
 
-    public void testSitePrefixPath() throws ConfigurationError {
+    public void testConvertToDefaultLanguage__PathPatternWithSitePrefixPath() throws ConfigurationError, MalformedURLException {
         Headers h = makeHeaderWithSitePrefixPath("/global/en/foo", "/global/");
-        assertEquals("/global/", h.removeLang("/global/en/", null));
-        assertEquals("/en/global/", h.removeLang("/en/global/", null));
+        URL url;
+
+        url = new URL("http://site.com/global/en/");
+        assertEquals("http://site.com/global/", h.convertToDefaultLanguage(url).toString());
+
+        url = new URL("http://site.com/en/global/");
+        assertEquals("http://site.com/en/global/", h.convertToDefaultLanguage(url).toString());
     }
 
     public void testLocationWithDefaultLangCode() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
@@ -29,6 +29,15 @@ public class MockHttpServletRequest {
         return mock;
     }
 
+    public static HttpServletRequest createWithRemoteHost(String urlString, String remoteHost) {
+        HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
+        stubLocation(mock, parseURL(urlString));
+        stubHeaders(mock);
+        EasyMock.expect(mock.getRemoteHost()).andReturn(remoteHost).atLeastOnce();
+        EasyMock.replay(mock);
+        return mock;
+    }
+
     private static URL parseURL(String urlString) {
         URL url;
         try {
@@ -50,7 +59,6 @@ public class MockHttpServletRequest {
         EasyMock.expect(mock.getServerName()).andReturn(url.getHost()).anyTimes();
         EasyMock.expect(mock.getQueryString()).andReturn(url.getQuery()).anyTimes();
         EasyMock.expect(mock.getServerPort()).andReturn(port).anyTimes();
-        EasyMock.expect(mock.getRemoteHost()).andReturn(url.getHost()).anyTimes();
         EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
         EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
     }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -58,8 +58,8 @@ public class WovnHttpServletRequestTest extends TestCase {
         assertNotNull(wovnRequest);
     }
 
-    public void testGetRemoteHostWithPath() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestPath();
+    public void testGetRemoteHost__PathPattern__DoNotModify() throws ConfigurationError {
+        HttpServletRequest mockRequest = MockHttpServletRequest.createWithRemoteHost("https://site.com/en/", "proxy.com");
         FilterConfig mockConfig = mockConfigPath();
 
         Settings settings = new Settings(mockConfig);
@@ -68,11 +68,11 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("example.com", wovnRequest.getRemoteHost());
+        assertEquals("proxy.com", wovnRequest.getRemoteHost());
     }
 
-    public void testGetRemoteHostWithSubDomain() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestSubDomain();
+    public void testGetRemoteHost__SubdomainPattern__RemoveLanguageCodeFromRemoteHost() throws ConfigurationError {
+        HttpServletRequest mockRequest = MockHttpServletRequest.createWithRemoteHost("https://en.site.com/", "en.proxy.com");
         FilterConfig mockConfig = mockConfigSubDomain();
 
         Settings settings = new Settings(mockConfig);
@@ -81,11 +81,11 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("example.com", wovnRequest.getRemoteHost());
+        assertEquals("proxy.com", wovnRequest.getRemoteHost());
     }
 
-    public void testGetRemoteHostWithQuery() throws ConfigurationError {
-        HttpServletRequest mockRequest = mockRequestQuery();
+    public void testGetRemoteHost__QueryPattern__DoNotModify() throws ConfigurationError {
+        HttpServletRequest mockRequest = MockHttpServletRequest.createWithRemoteHost("https://site.com/?wovn=en", "proxy.com");
         FilterConfig mockConfig = mockConfigQuery();
 
         Settings settings = new Settings(mockConfig);
@@ -94,7 +94,7 @@ public class WovnHttpServletRequestTest extends TestCase {
 
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(mockRequest, headers);
 
-        assertEquals("example.com", wovnRequest.getRemoteHost());
+        assertEquals("proxy.com", wovnRequest.getRemoteHost());
     }
 
     public void testGetServerNameWithPath() throws ConfigurationError {


### PR DESCRIPTION
We want to better control what our URL manipulation inputs and outputs are, so guarantee that our inputs are full URLs.

The only remaining incomplete URL sent as input to UrlLanguagePatternHandler originates from `WovnHttpServletRequest.getRemoteHost()`. This PR changes the way we ask to remove language from `request.getRemoteHost()`, such that the language handlers always receive full URLs.