### PR TITLE
Support Custom Domain configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ Set your WOVN.io Account's project token. This parameter is required.
 
 ### 2.3. urlPattern
 
-Within the Java Application, the library works by adding new URL's for translation. You can set the URL type by using the Url Pattern Parameter. There are 3 URL types that can be set.
+Within the Java Application, the library works by adding new URL's for translation. You can set the URL type by using the Url Pattern Parameter.
+Three default URL pattern types are available, plus a highly customizable Custom Domain option.
 
-parameters  | Translated page's URL           | Notes
------------ | ------------------------------- | ------
-'path'      | https://wovn.io/ja/contact      | Default Value. If no settings have been set, url_pattern defaults to this value.
-'subdomain' | https://ja.wovn.io/contact      | The server's DNS settings must be configured.
-'query'     | https://wovn.io/contact?wovn=ja | The least amount of changes to the application required to complete setup.
+The examples below are for the original URL `https://wovn.io/contact`, when visiting the page in korean (as a translated language).
 
-※ The previously mentioned URL's are examples of the following URL translated via the WOVN.io library. As can be seen, depending on the URL Parameter the url will change.
-
-    https://wovn.io/contact
+url pattern type | Translated page's URL           | Description
+---------------- | ------------------------------- | ------
+"path"           | https://wovn.io/ko/contact      | Language code is inserted as the first section of the path
+"subdomain"      | https://ko.wovn.io/contact      | Language code is inserted as the first subdomain. (The server's DNS settings must be configured for this option.)
+"query"          | https://wovn.io/contact?wovn=ko | Language code is inserted as a query parameter. (This option requires the least amount of changes to the application.)
+"customDomain"   | (see section 2.12 below)        | The custom domain option lets you define domain and path for each language independently.
 
 ### 2.5. defaultLang
 
@@ -245,7 +245,7 @@ By default, WOVN will translate all pages for your domain and process path langu
 
 #### Requirements
 
-This setting _must_ be used together with the `urlPattern = path` setting.
+This setting may only be used together with the `urlPattern = path` setting.
 
 Furthermore, it is highly recommended to also configure your `web.xml` with a corresponding filter-mapping for the wovnjava servlet filter. If prefix path is set to `city` as in the example above, the corresponding filter-mapping would look as follows.
 ```
@@ -256,7 +256,46 @@ Furthermore, it is highly recommended to also configure your `web.xml` with a co
 </filter-mapping>
 ```
 
-### 2.12. supportedLangs
+### 2.12. customDomainLangs
+
+This setting lets you define the domain and path that corresponds to each of your supported languages.
+
+The format of the setting is as follows
+```
+FORMAT: <baseURL>:<langCode>,<baseURL>:<langCode>,...
+
+EXAMPLE: www.site.co.jp:ja,www.site.com/english:en
+```
+Note that the `<baseURL>` has only host and a path prefix.
+Anything before the host, like `http://` should not be included, but subdomains must be included.
+
+For the example above, all request URLs that match `www.site.co.jp` will be considered as requests in Japanese langauge.
+All request URLs that match `www.site.com/english/*` will be considered as requests in English language.
+Requests that do not match a domain language, like for example `www.site.com/admin`, will not be processed by the wovnjava library.
+
+The `web.xml` configuration for the above example will look as follows
+```xml
+<filter>
+  ...
+  <init-param>
+    <param-name>urlPattern</param-name>
+    <param-value>customDomain</param-value>
+  </init-param>
+  <init-param>
+    <param-name>customDomainLangs</param-name>
+    <param-value>www.site.co.jp:ja,www.site.com/english:en</param-value>
+  </init-param>
+  ...
+</filter>
+```
+
+#### Requirements
+
+This setting may only be used together with the `urlPattern = customDomain` setting.
+
+Each custom domain language must also be represented in `supportedLangs`. And vice versa, if this setting is used, each language declared in `supportedLangs` must be given a custom domain.
+
+### 2.13. supportedLangs
 
 This parameter lists the set of languages for which the library performs translations.
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Set your WOVN.io Account's project token. This parameter is required.
 
 ### 2.3. urlPattern
 
-Within the Java Application, the library works by adding new URL's for translation. You can set the URL type by using the Url Pattern Parameter.
-Three default URL pattern types are available, plus a highly customizable Custom Domain option.
+Within the Java Application, the library works by adding new URL's for translation. You can set the URL type by using the urlPattern Parameter.
+Three basic URL pattern types are available, plus a highly customizable Custom Domain option.
 
 The examples below are for the original URL `https://wovn.io/contact`, when visiting the page in korean (as a translated language).
 
@@ -247,7 +247,7 @@ By default, WOVN will translate all pages for your domain and process path langu
 
 This setting may only be used together with the `urlPattern = path` setting.
 
-Furthermore, it is highly recommended to also configure your `web.xml` with a corresponding filter-mapping for the wovnjava servlet filter. If prefix path is set to `city` as in the example above, the corresponding filter-mapping would look as follows.
+Furthermore, it is highly recommended to also configure your `web.xml` with a corresponding filter-mapping for the WovnServletFilter. If prefix path is set to `city` as in the example above, the corresponding filter-mapping would look as follows.
 ```
 <filter-mapping>
   <filter-name>wovn</filter-name>
@@ -271,7 +271,7 @@ Anything before the host, like `http://` should not be included, but subdomains 
 
 For the example above, all request URLs that match `www.site.co.jp` will be considered as requests in Japanese langauge.
 All request URLs that match `www.site.com/english/*` will be considered as requests in English language.
-Requests that do not match a domain language, like for example `www.site.com/admin`, will not be processed by the wovnjava library.
+Requests that do not match a domain language, like for example `www.site.com/admin`, will not be processed by WovnServletFilter.
 
 The `web.xml` configuration for the above example will look as follows
 ```xml
@@ -293,7 +293,10 @@ The `web.xml` configuration for the above example will look as follows
 
 This setting may only be used together with the `urlPattern = customDomain` setting.
 
-Each custom domain language must also be represented in `supportedLangs`. And vice versa, if this setting is used, each language declared in `supportedLangs` must be given a custom domain.
+If this setting is used, each language declared in `supportedLangs` must be given a custom domain. Vice versa, each custom domain language must also be represented in `supportedLangs`.
+
+Lastly, the path declared for your original language must match the structure of the underlying web server.
+In other words, you cannot use this setting to change the request path of your content in original language.
 
 ### 2.13. supportedLangs
 

--- a/README.md
+++ b/README.md
@@ -266,14 +266,17 @@ FORMAT: <baseURL>:<langCode>,<baseURL>:<langCode>,...
 
 EXAMPLE: www.site.co.jp:ja,www.site.com/english:en
 ```
-Note that the `<baseURL>` has only host and a path prefix.
-Anything before the host, like `http://` should not be included, but subdomains must be included.
+Note that `<baseURL>` has only host and path prefix.
+Anything before the host, like `http://` should not be included. Port numbers should also not be included. However, all applicable subdomains must be included.
 
 For the example above, all request URLs that match `www.site.co.jp` will be considered as requests in Japanese langauge.
 All request URLs that match `www.site.com/english/*` will be considered as requests in English language.
 Requests that do not match a domain language, like for example `www.site.com/admin`, will not be processed by WovnServletFilter.
 
-The `web.xml` configuration for the above example will look as follows
+With the above example configuration, the page `http://www.site.co.jp/about.html` in english language will
+have the URL `http://www.site.com/english/about.html`.
+
+The corresponding `web.xml` configuration will look as follows
 ```xml
 <filter>
   ...

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -137,6 +137,7 @@ class Api {
         appendKeyValue(sb, "&lang_code=", lang);
         appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
         appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPath);
+        appendKeyValue(sb, "&custom_domain_langs=", CustomDomainLanguageSerializer.serializeToJson(settings.customDomainLanguages));
         appendKeyValue(sb, "&product=", "wovnjava");
         appendKeyValue(sb, "&version=", Settings.VERSION);
         appendKeyValue(sb, "&debug_mode=", String.valueOf(this.requestOptions.getDebugMode()));

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
@@ -12,7 +12,7 @@ class CustomDomainLanguage {
 
     public CustomDomainLanguage(String host, String path, Lang lang) {
         this.host = host;
-        this.path = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        this.path = path;
         this.lang = lang;
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
@@ -2,8 +2,6 @@ package com.github.wovnio.wovnjava;
 
 import java.net.URL;
 import java.util.Arrays;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 class CustomDomainLanguage {
     public final String host;

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
@@ -1,0 +1,41 @@
+package com.github.wovnio.wovnjava;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+class CustomDomainLanguage {
+    public final String host;
+    public final String path;
+    public final Lang lang;
+
+    public CustomDomainLanguage(String host, String path, Lang lang) {
+        this.host = host;
+        this.path = path.endsWith("/") ? path : path + "/";
+        this.lang = lang;
+    }
+
+    public boolean isMatch(URL url) {
+        if (url == null) return false;
+
+        return this.host.equalsIgnoreCase(url.getHost()) && this.pathIsEqualOrSubsetOf(this.path, url.getPath());
+    }
+
+    private boolean pathIsEqualOrSubsetOf(String basePath, String testPath) {
+        String[] basePathList = Arrays.stream(basePath.split("/")).filter(s -> !s.isEmpty()).toArray(String[]::new);
+        String[] testPathList = Arrays.stream(testPath.split("/")).filter(s -> !s.isEmpty()).toArray(String[]::new);
+
+        if (basePathList.length > testPathList.length) {
+            return false;
+        }
+
+        for (int i = 0; i < basePathList.length; i++) {
+            if (!basePathList[i].equalsIgnoreCase(testPathList[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguage.java
@@ -12,7 +12,7 @@ class CustomDomainLanguage {
 
     public CustomDomainLanguage(String host, String path, Lang lang) {
         this.host = host;
-        this.path = path.endsWith("/") ? path : path + "/";
+        this.path = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
         this.lang = lang;
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -27,7 +27,6 @@ class CustomDomainLanguageSerializer {
             }
 
             String hostAndPath = splitPair[0].trim();
-            // TODO: raise error if `hostAndPath` includes protocol (match against "http" or "://", for example)
             try {
                 URL url = new URL("http://" + hostAndPath);
                 customDomainLanguageList.add(new CustomDomainLanguage(url.getHost(), removeTrailingSlash(url.getPath()), lang));

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -38,6 +38,10 @@ class CustomDomainLanguageSerializer {
     }
 
     public static String serializeToJson(CustomDomainLanguages customDomainLanguages) {
+        if (customDomainLanguages == null) {
+            return "";
+        }
+
         ArrayList<String> items = new ArrayList<String>();
         for (CustomDomainLanguage cdl : customDomainLanguages.customDomainLanguageList) {
             items.add(cdl.host + cdl.path + "/\":\"" + cdl.lang.code);

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -1,8 +1,6 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 import java.net.MalformedURLException;
 import java.net.URL;
 

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -9,7 +9,7 @@ import java.net.URL;
 class CustomDomainLanguageSerializer {
     private CustomDomainLanguageSerializer() {}
 
-    public static ArrayList<CustomDomainLanguage> deserialize(String rawCustomDomainLanguages) throws ConfigurationError {
+    public static ArrayList<CustomDomainLanguage> deserializeFilterConfig(String rawCustomDomainLanguages) throws ConfigurationError {
         ArrayList<CustomDomainLanguage> customDomainLanguageList = new ArrayList<CustomDomainLanguage>();
 
         for (String rawPair : rawCustomDomainLanguages.split(",")) {

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -1,0 +1,72 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class CustomDomainLanguageSerializer {
+    private CustomDomainLanguageSerializer() {}
+
+    public static CustomDomainLanguages deserialize(String rawCustomDomainLanguages) throws ConfigurationError {
+        if (rawCustomDomainLanguages == null || rawCustomDomainLanguages.isEmpty()) {
+            throw new ConfigurationError("Using \"urlPattern=customDomain\", missing required configuration for \"customDomainLangs\".");
+        }
+
+        ArrayList<CustomDomainLanguage> customDomainLanguageList = new ArrayList<CustomDomainLanguage>();
+
+        for (String rawPair : rawCustomDomainLanguages.split(",")) {
+            if (rawPair == null || rawPair.isEmpty()) {
+                continue;
+            }
+            String[] splitPair = rawPair.split(":");
+            if (splitPair.length != 2) {
+                throw new ConfigurationError("Invalid configuration format for \"customDomainLangs\": " + rawCustomDomainLanguages);
+            }
+
+            Lang lang = Lang.get(splitPair[1].trim());
+            if (lang == null) {
+                throw new ConfigurationError("Invalid target language for \"customDomainLangs\", each value must match a supported language code.");
+            }
+
+            String hostAndPath = splitPair[0].trim();
+            try {
+                URL url = new URL("http://" + hostAndPath);
+                customDomainLanguageList.add(new CustomDomainLanguage(url.getHost(), url.getPath(), lang));
+            }
+            catch (MalformedURLException e) {
+                throw new ConfigurationError("MalformedURLException when parsing \"customDomainLangs\": " + e.getMessage());
+            }
+        }
+
+        validateUniqueness(customDomainLanguageList);
+
+        return new CustomDomainLanguages(customDomainLanguageList);
+    }
+
+    private static void validateUniqueness(ArrayList<CustomDomainLanguage> customDomainLanguageList) throws ConfigurationError {
+        ArrayList<Lang> includedLangs = new ArrayList<Lang>();
+        ArrayList<String> includedUrls = new ArrayList<String>();
+
+        for (CustomDomainLanguage customDomainLanguage : customDomainLanguageList) {
+            Lang lang = customDomainLanguage.lang;
+            if (includedLangs.contains(lang)) {
+                throw new ConfigurationError("Each language can only be specified once for \"customDomainLangs\". \"" + lang.code + "\" is specified more than once.");
+            } else {
+                includedLangs.add(lang);
+            }
+
+            String url = customDomainLanguage.host + removeTrailingSlash(customDomainLanguage.path);
+            if (includedUrls.contains(url)) {
+                throw new ConfigurationError("Each language must be mapped to a unique domain and path combination for \"customDomainLangs\". \"" + url + "\" is used twice.");
+            } else {
+                includedUrls.add(url);
+            }
+        }
+    }
+
+    private static String removeTrailingSlash(String path) {
+        return path.replaceAll("/$", "");
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializer.java
@@ -37,6 +37,14 @@ class CustomDomainLanguageSerializer {
         return customDomainLanguageList;
     }
 
+    public static String serializeToJson(CustomDomainLanguages customDomainLanguages) {
+        ArrayList<String> items = new ArrayList<String>();
+        for (CustomDomainLanguage cdl : customDomainLanguages.customDomainLanguageList) {
+            items.add(cdl.host + cdl.path + "/\":\"" + cdl.lang.code);
+        }
+        return "{\"" + String.join("\",\"", items) + "\"}";
+    }
+
     private static String removeTrailingSlash(String path) {
         return path.replaceAll("/$", "");
     }

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidator.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidator.java
@@ -1,9 +1,6 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 class CustomDomainLanguageValidator {

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidator.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidator.java
@@ -1,0 +1,42 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class CustomDomainLanguageValidator {
+    private CustomDomainLanguageValidator() {}
+
+    public static ValidationResult validate(ArrayList<CustomDomainLanguage> customDomainLanguageList, ArrayList<Lang> supportedLangs) {
+        ArrayList<Lang> includedLangs = new ArrayList<Lang>();
+        ArrayList<String> includedUrls = new ArrayList<String>();
+
+        for (CustomDomainLanguage customDomainLanguage : customDomainLanguageList) {
+            Lang lang = customDomainLanguage.lang;
+            if (includedLangs.contains(lang)) {
+                return ValidationResult.failure("Each language can only be specified once for \"customDomainLangs\". \"" + lang.code + "\" is specified more than once.");
+            } else {
+                includedLangs.add(lang);
+            }
+
+            String url = customDomainLanguage.host + customDomainLanguage.path;
+            if (includedUrls.contains(url)) {
+                return ValidationResult.failure("Each language must be mapped to a unique domain and path combination for \"customDomainLangs\". \"" + url + "\" is used twice.");
+            } else {
+                includedUrls.add(url);
+            }
+        }
+
+        if (customDomainLanguageList.size() != supportedLangs.size()) {
+            return ValidationResult.failure("Languages in \"customDomainLangs\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");
+        }
+        for (CustomDomainLanguage customDomainLanguage : customDomainLanguageList) {
+            if (!supportedLangs.contains(customDomainLanguage.lang)) {
+                return ValidationResult.failure("Custom domain language is declared for a language not declared in \"supportedLangs\".");
+            }
+        }
+        return ValidationResult.success();
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguages.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguages.java
@@ -1,0 +1,39 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.net.URL;
+
+class CustomDomainLanguages {
+    public final ArrayList<CustomDomainLanguage> customDomainLanguageList;
+
+    public CustomDomainLanguages(ArrayList<CustomDomainLanguage> customDomainLanguageList) {
+        Collections.sort(customDomainLanguageList, new SortByDecendingPathLength()); 
+        this.customDomainLanguageList = customDomainLanguageList;
+    }
+
+    public CustomDomainLanguage getCustomDomainLanguageByLang(String langCode) {
+        for (CustomDomainLanguage customDomainLanguage : this.customDomainLanguageList) {
+            if (customDomainLanguage.lang.code == langCode) {
+                return customDomainLanguage;
+            }
+        }
+        return null;
+    }
+
+    public CustomDomainLanguage getCustomDomainLanguageByUrl(URL url) {
+        for (CustomDomainLanguage customDomainLanguage : this.customDomainLanguageList) {
+            if (customDomainLanguage.isMatch(url)) {
+                return customDomainLanguage;
+            }
+        }
+        return null;
+    }
+}
+
+class SortByDecendingPathLength implements Comparator<CustomDomainLanguage> { 
+    public int compare(CustomDomainLanguage a, CustomDomainLanguage b) { 
+        return b.path.length() - a.path.length(); 
+    } 
+} 

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguages.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainLanguages.java
@@ -13,9 +13,9 @@ class CustomDomainLanguages {
         this.customDomainLanguageList = customDomainLanguageList;
     }
 
-    public CustomDomainLanguage getCustomDomainLanguageByLang(String langCode) {
+    public CustomDomainLanguage getCustomDomainLanguageByLang(Lang lang) {
         for (CustomDomainLanguage customDomainLanguage : this.customDomainLanguageList) {
-            if (customDomainLanguage.lang.code == langCode) {
+            if (customDomainLanguage.lang == lang) {
                 return customDomainLanguage;
             }
         }

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -1,5 +1,6 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.regex.Pattern;
 import java.net.URL;
 import java.net.MalformedURLException;
 

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -37,8 +37,8 @@ class CustomDomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         CustomDomainLanguage targetCDL = this.customDomainLanguages.getCustomDomainLanguageByLang(lang);
         if (targetCDL == null || currentCDL == targetCDL) return urlString;
 
-        Pattern p = Pattern.compile("^(" + currentCDL.path + ")(/|$)");
-        String newFile = p.matcher(url.getFile()).replaceFirst(targetCDL.path + "$2");
+        Pattern p = Pattern.compile("^(" + currentCDL.path + ")");
+        String newFile = p.matcher(url.getFile()).replaceFirst(targetCDL.path);
 
         try {
             URL result = new URL(url.getProtocol(), targetCDL.host, url.getPort(), newFile);

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -1,0 +1,21 @@
+package com.github.wovnio.wovnjava;
+
+class CustomDomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
+    private CustomDomainLanguages customDomainLanguages;
+
+    CustomDomainUrlLanguagePatternHandler(CustomDomainLanguages customDomainLanguages) {
+        this.customDomainLanguages = customDomainLanguages;
+    }
+
+    String getLang(String url) {
+        return "";
+    }
+
+    String removeLang(String url, String lang) {
+        return url;
+    }
+
+    String insertLang(String url, String lang) {
+        return url;
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -48,6 +48,14 @@ class CustomDomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         }
     }
 
+    public boolean canInterceptUrl(String urlString) {
+        URL url = getUrlObject(urlString);
+        if (url == null) return false;
+
+        CustomDomainLanguage customDomainLanguage = this.customDomainLanguages.getCustomDomainLanguageByUrl(url);
+        return customDomainLanguage != null;
+    }
+
     private URL getUrlObject(String url) {
         try {
             return new URL(url);

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -33,7 +33,7 @@ class CustomDomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
         CustomDomainLanguage currentCDL = this.customDomainLanguages.getCustomDomainLanguageByUrl(url);
         if (currentCDL == null) return urlString;
 
-        CustomDomainLanguage targetCDL = this.customDomainLanguages.getCustomDomainLanguageByLang(lang.code); //TODO: change to pass Lang object
+        CustomDomainLanguage targetCDL = this.customDomainLanguages.getCustomDomainLanguageByLang(lang);
         if (targetCDL == null || currentCDL == targetCDL) return urlString;
 
         Pattern p = Pattern.compile("^(" + currentCDL.path + ")(/|$)");

--- a/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
+++ b/src/main/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandler.java
@@ -1,21 +1,57 @@
 package com.github.wovnio.wovnjava;
 
+import java.net.URL;
+import java.net.MalformedURLException;
+
 class CustomDomainUrlLanguagePatternHandler extends UrlLanguagePatternHandler {
+    private Lang defaultLang;
     private CustomDomainLanguages customDomainLanguages;
 
-    CustomDomainUrlLanguagePatternHandler(CustomDomainLanguages customDomainLanguages) {
+    CustomDomainUrlLanguagePatternHandler(Lang defaultLang, CustomDomainLanguages customDomainLanguages) {
+        this.defaultLang = defaultLang;
         this.customDomainLanguages = customDomainLanguages;
     }
 
-    String getLang(String url) {
-        return "";
+    Lang getLang(String urlString) {
+        URL url = getUrlObject(urlString);
+        if (url == null) return null;
+
+        CustomDomainLanguage customDomainLanguage = this.customDomainLanguages.getCustomDomainLanguageByUrl(url);
+        if (customDomainLanguage == null) return null;
+
+        return customDomainLanguage.lang;
     }
 
-    String removeLang(String url, String lang) {
-        return url;
+    String convertToDefaultLanguage(String urlString) {
+        return convertToTargetLanguage(urlString, this.defaultLang);
     }
 
-    String insertLang(String url, String lang) {
-        return url;
+    String convertToTargetLanguage(String urlString, Lang lang) {
+        URL url = getUrlObject(urlString);
+        if (url == null) return urlString;
+
+        CustomDomainLanguage currentCDL = this.customDomainLanguages.getCustomDomainLanguageByUrl(url);
+        if (currentCDL == null) return urlString;
+
+        CustomDomainLanguage targetCDL = this.customDomainLanguages.getCustomDomainLanguageByLang(lang.code); //TODO: change to pass Lang object
+        if (targetCDL == null || currentCDL == targetCDL) return urlString;
+
+        Pattern p = Pattern.compile("^(" + currentCDL.path + ")(/|$)");
+        String newFile = p.matcher(url.getFile()).replaceFirst(targetCDL.path + "$2");
+
+        try {
+            URL result = new URL(url.getProtocol(), targetCDL.host, url.getPort(), newFile);
+            return result.toString();
+        } catch (MalformedURLException e) {
+            return urlString;
+        }
+    }
+
+    private URL getUrlObject(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -1,8 +1,6 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -139,6 +139,10 @@ class HtmlConverter {
             sb.append("&sitePrefixPath=");
             sb.append(settings.sitePrefixPath.replaceFirst("/", ""));
         }
+        if (settings.customDomainLanguages != null) {
+            sb.append("&customDomainLangs=");
+            sb.append(CustomDomainLanguageSerializer.serializeToJson(settings.customDomainLanguages));
+        }
         String key = sb.toString();
         js.attr("src", settings.snippetUrl);
         js.attr("data-wovnio", key);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -88,6 +88,9 @@ class Settings {
         // so here we only assert that some string is declared for this setting.
         if (value == null || value.isEmpty()) {
             throw new ConfigurationError("Missing required configuration for \"urlPattern\".");
+        } else if (value.equals("customDomain")) {
+            // Other systems expect snake_case, but we want to also accept camelCase for java
+            value = "custom_domain";
         }
         return value;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -147,7 +147,7 @@ class Settings {
         if (rawCustomDomainLangs == null || rawCustomDomainLangs.isEmpty()) {
             return null;
         }
-        ArrayList<CustomDomainLanguage> customDomainLanguageList = CustomDomainLanguageSerializer.deserialize(rawCustomDomainLangs);
+        ArrayList<CustomDomainLanguage> customDomainLanguageList = CustomDomainLanguageSerializer.deserializeFilterConfig(rawCustomDomainLangs);
         ValidationResult validationResult = CustomDomainLanguageValidator.validate(customDomainLanguageList, supportedLangs);
         if (!validationResult.success) {
             throw new ConfigurationError(validationResult.errorMessage);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -114,6 +114,9 @@ class Settings {
             if (lang == null) {
                 throw new ConfigurationError("Invalid configuration for \"supportedLangs\", each value must match a supported language code.");
             }
+            if (verifiedLangs.contains(lang)) {
+                throw new ConfigurationError("Invalid configuration for \"supportedLangs\", each language must only be specified once.");
+            }
             verifiedLangs.add(lang);
         }
         if (!verifiedLangs.contains(defaultLang)) {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -111,6 +111,9 @@ class Settings {
             if (lang == null) {
                 throw new ConfigurationError("Invalid configuration for \"supportedLangs\", each value must match a supported language code.");
             }
+            if (verifiedLangs.contains(lang.code)) {
+                throw new ConfigurationError("Invalid configuration for \"supportedLangs\", each language must only be specified once.");
+            }
             verifiedLangs.add(lang.code);
         }
         if (!verifiedLangs.contains(defaultLangCode)) {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -30,6 +30,8 @@ class Settings {
     public final boolean enableFlushBuffer;
 
     public final String sitePrefixPath;
+    public final String rawCustomDomainLangs;
+
     public final String snippetUrl;
     public final String apiUrl;
     public final String originalUrlHeader;
@@ -56,6 +58,7 @@ class Settings {
         this.enableFlushBuffer = reader.getBoolParameterDefaultFalse("enableFlushBuffer");
 
         this.sitePrefixPath = normalizeSitePrefixPath(reader.getStringParameter("sitePrefixPath"));
+        this.rawCustomDomainLangs = reader.getStringParameter("customDomainLangs");
 
         String defaultApiUrl = this.devMode ? DefaultApiUrlDevelopment : DefaultApiUrlProduction;
         this.apiUrl = stringOrDefault(reader.getStringParameter("apiUrl"), defaultApiUrl);

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -88,7 +88,7 @@ class Settings {
         // so here we only assert that some string is declared for this setting.
         if (value == null || value.isEmpty()) {
             throw new ConfigurationError("Missing required configuration for \"urlPattern\".");
-        } else if (value.equals("customDomain")) {
+        } else if ("customdomain".equalsIgnoreCase(value)) {
             // Other systems expect snake_case, but we want to also accept camelCase for java
             value = "custom_domain";
         }

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -27,12 +27,12 @@ final class UrlLanguagePatternHandlerFactory {
         }
     }
 
-    private static boolean isCustomDomainLanguagesCompatible(CustomDomainLanguages customDomainLanguages, ArrayList<String> supportedLangs) {
+    private static boolean isCustomDomainLanguagesCompatible(CustomDomainLanguages customDomainLanguages, ArrayList<Lang> supportedLangs) {
         if (customDomainLanguages.customDomainLanguageList.size() != supportedLangs.size()) {
             return false;
         }
         for (CustomDomainLanguage customDomainLanguage : customDomainLanguages.customDomainLanguageList) {
-            if (!supportedLangs.contains(customDomainLanguage.lang.code)) {
+            if (!supportedLangs.contains(customDomainLanguage.lang)) {
                 return false;
             }
         }

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -1,22 +1,42 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.ArrayList;
+
 final class UrlLanguagePatternHandlerFactory {
     private UrlLanguagePatternHandlerFactory() {}
 
     public static UrlLanguagePatternHandler create(Settings settings) throws ConfigurationError {
-        return create(settings.urlPattern, settings.sitePrefixPath);
+        return create(settings.urlPattern, settings.sitePrefixPath, settings.rawCustomDomainLangs, settings.supportedLangs);
     }
 
-    public static UrlLanguagePatternHandler create(String urlPattern, String sitePrefixPath) throws ConfigurationError {
+    public static UrlLanguagePatternHandler create(String urlPattern, String sitePrefixPath, String rawCustomDomainLangs, ArrayList<String> supportedLangs) throws ConfigurationError {
         if ("path".equalsIgnoreCase(urlPattern)) {
             return new PathUrlLanguagePatternHandler(sitePrefixPath);
         } else if ("query".equalsIgnoreCase(urlPattern)) {
             return new QueryUrlLanguagePatternHandler();
         } else if ("subdomain".equalsIgnoreCase(urlPattern)) {
             return new SubdomainUrlLanguagePatternHandler();
+        } else if ("customDomain".equalsIgnoreCase(urlPattern)) {
+            CustomDomainLanguages customDomainLanguages = CustomDomainLanguageSerializer.deserialize(rawCustomDomainLangs);
+            if (!isCustomDomainLanguagesCompatible(customDomainLanguages, supportedLangs)) {
+                throw new ConfigurationError("\"customDomainLanguages\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");
+            }
+            return new CustomDomainUrlLanguagePatternHandler(customDomainLanguages);
         } else {
             throw new ConfigurationError("Invalid url pattern: " + urlPattern);
         }
+    }
+
+    private static boolean isCustomDomainLanguagesCompatible(CustomDomainLanguages customDomainLanguages, ArrayList<String> supportedLangs) {
+        if (customDomainLanguages.customDomainLanguageList.size() != supportedLangs.size()) {
+            return false;
+        }
+        for (CustomDomainLanguage customDomainLanguage : customDomainLanguages.customDomainLanguageList) {
+            if (!supportedLangs.contains(customDomainLanguage.lang.code)) {
+                return false;
+            }
+        }
+        return true;
     }
 }
 

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -16,7 +16,7 @@ final class UrlLanguagePatternHandlerFactory {
             return new QueryUrlLanguagePatternHandler(defaultLang, supportedLangs);
         } else if ("subdomain".equalsIgnoreCase(urlPattern)) {
             return new SubdomainUrlLanguagePatternHandler(defaultLang, supportedLangs);
-        } else if ("customDomain".equalsIgnoreCase(urlPattern)) {
+        } else if ("custom_domain".equalsIgnoreCase(urlPattern)) {
             CustomDomainLanguages customDomainLanguages = CustomDomainLanguageSerializer.deserialize(rawCustomDomainLangs);
             if (!isCustomDomainLanguagesCompatible(customDomainLanguages, supportedLangs)) {
                 throw new ConfigurationError("\"customDomainLangs\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -19,7 +19,7 @@ final class UrlLanguagePatternHandlerFactory {
         } else if ("customDomain".equalsIgnoreCase(urlPattern)) {
             CustomDomainLanguages customDomainLanguages = CustomDomainLanguageSerializer.deserialize(rawCustomDomainLangs);
             if (!isCustomDomainLanguagesCompatible(customDomainLanguages, supportedLangs)) {
-                throw new ConfigurationError("\"customDomainLanguages\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");
+                throw new ConfigurationError("\"customDomainLangs\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");
             }
             return new CustomDomainUrlLanguagePatternHandler(defaultLang, customDomainLanguages);
         } else {

--- a/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactory.java
@@ -6,10 +6,10 @@ final class UrlLanguagePatternHandlerFactory {
     private UrlLanguagePatternHandlerFactory() {}
 
     public static UrlLanguagePatternHandler create(Settings settings) throws ConfigurationError {
-        return create(settings.defaultLang, settings.supportedLangs, settings.urlPattern, settings.sitePrefixPath, settings.rawCustomDomainLangs);
+        return create(settings.defaultLang, settings.supportedLangs, settings.urlPattern, settings.sitePrefixPath, settings.customDomainLanguages);
     }
 
-    public static UrlLanguagePatternHandler create(Lang defaultLang, ArrayList<Lang> supportedLangs, String urlPattern, String sitePrefixPath, String rawCustomDomainLangs) throws ConfigurationError {
+    public static UrlLanguagePatternHandler create(Lang defaultLang, ArrayList<Lang> supportedLangs, String urlPattern, String sitePrefixPath, CustomDomainLanguages customDomainLanguages) throws ConfigurationError {
         if ("path".equalsIgnoreCase(urlPattern)) {
             return new PathUrlLanguagePatternHandler(defaultLang, supportedLangs, sitePrefixPath);
         } else if ("query".equalsIgnoreCase(urlPattern)) {
@@ -17,25 +17,12 @@ final class UrlLanguagePatternHandlerFactory {
         } else if ("subdomain".equalsIgnoreCase(urlPattern)) {
             return new SubdomainUrlLanguagePatternHandler(defaultLang, supportedLangs);
         } else if ("custom_domain".equalsIgnoreCase(urlPattern)) {
-            CustomDomainLanguages customDomainLanguages = CustomDomainLanguageSerializer.deserialize(rawCustomDomainLangs);
-            if (!isCustomDomainLanguagesCompatible(customDomainLanguages, supportedLangs)) {
-                throw new ConfigurationError("\"customDomainLangs\" does not match \"supportedLangs\". A custom domain must be declared for each supported language.");
+            if (customDomainLanguages == null) {
+                throw new ConfigurationError("\"customDomainLangs\" setting must be configured when \"urlPattern=customDomain\".");
             }
             return new CustomDomainUrlLanguagePatternHandler(defaultLang, customDomainLanguages);
         } else {
             throw new ConfigurationError("Invalid url pattern: " + urlPattern);
         }
-    }
-
-    private static boolean isCustomDomainLanguagesCompatible(CustomDomainLanguages customDomainLanguages, ArrayList<Lang> supportedLangs) {
-        if (customDomainLanguages.customDomainLanguageList.size() != supportedLangs.size()) {
-            return false;
-        }
-        for (CustomDomainLanguage customDomainLanguage : customDomainLanguages.customDomainLanguageList) {
-            if (!supportedLangs.contains(customDomainLanguage.lang)) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/ValidationResult.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ValidationResult.java
@@ -1,0 +1,19 @@
+package com.github.wovnio.wovnjava;
+
+class ValidationResult {
+    public final boolean success;
+    public final String errorMessage;
+
+    public static ValidationResult success() {
+        return new ValidationResult(true, null);
+    }
+
+    public static ValidationResult failure(String errorMessage) {
+        return new ValidationResult(false, errorMessage);
+    }
+
+    private ValidationResult(boolean success, String errorMessage) {
+        this.success = success;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -31,7 +31,7 @@ public class WovnServletFilter implements Filter {
             this.urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
             this.fileExtensionMatcher = new FileExtensionMatcher();
         } catch (ConfigurationError e) {
-            throw new ServletException("WovnServletFilter ConfigurationError: " + e.getMessage());
+            throw new ServletException("WovnServletFilter ConfigurationError: " + e.getMessage() + " (See WovnServletFilter instructions at https://github.com/WOVNio/wovnjava)");
         }
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -75,6 +75,7 @@ public class ApiTest extends TestCase {
                                      "&lang_code=ja" +
                                      "&url_pattern=path" +
                                      "&site_prefix_path=" +
+                                     "&custom_domain_langs=" +
                                      "&product=wovnjava" +
                                      "&version=" + Settings.VERSION +
                                      "&debug_mode=false" +

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -8,7 +8,7 @@ import org.easymock.EasyMock;
 public class CustomDomainLanguageSerializerTest extends TestCase {
     public void testDeserialize__SingleLanguage() throws ConfigurationError {
         String input = "site.com:en";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
 
         assertEquals(1, results.size());
 
@@ -19,22 +19,22 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
     public void testDeserialize__MultipleLanguages() throws ConfigurationError {
         String input = "site.com:en,site.com/ja:ja";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
 
         assertEquals(2, results.size());
 
-        assertEquals("ja", results.get(0).lang.code);
+        assertEquals("en", results.get(0).lang.code);
         assertEquals("site.com", results.get(0).host);
-        assertEquals("/ja", results.get(0).path);
+        assertEquals("", results.get(0).path);
 
-        assertEquals("en", results.get(1).lang.code);
+        assertEquals("ja", results.get(1).lang.code);
         assertEquals("site.com", results.get(1).host);
-        assertEquals("", results.get(1).path);
+        assertEquals("/ja", results.get(1).path);
     }
 
-    public void testDeserialize__MultipleLanguages__DomainAndPathVarieties() throws ConfigurationError {
-        String input = "site.co.uk/english:en,japan.site.com/:ja,japan.site.com/ko:ko";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+    public void testDeserialize__MultipleLanguages__DomainAndPathVarieties__StripTrailingSlashFromPath() throws ConfigurationError {
+        String input = "site.co.uk/english/:en,japan.site.com/:ja,japan.site.com/ko:ko";
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
 
         assertEquals(3, results.size());
 
@@ -42,17 +42,17 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         assertEquals("site.co.uk", results.get(0).host);
         assertEquals("/english", results.get(0).path);
 
-        assertEquals("ko", results.get(1).lang.code);
+        assertEquals("ja", results.get(1).lang.code);
         assertEquals("japan.site.com", results.get(1).host);
-        assertEquals("/ko", results.get(1).path);
+        assertEquals("", results.get(1).path);
 
-        assertEquals("ja", results.get(2).lang.code);
+        assertEquals("ko", results.get(2).lang.code);
         assertEquals("japan.site.com", results.get(2).host);
-        assertEquals("", results.get(2).path);
+        assertEquals("/ko", results.get(2).path);
     }
 
-    public void testDeserialize__SameLanguageSpecifiedMoreThanOnce__ThrowError() throws ConfigurationError {
-        String input = "site.com/english:en,japan.site.com/:ja,site.com/ja:ja";
+    public void testDeserialize__InvalidFormat__ThrowError() throws ConfigurationError {
+        String input = "site.com:en,site.com:8000:ja";
 
         boolean errorThrown = false;
         try {
@@ -63,20 +63,8 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         assertEquals(true, errorThrown);
     }
 
-    public void testDeserialize__TwoLanguagesWithSameDomainAndPath__ThrowError() throws ConfigurationError {
-        String input = "site.com/english:en,site.com:ja,site.com:ko";
-
-        boolean errorThrown = false;
-        try {
-            CustomDomainLanguageSerializer.deserialize(input);
-        } catch (ConfigurationError e) {
-            errorThrown = true;
-        }
-        assertEquals(true, errorThrown);
-    }
-
-    public void testDeserialize__DomainAndPathDifferingOnlyByTrailingSlash__ThrowError() throws ConfigurationError {
-        String input = "site.com/global:en,site.com:ja,site.com/global/:ko";
+    public void testDeserialize__InvalidLanguageCode__ThrowError() throws ConfigurationError {
+        String input = "site.com:en,site.com:japanese";
 
         boolean errorThrown = false;
         try {

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -14,7 +14,7 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals("en", results.get(0).lang.code);
         assertEquals("site.com", results.get(0).host);
-        assertEquals("/", results.get(0).path);
+        assertEquals("", results.get(0).path);
     }
 
     public void testDeserialize__MultipleLanguages() throws ConfigurationError {
@@ -25,11 +25,11 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals("ja", results.get(0).lang.code);
         assertEquals("site.com", results.get(0).host);
-        assertEquals("/ja/", results.get(0).path);
+        assertEquals("/ja", results.get(0).path);
 
         assertEquals("en", results.get(1).lang.code);
         assertEquals("site.com", results.get(1).host);
-        assertEquals("/", results.get(1).path);
+        assertEquals("", results.get(1).path);
     }
 
     public void testDeserialize__MultipleLanguages__DomainAndPathVarieties() throws ConfigurationError {
@@ -40,15 +40,15 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals("en", results.get(0).lang.code);
         assertEquals("site.co.uk", results.get(0).host);
-        assertEquals("/english/", results.get(0).path);
+        assertEquals("/english", results.get(0).path);
 
         assertEquals("ko", results.get(1).lang.code);
         assertEquals("japan.site.com", results.get(1).host);
-        assertEquals("/ko/", results.get(1).path);
+        assertEquals("/ko", results.get(1).path);
 
         assertEquals("ja", results.get(2).lang.code);
         assertEquals("japan.site.com", results.get(2).host);
-        assertEquals("/", results.get(2).path);
+        assertEquals("", results.get(2).path);
     }
 
     public void testDeserialize__SameLanguageSpecifiedMoreThanOnce__ThrowError() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -12,9 +12,9 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals(1, results.size());
 
-        assertEquals("site.com", results.get(0).host);
-        assertEquals("", results.get(0).path);
         assertEquals("en", results.get(0).lang.code);
+        assertEquals("site.com", results.get(0).host);
+        assertEquals("/", results.get(0).path);
     }
 
     public void testDeserialize__MultipleLanguages() throws ConfigurationError {
@@ -23,13 +23,13 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals(2, results.size());
 
+        assertEquals("ja", results.get(0).lang.code);
         assertEquals("site.com", results.get(0).host);
-        assertEquals("", results.get(0).path);
-        assertEquals("en", results.get(0).lang.code);
+        assertEquals("/ja/", results.get(0).path);
 
+        assertEquals("en", results.get(1).lang.code);
         assertEquals("site.com", results.get(1).host);
-        assertEquals("/ja", results.get(1).path);
-        assertEquals("ja", results.get(1).lang.code);
+        assertEquals("/", results.get(1).path);
     }
 
     public void testDeserialize__MultipleLanguages__DomainAndPathVarieties() throws ConfigurationError {
@@ -38,17 +38,17 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
 
         assertEquals(3, results.size());
 
-        assertEquals("site.co.uk", results.get(0).host);
-        assertEquals("/english", results.get(0).path);
         assertEquals("en", results.get(0).lang.code);
+        assertEquals("site.co.uk", results.get(0).host);
+        assertEquals("/english/", results.get(0).path);
 
+        assertEquals("ko", results.get(1).lang.code);
         assertEquals("japan.site.com", results.get(1).host);
-        assertEquals("/", results.get(1).path);
-        assertEquals("ja", results.get(1).lang.code);
+        assertEquals("/ko/", results.get(1).path);
 
+        assertEquals("ja", results.get(2).lang.code);
         assertEquals("japan.site.com", results.get(2).host);
-        assertEquals("/ko", results.get(2).path);
-        assertEquals("ko", results.get(2).lang.code);
+        assertEquals("/", results.get(2).path);
     }
 
     public void testDeserialize__SameLanguageSpecifiedMoreThanOnce__ThrowError() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -74,4 +74,16 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         }
         assertEquals(true, errorThrown);
     }
+
+    public void testSerializeToJson() {
+        ArrayList<CustomDomainLanguage> languageList = new ArrayList<CustomDomainLanguage>();
+        languageList.add(new CustomDomainLanguage("site.com", "", Lang.get("en")));
+        languageList.add(new CustomDomainLanguage("site.com", "/jap", Lang.get("ja")));
+        languageList.add(new CustomDomainLanguage("eu.site.com", "/france", Lang.get("fr")));
+
+        CustomDomainLanguages customDomainLanguages = new CustomDomainLanguages(languageList);
+
+        String result = CustomDomainLanguageSerializer.serializeToJson(customDomainLanguages);
+        assertEquals("{\"eu.site.com/france/\":\"fr\",\"site.com/jap/\":\"ja\",\"site.com/\":\"en\"}", result);
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -1,0 +1,89 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class CustomDomainLanguageSerializerTest extends TestCase {
+    public void testDeserialize__SingleLanguage() throws ConfigurationError {
+        String input = "site.com:en";
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+
+        assertEquals(1, results.size());
+
+        assertEquals("site.com", results.get(0).host);
+        assertEquals("", results.get(0).path);
+        assertEquals("en", results.get(0).lang.code);
+    }
+
+    public void testDeserialize__MultipleLanguages() throws ConfigurationError {
+        String input = "site.com:en,site.com/ja:ja";
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+
+        assertEquals(2, results.size());
+
+        assertEquals("site.com", results.get(0).host);
+        assertEquals("", results.get(0).path);
+        assertEquals("en", results.get(0).lang.code);
+
+        assertEquals("site.com", results.get(1).host);
+        assertEquals("/ja", results.get(1).path);
+        assertEquals("ja", results.get(1).lang.code);
+    }
+
+    public void testDeserialize__MultipleLanguages__DomainAndPathVarieties() throws ConfigurationError {
+        String input = "site.co.uk/english:en,japan.site.com/:ja,japan.site.com/ko:ko";
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input).customDomainLanguageList;
+
+        assertEquals(3, results.size());
+
+        assertEquals("site.co.uk", results.get(0).host);
+        assertEquals("/english", results.get(0).path);
+        assertEquals("en", results.get(0).lang.code);
+
+        assertEquals("japan.site.com", results.get(1).host);
+        assertEquals("/", results.get(1).path);
+        assertEquals("ja", results.get(1).lang.code);
+
+        assertEquals("japan.site.com", results.get(2).host);
+        assertEquals("/ko", results.get(2).path);
+        assertEquals("ko", results.get(2).lang.code);
+    }
+
+    public void testDeserialize__SameLanguageSpecifiedMoreThanOnce__ThrowError() throws ConfigurationError {
+        String input = "site.com/english:en,japan.site.com/:ja,site.com/ja:ja";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testDeserialize__TwoLanguagesWithSameDomainAndPath__ThrowError() throws ConfigurationError {
+        String input = "site.com/english:en,site.com:ja,site.com:ko";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testDeserialize__DomainAndPathDifferingOnlyByTrailingSlash__ThrowError() throws ConfigurationError {
+        String input = "site.com/global:en,site.com:ja,site.com/global/:ko";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageSerializerTest.java
@@ -6,9 +6,9 @@ import junit.framework.TestCase;
 import org.easymock.EasyMock;
 
 public class CustomDomainLanguageSerializerTest extends TestCase {
-    public void testDeserialize__SingleLanguage() throws ConfigurationError {
+    public void testDeserializeFilterConfig__SingleLanguage() throws ConfigurationError {
         String input = "site.com:en";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserializeFilterConfig(input);
 
         assertEquals(1, results.size());
 
@@ -17,9 +17,9 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         assertEquals("", results.get(0).path);
     }
 
-    public void testDeserialize__MultipleLanguages() throws ConfigurationError {
+    public void testDeserializeFilterConfig__MultipleLanguages() throws ConfigurationError {
         String input = "site.com:en,site.com/ja:ja";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserializeFilterConfig(input);
 
         assertEquals(2, results.size());
 
@@ -32,9 +32,9 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         assertEquals("/ja", results.get(1).path);
     }
 
-    public void testDeserialize__MultipleLanguages__DomainAndPathVarieties__StripTrailingSlashFromPath() throws ConfigurationError {
+    public void testDeserializeFilterConfig__MultipleLanguages__DomainAndPathVarieties__StripTrailingSlashFromPath() throws ConfigurationError {
         String input = "site.co.uk/english/:en,japan.site.com/:ja,japan.site.com/ko:ko";
-        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserialize(input);
+        ArrayList<CustomDomainLanguage> results = CustomDomainLanguageSerializer.deserializeFilterConfig(input);
 
         assertEquals(3, results.size());
 
@@ -51,24 +51,24 @@ public class CustomDomainLanguageSerializerTest extends TestCase {
         assertEquals("/ko", results.get(2).path);
     }
 
-    public void testDeserialize__InvalidFormat__ThrowError() throws ConfigurationError {
+    public void testDeserializeFilterConfig__InvalidFormat__ThrowError() throws ConfigurationError {
         String input = "site.com:en,site.com:8000:ja";
 
         boolean errorThrown = false;
         try {
-            CustomDomainLanguageSerializer.deserialize(input);
+            CustomDomainLanguageSerializer.deserializeFilterConfig(input);
         } catch (ConfigurationError e) {
             errorThrown = true;
         }
         assertEquals(true, errorThrown);
     }
 
-    public void testDeserialize__InvalidLanguageCode__ThrowError() throws ConfigurationError {
+    public void testDeserializeFilterConfig__InvalidLanguageCode__ThrowError() throws ConfigurationError {
         String input = "site.com:en,site.com:japanese";
 
         boolean errorThrown = false;
         try {
-            CustomDomainLanguageSerializer.deserialize(input);
+            CustomDomainLanguageSerializer.deserializeFilterConfig(input);
         } catch (ConfigurationError e) {
             errorThrown = true;
         }

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageTest.java
@@ -1,0 +1,87 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class CustomDomainLanguageTest extends TestCase {
+    CustomDomainLanguage customDomainRootPath;
+    CustomDomainLanguage customDomainWithPathNoTrailingSlash;
+    CustomDomainLanguage customDomainWithPathTrailingSlash;
+    CustomDomainLanguage customDomainWithPathEncodedSpaces;
+
+    protected void setUp() throws Exception {
+        this.customDomainRootPath = new CustomDomainLanguage("foo.com", "/", Lang.get("en"));
+        this.customDomainWithPathNoTrailingSlash = new CustomDomainLanguage("foo.com", "/path", Lang.get("en"));
+        this.customDomainWithPathTrailingSlash = new CustomDomainLanguage("foo.com", "/path/", Lang.get("en"));
+        this.customDomainWithPathEncodedSpaces = new CustomDomainLanguage("foo.com", "/dir%20path", Lang.get("en"));
+    }
+
+    public void testIsMatch__nullURL__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainRootPath.isMatch(null));
+    }
+
+    public void testIsMatch__DifferentDomain__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainRootPath.isMatch(new URL("http://otherdomain.com/other/test.html")));
+    }
+
+    public void testIsMatch__DifferentPortNumber__IsIgnored() throws MalformedURLException {
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com:3000/other/test.html")));
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com:80/other/test.html")));
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com/other/test.html")));
+    }
+
+    public void testIsMatch__DifferentSchema__IsIgnored() throws MalformedURLException {
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("https://foo.com/other/test.html")));
+    }
+
+    public void testIsMatch__Subdomain__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainRootPath.isMatch(new URL("http://en.foo.com/other/test.html")));
+    }
+
+    public void testIsMatch__SameDomain__True() throws MalformedURLException {
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com/other/test.html")));
+    }
+
+    public void testIsMatch__SameDomainDifferentCasing__True() throws MalformedURLException {
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://FOO.com/other/test.html")));
+    }
+
+    public void testIsMatch__PathStartsWithCustomPath__True() throws MalformedURLException {
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com")));
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com/")));
+        assertEquals(true, this.customDomainRootPath.isMatch(new URL("http://foo.com/other/test.html?foo=bar")));
+
+        assertEquals(true, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/path")));
+        assertEquals(true, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/path/")));
+        assertEquals(true, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/path/other/test.html?foo=bar")));
+
+        assertEquals(true, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/path")));
+        assertEquals(true, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/path/")));
+        assertEquals(true, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/path/other/test.html?foo=bar")));
+
+        assertEquals(true, this.customDomainWithPathEncodedSpaces.isMatch(new URL("http://foo.com/dir%20path")));
+        assertEquals(true, this.customDomainWithPathEncodedSpaces.isMatch(new URL("http://foo.com/dir%20path?foo=bar")));
+    }
+
+    public void testIsMatch__PathMatchesSubstring__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/pathsuffix/other/test.html")));
+        assertEquals(false, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/pathsuffix/other/test.html")));
+        assertEquals(false, this.customDomainWithPathEncodedSpaces.isMatch(new URL("http://foo.com/dir%20pathsuffix/other/test.html")));
+    }
+
+    public void testIsMatch__PathMatchesCustomPathAsSuffix__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/images/path/foo.png")));
+        assertEquals(false, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/images/path/foo.png")));
+    }
+
+    public void testIsMatch__PathPartiallyMatchesCustomPath__False() throws MalformedURLException {
+        assertEquals(false, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com")));
+        assertEquals(false, this.customDomainWithPathNoTrailingSlash.isMatch(new URL("http://foo.com/")));
+        assertEquals(false, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com")));
+        assertEquals(false, this.customDomainWithPathTrailingSlash.isMatch(new URL("http://foo.com/")));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidatorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguageValidatorTest.java
@@ -1,0 +1,110 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class CustomDomainLanguageValidatorTest extends TestCase {
+    private ArrayList<Lang> supportedLangs;
+
+    protected void setUp() throws Exception {
+        this.supportedLangs = new ArrayList<Lang>();
+        this.supportedLangs.add(Lang.get("en"));
+        this.supportedLangs.add(Lang.get("ja"));
+        this.supportedLangs.add(Lang.get("ko"));
+    }
+
+    public void testValidate__ValidConfiguration__ResultSuccess() throws ConfigurationError {
+        ArrayList<CustomDomainLanguage> customDomainLanguageList = new ArrayList<CustomDomainLanguage>();
+        customDomainLanguageList.add(new CustomDomainLanguage("foo.com", "", Lang.get("en")));
+        customDomainLanguageList.add(new CustomDomainLanguage("foo.com", "/ja", Lang.get("ja")));
+        customDomainLanguageList.add(new CustomDomainLanguage("korea.foo.com", "/ko", Lang.get("ko")));
+
+        ValidationResult result = CustomDomainLanguageValidator.validate(customDomainLanguageList, this.supportedLangs);
+        assertEquals(true, result.success);
+    }
+
+    /*
+    public void testDeserialize__SameLanguageSpecifiedMoreThanOnce__ThrowError() throws ConfigurationError {
+        String input = "site.com/english:en,japan.site.com/:ja,site.com/ja:ja";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testDeserialize__TwoLanguagesWithSameDomainAndPath__ThrowError() throws ConfigurationError {
+        String input = "site.com/english:en,site.com:ja,site.com:ko";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testDeserialize__DomainAndPathDifferingOnlyByTrailingSlash__ThrowError() throws ConfigurationError {
+        String input = "site.com/global:en,site.com:ja,site.com/global/:ko";
+
+        boolean errorThrown = false;
+        try {
+            CustomDomainLanguageSerializer.deserialize(input);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testCreate__UrlPatternCustomDomain__CustomDomainLangsNotDeclaredForAllSupportedLangs__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("sitePrefixPath", "");
+            put("customDomainLangs", "site.com:en,site.co.jp:ja");
+            put("supportedLangs", "en,ja,ko");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testCreate__UrlPatternCustomDomain__CustomDomainLangDeclaredForLanguageNotInSupportedLangs__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("sitePrefixPath", "");
+            put("customDomainLangs", "site.com:en,site.co.jp:ja,site.kr:ko");
+            put("supportedLangs", "en,ja");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testCreate__InvalidUrlPattern__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "invalid");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+    */
+}

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
@@ -16,10 +16,10 @@ public class CustomDomainLanguagesTest extends TestCase {
     private CustomDomainLanguages sut;
 
     protected void setUp() throws Exception {
-        this.french = new CustomDomainLanguage("foo.com", "/", Lang.get("fr"));
+        this.french = new CustomDomainLanguage("foo.com", "", Lang.get("fr"));
         this.japanese = new CustomDomainLanguage("foo.com", "/path", Lang.get("ja"));
         this.german = new CustomDomainLanguage("foo.com", "/dir/path", Lang.get("de"));
-        this.english = new CustomDomainLanguage("english.foo.com", "/", Lang.get("en"));
+        this.english = new CustomDomainLanguage("english.foo.com", "", Lang.get("en"));
 
         ArrayList<CustomDomainLanguage> languageList = new ArrayList<CustomDomainLanguage>();
         languageList.add(this.french);

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
@@ -1,0 +1,77 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class CustomDomainLanguagesTest extends TestCase {
+    private CustomDomainLanguage french;
+    private CustomDomainLanguage japanese;
+    private CustomDomainLanguage german;
+    private CustomDomainLanguage english;
+
+    private CustomDomainLanguages sut;
+
+    protected void setUp() throws Exception {
+        this.french = new CustomDomainLanguage("foo.com", "/", Lang.get("fr"));
+        this.japanese = new CustomDomainLanguage("foo.com", "/path", Lang.get("ja"));
+        this.german = new CustomDomainLanguage("foo.com", "/dir/path", Lang.get("de"));
+        this.english = new CustomDomainLanguage("english.foo.com", "/", Lang.get("en"));
+
+        ArrayList<CustomDomainLanguage> languageList = new ArrayList<CustomDomainLanguage>();
+        languageList.add(this.french);
+        languageList.add(this.japanese);
+        languageList.add(this.german);
+        languageList.add(this.english);
+        this.sut = new CustomDomainLanguages(languageList);
+    }
+
+    public void testGetCustomDomainLanguageByLang__UnknownLanguage__ReturnNull() throws MalformedURLException {
+        assertEquals(null, this.sut.getCustomDomainLanguageByLang("unknown"));
+    }
+
+    public void testGetCustomDomainLanguageByLang__LanguageExists__ReturnMatch() throws MalformedURLException {
+        assertEquals(this.french, this.sut.getCustomDomainLanguageByLang("fr"));
+        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByLang("ja"));
+        assertEquals(this.german, this.sut.getCustomDomainLanguageByLang("de"));
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByLang("en"));
+    }
+
+    public void testGetCustomDomainLanguageByUrl__UrlMatchesDomain__ReturnsMatch() throws MalformedURLException {
+        assertEquals(this.french, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com")));
+        assertEquals(this.french, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/")));
+        assertEquals(this.french, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/test.html")));
+
+        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path")));
+        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path/")));
+        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path/test.html")));
+
+        assertEquals(this.german, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/dir/path")));
+        assertEquals(this.german, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/dir/path/")));
+        assertEquals(this.german, this.sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/dir/path/test.html")));
+
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByUrl(new URL("http://english.foo.com")));
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByUrl(new URL("http://english.foo.com/dir/path")));
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByUrl(new URL("http://english.foo.com/dir/path/")));
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByUrl(new URL("http://english.foo.com/dir/path/test.html")));
+    }
+
+    public void testGetCustomDomainLanguageByUrl__NestedPaths__ReturnsMatch() throws MalformedURLException {
+        CustomDomainLanguage japanese = new CustomDomainLanguage("foo.com", "/path", Lang.get("ja"));
+        CustomDomainLanguage english = new CustomDomainLanguage("foo.com", "/path/en", Lang.get("en"));
+        CustomDomainLanguage french = new CustomDomainLanguage("foo.com", "/path/fr", Lang.get("fr"));
+
+        ArrayList<CustomDomainLanguage> languageList = new ArrayList<CustomDomainLanguage>();
+        languageList.add(french);
+        languageList.add(japanese);
+        languageList.add(english);
+        CustomDomainLanguages sut = new CustomDomainLanguages(languageList);
+
+        assertEquals(japanese, sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path")));
+        assertEquals(english, sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path/en")));
+        assertEquals(french, sut.getCustomDomainLanguageByUrl(new URL("http://foo.com/path/fr")));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainLanguagesTest.java
@@ -30,14 +30,14 @@ public class CustomDomainLanguagesTest extends TestCase {
     }
 
     public void testGetCustomDomainLanguageByLang__UnknownLanguage__ReturnNull() throws MalformedURLException {
-        assertEquals(null, this.sut.getCustomDomainLanguageByLang("unknown"));
+        assertEquals(null, this.sut.getCustomDomainLanguageByLang(null));
     }
 
     public void testGetCustomDomainLanguageByLang__LanguageExists__ReturnMatch() throws MalformedURLException {
-        assertEquals(this.french, this.sut.getCustomDomainLanguageByLang("fr"));
-        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByLang("ja"));
-        assertEquals(this.german, this.sut.getCustomDomainLanguageByLang("de"));
-        assertEquals(this.english, this.sut.getCustomDomainLanguageByLang("en"));
+        assertEquals(this.french, this.sut.getCustomDomainLanguageByLang(Lang.get("fr")));
+        assertEquals(this.japanese, this.sut.getCustomDomainLanguageByLang(Lang.get("ja")));
+        assertEquals(this.german, this.sut.getCustomDomainLanguageByLang(Lang.get("de")));
+        assertEquals(this.english, this.sut.getCustomDomainLanguageByLang(Lang.get("en")));
     }
 
     public void testGetCustomDomainLanguageByUrl__UrlMatchesDomain__ReturnsMatch() throws MalformedURLException {

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -159,4 +159,46 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("http://japan.site.com:6000/cat.png", sut.convertToTargetLanguage("http://site.co.uk:6000/fr/cat.png", this.japanese));
         assertEquals("http://japan.site.com:6000?user=tom", sut.convertToTargetLanguage("http://site.co.uk:6000/fr?user=tom", this.japanese));
     }
+
+    public void testCanInterceptUrl__UrlMatchesCustomDomainLanguage__ReturnTrue() {
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk?user=tom"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/friday/"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/cat.png"));
+
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/fr"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/fr/"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/fr/cat.png"));
+        assertEquals(true, sut.canInterceptUrl("http://site.co.uk/fr?user=tom"));
+
+        assertEquals(true, sut.canInterceptUrl("http://japan.site.com"));
+        assertEquals(true, sut.canInterceptUrl("http://japan.site.com/"));
+        assertEquals(true, sut.canInterceptUrl("http://japan.site.com/cat.png"));
+        assertEquals(true, sut.canInterceptUrl("http://japan.site.com?user=tom"));
+
+        assertEquals(true, sut.canInterceptUrl("https://korean.com/ko"));
+        assertEquals(true, sut.canInterceptUrl("https://korean.com/ko/"));
+        assertEquals(true, sut.canInterceptUrl("https://korean.com/ko/cat.png"));
+        assertEquals(true, sut.canInterceptUrl("https://korean.com/ko?user=tom"));
+    }
+
+    public void testCanInterceptUrl__UrlDoesNotMatchCustomDomainLanguage__ReturnFalse() {
+        assertEquals(false, sut.canInterceptUrl("http://korean.com"));
+        assertEquals(false, sut.canInterceptUrl("http://korean.com/"));
+        assertEquals(false, sut.canInterceptUrl("http://korean.com/cat.png"));
+        assertEquals(false, sut.canInterceptUrl("http://korean.com?user=tom"));
+
+        assertEquals(false, sut.canInterceptUrl("http://example.com"));
+        assertEquals(false, sut.canInterceptUrl("http://example.com/fr"));
+        assertEquals(false, sut.canInterceptUrl("http://example.com/fr/"));
+        assertEquals(false, sut.canInterceptUrl("http://example.com/fr/cat.png"));
+        assertEquals(false, sut.canInterceptUrl("http://example.com/fr?user=tom"));
+    }
+
+    public void testCanInterceptUrl__IncompleteUrl__ReturnFalse() {
+        assertEquals(false, sut.canInterceptUrl("site.co.uk/fr"));
+        assertEquals(false, sut.canInterceptUrl("site.co.uk/fr/cat.png"));
+        assertEquals(false, sut.canInterceptUrl("/fr/global/cat.png"));
+        assertEquals(false, sut.canInterceptUrl("?user=tom"));
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -152,4 +152,11 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
         assertEquals("/fr/global/cat.png", sut.convertToTargetLanguage("/fr/global/cat.png", this.korean));
         assertEquals("?user=tom", sut.convertToTargetLanguage("?user=tom", this.korean));
     }
+
+    public void testConvertToTargetLanguage__SourceUrlHasExplicitPortNumber__ReturnUrlInTargetLanguageWithPortNumber() {
+        assertEquals("http://japan.site.com:6000", sut.convertToTargetLanguage("http://site.co.uk:6000/fr", this.japanese));
+        assertEquals("http://japan.site.com:6000/", sut.convertToTargetLanguage("http://site.co.uk:6000/fr/", this.japanese));
+        assertEquals("http://japan.site.com:6000/cat.png", sut.convertToTargetLanguage("http://site.co.uk:6000/fr/cat.png", this.japanese));
+        assertEquals("http://japan.site.com:6000?user=tom", sut.convertToTargetLanguage("http://site.co.uk:6000/fr?user=tom", this.japanese));
+    }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -1,0 +1,45 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
+    private Lang english;
+    private Lang japanese;
+    private Lang french;
+    private UrlLanguagePatternHandler sut;
+
+    protected void setUp() throws Exception {
+        this.english = Lang.get("en");
+        this.japanese = Lang.get("ja");
+        this.french = Lang.get("fr");
+
+        CustomDomainLanguage englishCDL = new CustomDomainLanguage("site.co.uk", "/", this.english);
+        CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "/", this.japanese);
+        CustomDomainLanguage frenchCDL= new CustomDomainLanguage("site.co.uk", "/fr/", this.french);
+
+        ArrayList<CustomDomainLanguage> langs = new ArrayList<CustomDomainLanguage>();
+        langs.add(englishCDL);
+        langs.add(japaneseCDL);
+        langs.add(frenchCDL);
+
+        CustomDomainLanguages customDomainLanguages = new CustomDomainLanguages(langs);
+        this.sut = new CustomDomainUrlLanguagePatternHandler(this.english, customDomainLanguages);
+        /*
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,ja,fr");
+            put("customDomainLangs", "site.co.uk:en,japan.site.com:ja,site.co.uk/fr:fr");
+        }});
+        this.sut = UrlLanguagePatternHandlerFactory.create(settings);
+        */
+    }
+
+    public void testGetLang__non() {
+        assertEquals(null, sut.getLang("invalid"));
+        assertEquals(this.english, sut.getLang("http://site.co.uk/global/cat.png"));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -7,23 +7,27 @@ import org.easymock.EasyMock;
 
 public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
     private Lang english;
-    private Lang japanese;
     private Lang french;
+    private Lang japanese;
+    private Lang korean;
     private UrlLanguagePatternHandler sut;
 
     protected void setUp() throws Exception {
         this.english = Lang.get("en");
-        this.japanese = Lang.get("ja");
         this.french = Lang.get("fr");
+        this.japanese = Lang.get("ja");
+        this.korean = Lang.get("ko");
 
         CustomDomainLanguage englishCDL = new CustomDomainLanguage("site.co.uk", "/", this.english);
-        CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "/", this.japanese);
         CustomDomainLanguage frenchCDL= new CustomDomainLanguage("site.co.uk", "/fr/", this.french);
+        CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "/", this.japanese);
+        CustomDomainLanguage koreanCDL = new CustomDomainLanguage("korean.com", "/ko/", this.korean);
 
         ArrayList<CustomDomainLanguage> langs = new ArrayList<CustomDomainLanguage>();
         langs.add(englishCDL);
-        langs.add(japaneseCDL);
         langs.add(frenchCDL);
+        langs.add(japaneseCDL);
+        langs.add(koreanCDL);
 
         CustomDomainLanguages customDomainLanguages = new CustomDomainLanguages(langs);
         this.sut = new CustomDomainUrlLanguagePatternHandler(this.english, customDomainLanguages);
@@ -38,8 +42,80 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
         */
     }
 
-    public void testGetLang__non() {
+    public void testGetLang__HasMatch__ReturnConvertedUrl() {
+        assertEquals(this.english, sut.getLang("http://site.co.uk"));
+        assertEquals(this.english, sut.getLang("http://site.co.uk/"));
+        assertEquals(this.english, sut.getLang("http://site.co.uk/global/"));
+        assertEquals(this.english, sut.getLang("https://site.co.uk/global/graph.png"));
+        assertEquals(this.english, sut.getLang("http://site.co.uk?user=tom"));
+
+        assertEquals(this.french, sut.getLang("http://site.co.uk/fr"));
+        assertEquals(this.french, sut.getLang("http://site.co.uk/fr/"));
+        assertEquals(this.french, sut.getLang("http://site.co.uk/fr/global"));
+        assertEquals(this.french, sut.getLang("https://site.co.uk/fr/graph.png?user=tom"));
+        assertEquals(this.french, sut.getLang("http://site.co.uk/fr?user=tom"));
+
+        assertEquals(this.japanese, sut.getLang("http://japan.site.com"));
+        assertEquals(this.japanese, sut.getLang("http://japan.site.com/"));
+        assertEquals(this.japanese, sut.getLang("http://japan.site.com/global"));
+        assertEquals(this.japanese, sut.getLang("https://japan.site.com/global/graph.png?user=tom"));
+        assertEquals(this.japanese, sut.getLang("http://japan.site.com?user=tom"));
+
+        assertEquals(this.korean, sut.getLang("http://korean.com/ko"));
+        assertEquals(this.korean, sut.getLang("http://korean.com/ko/"));
+        assertEquals(this.korean, sut.getLang("http://korean.com/ko/global"));
+        assertEquals(this.korean, sut.getLang("https://korean.com/ko?user=tom"));
+    }
+
+    public void testGetLang__InvalidUrl__ReturnNull() {
+        assertEquals(null, sut.getLang(""));
         assertEquals(null, sut.getLang("invalid"));
-        assertEquals(this.english, sut.getLang("http://site.co.uk/global/cat.png"));
+        assertEquals(null, sut.getLang("http:"));
+        assertEquals(null, sut.getLang("site.co.uk"));
+        assertEquals(null, sut.getLang("/fr/cat.png"));
+        assertEquals(null, sut.getLang("japan.site.com/cat.png"));
+    }
+
+    public void testGetLang__NonMatchingUrl__ReturnNull() {
+        assertEquals(null, sut.getLang("http://site.com"));
+        assertEquals(null, sut.getLang("http://site.com/cat.png"));
+        assertEquals(null, sut.getLang("http://japan.site.co.uk/fr/cat.png"));
+        assertEquals(null, sut.getLang("http://korean.com"));
+        assertEquals(null, sut.getLang("http://korean.com/"));
+        assertEquals(null, sut.getLang("http://korean.com/cat.png"));
+        assertEquals(null, sut.getLang("http://korean.com?user=tom"));
+    }
+
+    public void testConvertToDefaultLanguage__ValidRequest__ReturnUrlInDefaultLanguage() {
+        assertEquals("http://site.co.uk", sut.convertToDefaultLanguage("http://site.co.uk"));
+        assertEquals("http://site.co.uk/friday/", sut.convertToDefaultLanguage("http://site.co.uk/friday/"));
+
+        assertEquals("http://site.co.uk", sut.convertToDefaultLanguage("http://site.co.uk/fr"));
+        assertEquals("http://site.co.uk/", sut.convertToDefaultLanguage("http://site.co.uk/fr/"));
+        assertEquals("http://site.co.uk/cat.png", sut.convertToDefaultLanguage("http://site.co.uk/fr/cat.png"));
+        assertEquals("http://site.co.uk?user=tom", sut.convertToDefaultLanguage("http://site.co.uk/fr?user=tom"));
+
+        assertEquals("http://site.co.uk", sut.convertToDefaultLanguage("http://japan.site.com"));
+        assertEquals("http://site.co.uk/", sut.convertToDefaultLanguage("http://japan.site.com/"));
+        assertEquals("http://site.co.uk/cat.png", sut.convertToDefaultLanguage("http://japan.site.com/cat.png"));
+        assertEquals("http://site.co.uk?user=tom", sut.convertToDefaultLanguage("http://japan.site.com?user=tom"));
+
+        assertEquals("https://site.co.uk", sut.convertToDefaultLanguage("https://korean.com/ko"));
+        assertEquals("https://site.co.uk/", sut.convertToDefaultLanguage("https://korean.com/ko/"));
+        assertEquals("https://site.co.uk/cat.png", sut.convertToDefaultLanguage("https://korean.com/ko/cat.png"));
+        assertEquals("https://site.co.uk?user=tom", sut.convertToDefaultLanguage("https://korean.com/ko?user=tom"));
+    }
+
+    public void testConvertToDefaultLanguage__NonMatchingUrl__DoNotModify() {
+        assertEquals("http://korean.com", sut.convertToDefaultLanguage("http://korean.com"));
+        assertEquals("http://korean.com/", sut.convertToDefaultLanguage("http://korean.com/"));
+        assertEquals("http://korean.com/cat.png", sut.convertToDefaultLanguage("http://korean.com/cat.png"));
+        assertEquals("http://korean.com?user=tom", sut.convertToDefaultLanguage("http://korean.com?user=tom"));
+
+        assertEquals("http://example.com", sut.convertToDefaultLanguage("http://example.com"));
+        assertEquals("http://example.com/fr", sut.convertToDefaultLanguage("http://example.com/fr"));
+        assertEquals("http://example.com/fr/", sut.convertToDefaultLanguage("http://example.com/fr/"));
+        assertEquals("http://example.com/fr/cat.png", sut.convertToDefaultLanguage("http://example.com/fr/cat.png"));
+        assertEquals("http://example.com/fr?user=tom", sut.convertToDefaultLanguage("http://example.com/fr?user=tom"));
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -18,10 +18,10 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
         this.japanese = Lang.get("ja");
         this.korean = Lang.get("ko");
 
-        CustomDomainLanguage englishCDL = new CustomDomainLanguage("site.co.uk", "/", this.english);
-        CustomDomainLanguage frenchCDL= new CustomDomainLanguage("site.co.uk", "/fr/", this.french);
-        CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "/", this.japanese);
-        CustomDomainLanguage koreanCDL = new CustomDomainLanguage("korean.com", "/ko/", this.korean);
+        CustomDomainLanguage englishCDL = new CustomDomainLanguage("site.co.uk", "", this.english);
+        CustomDomainLanguage frenchCDL= new CustomDomainLanguage("site.co.uk", "/fr", this.french);
+        CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "", this.japanese);
+        CustomDomainLanguage koreanCDL = new CustomDomainLanguage("korean.com", "/ko", this.korean);
 
         ArrayList<CustomDomainLanguage> langs = new ArrayList<CustomDomainLanguage>();
         langs.add(englishCDL);

--- a/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/CustomDomainUrlLanguagePatternHandlerTest.java
@@ -1,7 +1,6 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 import junit.framework.TestCase;
 import org.easymock.EasyMock;
@@ -19,7 +18,6 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
         this.japanese = Lang.get("ja");
         this.korean = Lang.get("ko");
 
-        /*
         CustomDomainLanguage englishCDL = new CustomDomainLanguage("site.co.uk", "/", this.english);
         CustomDomainLanguage frenchCDL= new CustomDomainLanguage("site.co.uk", "/fr/", this.french);
         CustomDomainLanguage japaneseCDL = new CustomDomainLanguage("japan.site.com", "/", this.japanese);
@@ -33,14 +31,6 @@ public class CustomDomainUrlLanguagePatternHandlerTest extends TestCase {
 
         CustomDomainLanguages customDomainLanguages = new CustomDomainLanguages(langs);
         this.sut = new CustomDomainUrlLanguagePatternHandler(this.english, customDomainLanguages);
-        */
-        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
-            put("urlPattern", "customDomain");
-            put("defaultLang", "en");
-            put("supportedLangs", "en,fr,ja,ko");
-            put("customDomainLangs", "site.co.uk:en,site.co.uk/fr:fr,japan.site.com:ja,korean.com/ko:ko");
-        }});
-        this.sut = UrlLanguagePatternHandlerFactory.create(settings);
     }
 
     public void testGetLang__HasMatch__ReturnConvertedUrl() {

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -360,6 +360,7 @@ public class HeadersTest extends TestCase {
     private Headers makeHeaderWithSitePrefixPath(String requestPath, String sitePrefixPath) throws ConfigurationError {
         HttpServletRequest mockRequest = mockRequestPath(requestPath);
         HashMap<String, String> option = new HashMap<String, String>() {{
+            put("urlPattern", "path");
             put("sitePrefixPath", sitePrefixPath);
         }};
         Settings s = TestUtil.makeSettings(option);

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -121,10 +121,31 @@ public class HtmlConverterTest extends TestCase {
         HashMap<String, String> option = new HashMap<String, String>() {{
             put("defaultLang", "ja");
             put("supportedLangs", "ja,en,th");
+            put("urlPattern", "path");
             put("sitePrefixPath", "global");
         }};
         Settings settings = TestUtil.makeSettings(option);
         HtmlConverter converter = this.createHtmlConverter(settings, location, original);
+
+        assertEquals(expectedHtml, converter.convert("ja"));
+    }
+
+    public void testConvertWithCustomDomain() throws ConfigurationError {
+        String original = "<html><head></head><body></body></html>";
+        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=custom_domain&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "\" data-wovnio-type=\"fallback\" async></script>";
+        String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.co.jp/tokyo\">" +
+                                   "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/english/tokyo\">";
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = "<html><head>" + expectedSnippet + expectedHrefLangs + expectedContentType + "</head><body></body></html>";
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "customDomain");
+            put("customDomainLangs", "site.co.jp:ja,site.com/english:en");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, "https://site.co.jp/tokyo", original);
 
         assertEquals(expectedHtml, converter.convert("ja"));
     }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -132,7 +132,7 @@ public class HtmlConverterTest extends TestCase {
 
     public void testConvertWithCustomDomain() throws ConfigurationError {
         String original = "<html><head></head><body></body></html>";
-        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=custom_domain&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "\" data-wovnio-type=\"fallback\" async></script>";
+        String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=custom_domain&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;customDomainLangs={&quot;site.com/english/&quot;:&quot;en&quot;,&quot;site.co.jp/&quot;:&quot;ja&quot;}\" data-wovnio-type=\"fallback\" async></script>";
         String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.co.jp/tokyo\">" +
                                    "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/english/tokyo\">";
         String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -397,7 +397,9 @@ public class SettingsTest extends TestCase {
 
     public void testCustomDomainLangs__SuccessfullyParseCustomDomainLangs() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("customDomainLangs", "site.com:en,site.com/ja:ja");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,ja,fr");
+            put("customDomainLangs", "site.com:en,site.com/ja:ja,france.com/:fr");
         }});
         Settings s = new Settings(config);
         ArrayList<CustomDomainLanguage> customDomainLanguageList = s.customDomainLanguages.customDomainLanguageList;

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -387,6 +387,14 @@ public class SettingsTest extends TestCase {
         assertEquals(Settings.DefaultTimeout, s.readTimeout);
     }
 
+    public void testCustomDomainLangs__AcceptRawCustomDomainLangsString() throws ConfigurationError {
+        FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
+            put("customDomainLangs", "site.com:en");
+        }});
+        Settings s = new Settings(config);
+        assertEquals("site.com:en", s.rawCustomDomainLangs);
+    }
+
     public void testConnectTimeout__InvalidInteger__ThrowError() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
             put("connectTimeout", "hoge");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -137,6 +137,22 @@ public class SettingsTest extends TestCase {
         assertEquals(true, errorThrown);
     }
 
+    public void testRequiredSettings__SupportedLangDeclaredMultipleTimes__throwError() throws ConfigurationError {
+        FilterConfig config = TestUtil.makeConfig(new HashMap<String, String>() {{
+            put("projectToken", "123456");
+            put("urlPattern", "path");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,ja,ja");
+        }});
+        boolean errorThrown = false;
+        try {
+            Settings s = new Settings(config);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
     public void testRequiredSettings__LegacyUserTokenDeclared__SetProjectTokenAsUserToken() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfig(new HashMap<String, String>() {{
             put("userToken", "98765");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -395,12 +395,20 @@ public class SettingsTest extends TestCase {
         assertEquals(Settings.DefaultTimeout, s.readTimeout);
     }
 
-    public void testCustomDomainLangs__AcceptRawCustomDomainLangsString() throws ConfigurationError {
+    public void testCustomDomainLangs__SuccessfullyParseCustomDomainLangs() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("customDomainLangs", "site.com:en");
+            put("customDomainLangs", "site.com:en,site.com/ja:ja");
         }});
         Settings s = new Settings(config);
-        assertEquals("site.com:en", s.rawCustomDomainLangs);
+        ArrayList<CustomDomainLanguage> customDomainLanguageList = s.customDomainLanguages.customDomainLanguageList;
+
+        assertEquals("ja", customDomainLanguageList.get(0).lang.code);
+        assertEquals("site.com", customDomainLanguageList.get(0).host);
+        assertEquals("/ja", customDomainLanguageList.get(0).path);
+
+        assertEquals("en", customDomainLanguageList.get(1).lang.code);
+        assertEquals("site.com", customDomainLanguageList.get(1).host);
+        assertEquals("", customDomainLanguageList.get(1).path);
     }
 
     public void testConnectTimeout__InvalidInteger__ThrowError() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactoryTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactoryTest.java
@@ -1,0 +1,89 @@
+package com.github.wovnio.wovnjava;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+
+public class UrlLanguagePatternHandlerFactoryTest extends TestCase {
+    public void testCreate__UrlPatternPath() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "path");
+        }});
+        UrlLanguagePatternHandler result = UrlLanguagePatternHandlerFactory.create(settings);
+        assertEquals(true, result instanceof PathUrlLanguagePatternHandler);
+    }
+
+    public void testCreate__UrlPatternQuery() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "query");
+        }});
+        UrlLanguagePatternHandler result = UrlLanguagePatternHandlerFactory.create(settings);
+        assertEquals(true, result instanceof QueryUrlLanguagePatternHandler);
+    }
+
+    public void testCreate__UrlPatternSubdomain() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "subdomain");
+        }});
+        UrlLanguagePatternHandler result = UrlLanguagePatternHandlerFactory.create(settings);
+        assertEquals(true, result instanceof SubdomainUrlLanguagePatternHandler);
+    }
+
+    public void testCreate__UrlPatternCustomDomain() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("sitePrefixPath", "");
+            put("customDomainLangs", "site.com:en,site.co.jp:ja");
+            put("supportedLangs", "en,ja");
+        }});
+        UrlLanguagePatternHandler result = UrlLanguagePatternHandlerFactory.create(settings);
+        assertEquals(true, result instanceof CustomDomainUrlLanguagePatternHandler);
+    }
+
+    public void testCreate__UrlPatternCustomDomain__CustomDomainLangNotDeclaredForAllSupportedLangs__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("sitePrefixPath", "");
+            put("customDomainLangs", "site.com:en,site.co.jp:ja");
+            put("supportedLangs", "en,ja,ko");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testCreate__UrlPatternCustomDomain__CustomDomainLangDeclaredForLanguageNotInSupportedLangs__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "customDomain");
+            put("sitePrefixPath", "");
+            put("customDomainLangs", "site.com:en,site.co.jp:ja,site.kr:ko");
+            put("supportedLangs", "en,ja");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+
+    public void testCreate__InvalidUrlPattern__ThrowError() throws ConfigurationError {
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("urlPattern", "invalid");
+        }});
+        boolean errorThrown = false;
+        try {
+            UrlLanguagePatternHandlerFactory.create(settings);
+        } catch (ConfigurationError e) {
+            errorThrown = true;
+        }
+        assertEquals(true, errorThrown);
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactoryTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlLanguagePatternHandlerFactoryTest.java
@@ -1,6 +1,5 @@
 package com.github.wovnio.wovnjava;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 
 import junit.framework.TestCase;
@@ -42,28 +41,10 @@ public class UrlLanguagePatternHandlerFactoryTest extends TestCase {
         assertEquals(true, result instanceof CustomDomainUrlLanguagePatternHandler);
     }
 
-    public void testCreate__UrlPatternCustomDomain__CustomDomainLangNotDeclaredForAllSupportedLangs__ThrowError() throws ConfigurationError {
+    public void testCreate__UrlPatternCustomDomain__CustomDomainLangsNotConfigured__ThrowError() throws ConfigurationError {
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("urlPattern", "customDomain");
-            put("sitePrefixPath", "");
-            put("customDomainLangs", "site.com:en,site.co.jp:ja");
             put("supportedLangs", "en,ja,ko");
-        }});
-        boolean errorThrown = false;
-        try {
-            UrlLanguagePatternHandlerFactory.create(settings);
-        } catch (ConfigurationError e) {
-            errorThrown = true;
-        }
-        assertEquals(true, errorThrown);
-    }
-
-    public void testCreate__UrlPatternCustomDomain__CustomDomainLangDeclaredForLanguageNotInSupportedLangs__ThrowError() throws ConfigurationError {
-        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
-            put("urlPattern", "customDomain");
-            put("sitePrefixPath", "");
-            put("customDomainLangs", "site.com:en,site.co.jp:ja,site.kr:ko");
-            put("supportedLangs", "en,ja");
         }});
         boolean errorThrown = false;
         try {


### PR DESCRIPTION
## Custom Domain
Custom Domain is a URL pattern configuration alternative to path, query, and subdomain. It can specify the domain and path corresponding to each language independently.

### Example 
Example domain and path mapping to original language Japanese plus two target languages:
```
"www.site.co.jp"       -> Japanese
"www.site.com/english" -> English
"spain.site.com"       -> Spanish
```
For this example mapping, the URL `http://www.site.co.jp/about.html` will map to the three languages as follows
```
Japanese  -> "http://www.site.co.jp/about.html"
English   -> "http://www.site.com/english/about.html"
Spanish   -> "http://spain.site.com/about.html"
```
The corresponding `web.xml` configuration looks as follows
```xml
<filter>
  ...
  <init-param>
    <param-name>defaultLang</param-name>
    <param-value>ja</param-value>
  </init-param>
  <init-param>
    <param-name>supportedLangs</param-name>
    <param-value>ja,en,es</param-value>
  </init-param>
  <init-param>
    <param-name>urlPattern</param-name>
    <param-value>customDomain</param-value>
  </init-param>
  <init-param>
    <param-name>customDomainLangs</param-name>
    <param-value>www.site.co.jp:ja,www.site.com/english:en,spain.site.com:es</param-value>
  </init-param>
  ...
</filter>
```