### PR TITLE
Use LinkedHashMap for deterministic hreflang ordering

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -1,6 +1,6 @@
 package com.github.wovnio.wovnjava;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.net.URL;
 import java.net.MalformedURLException;
 
@@ -115,8 +115,8 @@ class Headers {
         return this.isValidRequest;
     }
 
-    public HashMap<String, String> getHreflangUrlMap() {
-        HashMap<String, String> hreflangs = new HashMap<String, String>();
+    public LinkedHashMap<String, String> getHreflangUrlMap() {
+        LinkedHashMap<String, String> hreflangs = new LinkedHashMap<String, String>();
         for (Lang supportedLang : this.settings.supportedLangs) {
             String hreflangCode = supportedLang.codeISO639_1;
             String url = this.urlLanguagePatternHandler.convertToTargetLanguage(this.clientRequestUrlInDefaultLanguage, supportedLang);

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -112,9 +112,9 @@ public class HtmlConverterTest extends TestCase {
     public void testConvertWithSitePrefixPath() throws ConfigurationError {
         String original = "<html><head></head><body></body></html>";
         String expectedSnippet = "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + Settings.VERSION + "&amp;sitePrefixPath=global\" data-wovnio-type=\"fallback\" async></script>";
-        String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">" +
-                                   "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
-                                   "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">";
+        String expectedHrefLangs = "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/global/tokyo/\">" +
+                                   "<link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/en/tokyo/\">" +
+                                   "<link ref=\"alternate\" hreflang=\"th\" href=\"https://site.com/global/th/tokyo/\">";
         String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
         String expectedHtml = "<html><head>" + expectedSnippet + expectedHrefLangs + expectedContentType + "</head><body></body></html>";
 

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -37,8 +37,8 @@ public class InterceptorTest extends TestCase {
         String html = translate("https://example.com/ja/", originalHtml, settings, mockApiTimeout(), mockResponseHeadersTimeout());
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
-                        "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
+                        "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +
                         "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" +
                         "</head><body>test</body></html>";
@@ -55,8 +55,8 @@ public class InterceptorTest extends TestCase {
         String html = translate("https://example.com/", originalHtml, settings, null, null);
         String expect = "<!doctype html><html><head><title>test</title>" +
                         "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={}&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
-                        "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
+                        "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
                         "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +
                         "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" +
                         "</head><body>test</body></html>";


### PR DESCRIPTION
Hreflang elements are currently selected by iterating over a HashMap, which has undefined order.
Change implementation to use LinkedHashMap instead which iterates over elements in inserted order, such that tests do not change needlessly when compiling the library with various JDKs etc.

As a result, hreflang elements will now be inserted in the same order as specified in the `supportedLangs` setting.