### PR TITLE
Change insertLang to convertToTargetLanguage

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -75,7 +75,7 @@ class Headers {
 
         if (!shouldAddLanguageCode) return location;
 
-        return this.urlLanguagePatternHandler.insertLang(url.toString(), this.requestLang.code);
+        return this.urlLanguagePatternHandler.convertToTargetLanguage(url.toString(), this.requestLang);
     }
 
     URL convertToDefaultLanguage(URL url) {
@@ -119,7 +119,7 @@ class Headers {
         HashMap<String, String> hreflangs = new HashMap<String, String>();
         for (Lang supportedLang : this.settings.supportedLangs) {
             String hreflangCode = supportedLang.codeISO639_1;
-            String url = this.urlLanguagePatternHandler.insertLang(this.clientRequestUrlInDefaultLanguage, supportedLang.code);
+            String url = this.urlLanguagePatternHandler.convertToTargetLanguage(this.clientRequestUrlInDefaultLanguage, supportedLang);
             hreflangs.put(hreflangCode, url);
         }
         String hreflangCodeDefaultLang = this.settings.defaultLang.codeISO639_1;

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -34,6 +34,10 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     }
 
     String convertToTargetLanguage(String url, Lang lang) {
+        Lang currentLang = this.getLangMatch(url, this.getLangPattern);
+        if (currentLang != null && this.supportedLangs.contains(currentLang)) {
+            url = this.removeLang(url, currentLang.code);
+        }
         return this.insertLang(url, lang.code);
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandler.java
@@ -33,6 +33,10 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         }
     }
 
+    String convertToTargetLanguage(String url, Lang lang) {
+        return this.insertLang(url, lang.code);
+    }
+
     private String removeLang(String url, String lang) {
         if (lang.isEmpty()) return url;
 
@@ -41,7 +45,7 @@ class PathUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         return matcher.replaceFirst("$1$2$3$5");
     }
 
-    String insertLang(String url, String lang) {
+    private String insertLang(String url, String lang) {
         return this.matchSitePrefixPathPattern.matcher(url).replaceFirst("$1$2$3/" + lang + "$4");
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -30,6 +30,10 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         }
     }
 
+    String convertToTargetLanguage(String url, Lang lang) {
+        return this.insertLang(url, lang.code);
+    }
+
     private String removeLang(String url, String lang) {
         if (lang.isEmpty()) return url;
 
@@ -37,7 +41,7 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
                   .replaceAll("(\\?|&)$", "");
     }
 
-    String insertLang(String url, String lang) {
+    private String insertLang(String url, String lang) {
         if (this.hasQueryPattern.matcher(url).find()) {
             return url + "&wovn=" + lang;
         } else {

--- a/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandler.java
@@ -31,6 +31,10 @@ class QueryUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     }
 
     String convertToTargetLanguage(String url, Lang lang) {
+        Lang currentLang = this.getLangMatch(url, this.getLangPattern);
+        if (currentLang != null) {
+            url = this.removeLang(url, currentLang.code);
+        }
         return this.insertLang(url, lang.code);
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -28,6 +28,10 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         }
     }
 
+    String convertToTargetLanguage(String url, Lang lang) {
+        return this.insertLang(url, lang.code);
+    }
+
     private String removeLang(String url, String lang) {
         if (lang.isEmpty()) return url;
 
@@ -35,7 +39,7 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
                       .matcher(url).replaceFirst("$1");
     }
 
-    String insertLang(String url, String lang) {
+    private String insertLang(String url, String lang) {
         if (url.contains("://")) {
             return url.replaceFirst("://", "://" + lang + ".");
         } else if (url.startsWith("/")) {

--- a/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandler.java
@@ -29,6 +29,10 @@ class SubdomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
     }
 
     String convertToTargetLanguage(String url, Lang lang) {
+        Lang currentLang = this.getLangMatch(url, this.getLangPattern);
+        if (currentLang != null && this.supportedLangs.contains(currentLang)) {
+            url = this.removeLang(url, currentLang.code);
+        }
         return this.insertLang(url, lang.code);
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandler.java
@@ -12,7 +12,7 @@ abstract class UrlLanguagePatternHandler {
 
     abstract String convertToDefaultLanguage(String url);
 
-    abstract String insertLang(String url, String lang);
+    abstract String convertToTargetLanguage(String url, Lang lang);
 
     public boolean canInterceptUrl(String url) {
         return true;

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -189,17 +189,20 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals(true, sut.canInterceptUrl("site.com/pre/fix/page/index.html?query"));
     }
 
-    public void testInsertLang__DefaultSettings() {
+    public void testConvertToTargetLanguage__DefaultSettings() {
         PathUrlLanguagePatternHandler sut = create("");
         assertEquals("/ja", sut.convertToTargetLanguage("", this.japanese));
         assertEquals("/ja/", sut.convertToTargetLanguage("/", this.japanese));
         assertEquals("/ja/path/index.html", sut.convertToTargetLanguage("/path/index.html", this.japanese));
         assertEquals("site.com/ja/", sut.convertToTargetLanguage("site.com/", this.japanese));
+        assertEquals("site.com/ja/", sut.convertToTargetLanguage("site.com/ja/", this.japanese));
+        assertEquals("site.com/ja/", sut.convertToTargetLanguage("site.com/fr/", this.japanese));
+        assertEquals("site.com/ja/ru/", sut.convertToTargetLanguage("site.com/ru/", this.japanese));
         assertEquals("http://site.com/ja/home", sut.convertToTargetLanguage("http://site.com/home", this.japanese));
         assertEquals("https://fr.site.co.uk/ja?query", sut.convertToTargetLanguage("https://fr.site.co.uk?query", this.japanese));
     }
 
-    public void testInsertLang__UsingSitePrefixPath__MatchesSitePrefixPath() {
+    public void testConvertToTargetLanguage__UsingSitePrefixPath__MatchesSitePrefixPath() {
         PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("/pre/fix/ja", sut.convertToTargetLanguage("/pre/fix", this.japanese));
         assertEquals("/pre/fix/ja/", sut.convertToTargetLanguage("/pre/fix/", this.japanese));
@@ -208,7 +211,7 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("http://site.com/pre/fix/ja?query", sut.convertToTargetLanguage("http://site.com/pre/fix?query", this.japanese));
     }
 
-    public void testInsertLang__UsingSitePrefixPath__SitePrefixPathNotMatched() {
+    public void testConvertToTargetLanguage__UsingSitePrefixPath__SitePrefixPathNotMatched() {
         PathUrlLanguagePatternHandler sut = create("/pre/fix");
         assertEquals("", sut.convertToTargetLanguage("", this.japanese));
         assertEquals("/", sut.convertToTargetLanguage("/", this.japanese));

--- a/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/PathUrlLanguagePatternHandlerTest.java
@@ -191,31 +191,31 @@ public class PathUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testInsertLang__DefaultSettings() {
         PathUrlLanguagePatternHandler sut = create("");
-        assertEquals("/ja", sut.insertLang("", "ja"));
-        assertEquals("/ja/", sut.insertLang("/", "ja"));
-        assertEquals("/ja/path/index.html", sut.insertLang("/path/index.html", "ja"));
-        assertEquals("site.com/ja/", sut.insertLang("site.com/", "ja"));
-        assertEquals("http://site.com/ja/home", sut.insertLang("http://site.com/home", "ja"));
-        assertEquals("https://fr.site.co.uk/ja?query", sut.insertLang("https://fr.site.co.uk?query", "ja"));
+        assertEquals("/ja", sut.convertToTargetLanguage("", this.japanese));
+        assertEquals("/ja/", sut.convertToTargetLanguage("/", this.japanese));
+        assertEquals("/ja/path/index.html", sut.convertToTargetLanguage("/path/index.html", this.japanese));
+        assertEquals("site.com/ja/", sut.convertToTargetLanguage("site.com/", this.japanese));
+        assertEquals("http://site.com/ja/home", sut.convertToTargetLanguage("http://site.com/home", this.japanese));
+        assertEquals("https://fr.site.co.uk/ja?query", sut.convertToTargetLanguage("https://fr.site.co.uk?query", this.japanese));
     }
 
     public void testInsertLang__UsingSitePrefixPath__MatchesSitePrefixPath() {
         PathUrlLanguagePatternHandler sut = create("/pre/fix");
-        assertEquals("/pre/fix/ja", sut.insertLang("/pre/fix", "ja"));
-        assertEquals("/pre/fix/ja/", sut.insertLang("/pre/fix/", "ja"));
-        assertEquals("/pre/fix/ja/path/index.html", sut.insertLang("/pre/fix/path/index.html", "ja"));
-        assertEquals("site.com/pre/fix/ja/", sut.insertLang("site.com/pre/fix/", "ja"));
-        assertEquals("http://site.com/pre/fix/ja?query", sut.insertLang("http://site.com/pre/fix?query", "ja"));
+        assertEquals("/pre/fix/ja", sut.convertToTargetLanguage("/pre/fix", this.japanese));
+        assertEquals("/pre/fix/ja/", sut.convertToTargetLanguage("/pre/fix/", this.japanese));
+        assertEquals("/pre/fix/ja/path/index.html", sut.convertToTargetLanguage("/pre/fix/path/index.html", this.japanese));
+        assertEquals("site.com/pre/fix/ja/", sut.convertToTargetLanguage("site.com/pre/fix/", this.japanese));
+        assertEquals("http://site.com/pre/fix/ja?query", sut.convertToTargetLanguage("http://site.com/pre/fix?query", this.japanese));
     }
 
     public void testInsertLang__UsingSitePrefixPath__SitePrefixPathNotMatched() {
         PathUrlLanguagePatternHandler sut = create("/pre/fix");
-        assertEquals("", sut.insertLang("", "ja"));
-        assertEquals("/", sut.insertLang("/", "ja"));
-        assertEquals("/path/index.html", sut.insertLang("/path/index.html", "ja"));
-        assertEquals("site.com/", sut.insertLang("site.com/", "ja"));
-        assertEquals("http://site.com/home", sut.insertLang("http://site.com/home", "ja"));
-        assertEquals("https://fr.site.co.uk?query", sut.insertLang("https://fr.site.co.uk?query", "ja"));
+        assertEquals("", sut.convertToTargetLanguage("", this.japanese));
+        assertEquals("/", sut.convertToTargetLanguage("/", this.japanese));
+        assertEquals("/path/index.html", sut.convertToTargetLanguage("/path/index.html", this.japanese));
+        assertEquals("site.com/", sut.convertToTargetLanguage("site.com/", this.japanese));
+        assertEquals("http://site.com/home", sut.convertToTargetLanguage("http://site.com/home", this.japanese));
+        assertEquals("https://fr.site.co.uk?query", sut.convertToTargetLanguage("https://fr.site.co.uk?query", this.japanese));
     }
 
     public void testShouldRedirectExplicitDefaultLangUrl() {

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -79,13 +79,13 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("https://ja.site.com/ja/", sut.convertToDefaultLanguage("https://ja.site.com/ja/?wovn=ja"));
     }
 
-    public void testInsertLang() {
+    public void testConvertToTargetLanguage() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/?wovn=ja", sut.convertToTargetLanguage("/", this.japanese));
         assertEquals("/path/index.html?wovn=ja", sut.convertToTargetLanguage("/path/index.html", this.japanese));
         assertEquals("site.com/home?q=123&wovn=ja", sut.convertToTargetLanguage("site.com/home?q=123", this.japanese));
         assertEquals("http://site.com?wovn=ja", sut.convertToTargetLanguage("http://site.com", this.japanese));
-        // note that convertToTargetLanguage assumes URL without language code
-        assertEquals("http://site.com?wovn=fr&wovn=ja", sut.convertToTargetLanguage("http://site.com?wovn=fr", this.japanese));
+        assertEquals("http://site.com?wovn=ja", sut.convertToTargetLanguage("http://site.com?wovn=fr", this.japanese));
+        assertEquals("http://site.com?wovn=ja", sut.convertToTargetLanguage("http://site.com?wovn=ru", this.japanese));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/QueryUrlLanguagePatternHandlerTest.java
@@ -81,11 +81,11 @@ public class QueryUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testInsertLang() {
         QueryUrlLanguagePatternHandler sut = new QueryUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("/?wovn=ja", sut.insertLang("/", "ja"));
-        assertEquals("/path/index.html?wovn=ja", sut.insertLang("/path/index.html", "ja"));
-        assertEquals("site.com/home?q=123&wovn=ja", sut.insertLang("site.com/home?q=123", "ja"));
-        assertEquals("http://site.com?wovn=ja", sut.insertLang("http://site.com", "ja"));
-        // note that insertLang assumes URL without language code
-        assertEquals("http://site.com?wovn=fr&wovn=ja", sut.insertLang("http://site.com?wovn=fr", "ja"));
+        assertEquals("/?wovn=ja", sut.convertToTargetLanguage("/", this.japanese));
+        assertEquals("/path/index.html?wovn=ja", sut.convertToTargetLanguage("/path/index.html", this.japanese));
+        assertEquals("site.com/home?q=123&wovn=ja", sut.convertToTargetLanguage("site.com/home?q=123", this.japanese));
+        assertEquals("http://site.com?wovn=ja", sut.convertToTargetLanguage("http://site.com", this.japanese));
+        // note that convertToTargetLanguage assumes URL without language code
+        assertEquals("http://site.com?wovn=fr&wovn=ja", sut.convertToTargetLanguage("http://site.com?wovn=fr", this.japanese));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -74,14 +74,15 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("site.com/fr/index.html?lang=fr&wovn=fr", sut.convertToDefaultLanguage("fr.site.com/fr/index.html?lang=fr&wovn=fr"));
     }
 
-    public void testInsertLang() {
+    public void testConvertToTargetLanguage() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
         assertEquals("/", sut.convertToTargetLanguage("/", this.japanese));
         assertEquals("/path/index.html", sut.convertToTargetLanguage("/path/index.html", this.japanese));
         assertEquals("ja.site.com?q=none", sut.convertToTargetLanguage("site.com?q=none", this.japanese));
         assertEquals("http://ja.site.com?q=none", sut.convertToTargetLanguage("http://site.com?q=none", this.japanese));
         assertEquals("https://ja.user13.sub.site.co.jp/home", sut.convertToTargetLanguage("https://user13.sub.site.co.jp/home", this.japanese));
-        // note that convertToTargetLanguage assumes URL without language code
-        assertEquals("ja.ja.site.com", sut.convertToTargetLanguage("ja.site.com", this.japanese));
+        assertEquals("ja.site.com", sut.convertToTargetLanguage("ja.site.com", this.japanese));
+        assertEquals("ja.site.com", sut.convertToTargetLanguage("fr.site.com", this.japanese));
+        assertEquals("ja.ru.site.com", sut.convertToTargetLanguage("ru.site.com", this.japanese));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SubdomainUrlLanguagePatternHandlerTest.java
@@ -76,12 +76,12 @@ public class SubdomainUrlLanguagePatternHandlerTest extends TestCase {
 
     public void testInsertLang() {
         SubdomainUrlLanguagePatternHandler sut = new SubdomainUrlLanguagePatternHandler(this.defaultLang, this.supportedLangs);
-        assertEquals("/", sut.insertLang("/", "ja"));
-        assertEquals("/path/index.html", sut.insertLang("/path/index.html", "ja"));
-        assertEquals("ja.site.com?q=none", sut.insertLang("site.com?q=none", "ja"));
-        assertEquals("http://ja.site.com?q=none", sut.insertLang("http://site.com?q=none", "ja"));
-        assertEquals("https://ja.user13.sub.site.co.jp/home", sut.insertLang("https://user13.sub.site.co.jp/home", "ja"));
-        // note that insertLang assumes URL without language code
-        assertEquals("ja.ja.site.com", sut.insertLang("ja.site.com", "ja"));
+        assertEquals("/", sut.convertToTargetLanguage("/", this.japanese));
+        assertEquals("/path/index.html", sut.convertToTargetLanguage("/path/index.html", this.japanese));
+        assertEquals("ja.site.com?q=none", sut.convertToTargetLanguage("site.com?q=none", this.japanese));
+        assertEquals("http://ja.site.com?q=none", sut.convertToTargetLanguage("http://site.com?q=none", this.japanese));
+        assertEquals("https://ja.user13.sub.site.co.jp/home", sut.convertToTargetLanguage("https://user13.sub.site.co.jp/home", this.japanese));
+        // note that convertToTargetLanguage assumes URL without language code
+        assertEquals("ja.ja.site.com", sut.convertToTargetLanguage("ja.site.com", this.japanese));
     }
 }


### PR DESCRIPTION
Adjust interface to `insertLang` method
* Rename to `convertToTargetLanguage`
* Pass in a Lang object instead of language code string
* In existing pattern handlers, remove language code from input URL before inserting new language