### PR TITLE
Hide version number option

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMo
 
 A flag to control whether or not to show wovnjava version number in the `X-Wovn-Handler` HTTP response header.
 
-Turn off showVersion by setting the parameter to false.
+Hide wovnjava version number from HTTP header by setting `showVersion` to false.
 ```XML
 <init-param>
   <param-name>showVersion</param-name>

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ enableFlushBuffer         |          | false
 sitePrefixPath            |          |
 customDomainLangs         |          |
 debugMode                 |          | false
+showVersion               |          | true
 
 ### 2.1. projectToken (required)
 
@@ -335,6 +336,18 @@ Using `wovnDebugMode` as a query parameter will activate embedded debug informat
 This is intended to better understand what the problem is if something is not working correctly with wovnjava on your server.
 
 _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMode is turned on in your wovnjava configuration._
+
+### 2.12. showVersion
+
+A flag to disable hide the version number of `X-Wovn-Handler` header.
+
+Turn off showVersion by setting the parameter to false.
+```XML
+<init-param>
+  <param-name>showVersion</param-name>
+  <param-value>false</param-value>
+</init-param>
+```
 
 ## Supported Langauges
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMo
 
 ### 2.12. showVersion
 
-A flag to disable hide the version number of `X-Wovn-Handler` header.
+A flag to control whether or not to show wovnjava version number in the `X-Wovn-Handler` HTTP response header.
 
 Turn off showVersion by setting the parameter to false.
 ```XML

--- a/README_ja.md
+++ b/README_ja.md
@@ -162,3 +162,14 @@ wovnjava は下記の設定で書き換え前の URL を使って、正しい翻
 ※ 上記のリクエストヘッダ設定のサンプルは、下記ページから引用しています。
 
 https://coderwall.com/p/jhkw7w/passing-request-uri-into-request-header
+
+### 2.7. showVersion
+
+showVersion を `false` に設定すると、`X-Wovn-Hander`のバージョン番号を隠すことができます。
+```XML
+<init-param>
+  <param-name>showVersion</param-name>
+  <param-value>false</param-value>
+</init-param>
+```
+

--- a/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
@@ -43,6 +43,15 @@ class FilterConfigReader {
         return param.equals("on") || param.equals("true") || param.equals("1");
     }
 
+    boolean getBoolParameterDefaultTrue(String paramName) {
+        String param = this.config.getInitParameter(paramName);
+        if (param == null) {
+            return true;
+        }
+        param = param.trim().toLowerCase();
+        return !(param.equals("off") || param.equals("false") || param.equals("0"));
+    }
+
     ArrayList<String> getArrayParameter(String paramName) {
         String param = this.getStringParameter(paramName);
         ArrayList<String> al = new ArrayList<String>();

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -28,6 +28,7 @@ class Settings {
     public final boolean debugMode;
     public final boolean useProxy;
     public final boolean enableFlushBuffer;
+    public final boolean showVersion;
 
     public final String sitePrefixPath;
     public final CustomDomainLanguages customDomainLanguages;
@@ -56,6 +57,7 @@ class Settings {
         this.debugMode = reader.getBoolParameterDefaultFalse("debugMode");
         this.useProxy = reader.getBoolParameterDefaultFalse("useProxy");
         this.enableFlushBuffer = reader.getBoolParameterDefaultFalse("enableFlushBuffer");
+        this.showVersion = reader.getBoolParameterDefaultTrue("showVersion");
 
         this.sitePrefixPath = normalizeSitePrefixPath(reader.getStringParameter("sitePrefixPath"));
         this.customDomainLanguages = parseCustomDomainLangs(reader.getStringParameter("customDomainLangs"), this.supportedLangs);
@@ -175,6 +177,7 @@ class Settings {
         md.update(useProxy ? new byte[]{ 0 } : new byte[] { 1 });
         md.update(originalUrlHeader.getBytes());
         md.update(originalQueryStringHeader.getBytes());
+        md.update(showVersion ? new byte[] { 0 } : new byte[] { 1 });
         byte[] digest = md.digest();
         return DatatypeConverter.printHexBinary(digest).toUpperCase();
     }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -41,7 +41,11 @@ public class WovnServletFilter implements Filter {
         if (((HttpServletResponse)response).containsHeader("X-Wovn-Handler")) {
             isRequestAlreadyProcessed = true;
         } else {
-            ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+            if (this.settings.showVersion) {
+                ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
+            } else {
+                ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava");
+            }
         }
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -21,6 +21,7 @@ public class WovnServletFilter implements Filter {
     private UrlLanguagePatternHandler urlLanguagePatternHandler;
     private FileExtensionMatcher fileExtensionMatcher;
     private final HtmlChecker htmlChecker = new HtmlChecker();
+    private String wovnHandlerHeaderValue;
 
     public static final String VERSION = Settings.VERSION;  // for backward compatibility
 
@@ -30,6 +31,7 @@ public class WovnServletFilter implements Filter {
             this.settings = new Settings(config);
             this.urlLanguagePatternHandler = UrlLanguagePatternHandlerFactory.create(settings);
             this.fileExtensionMatcher = new FileExtensionMatcher();
+            this.wovnHandlerHeaderValue = this.getWovnHandlerHeaderValue();
         } catch (ConfigurationError e) {
             throw new ServletException("WovnServletFilter ConfigurationError: " + e.getMessage() + " (See WovnServletFilter instructions at https://github.com/WOVNio/wovnjava)");
         }
@@ -41,11 +43,7 @@ public class WovnServletFilter implements Filter {
         if (((HttpServletResponse)response).containsHeader("X-Wovn-Handler")) {
             isRequestAlreadyProcessed = true;
         } else {
-            if (this.settings.showVersion) {
-                ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
-            } else {
-                ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava");
-            }
+            ((HttpServletResponse) response).setHeader("X-Wovn-Handler", this.wovnHandlerHeaderValue);
         }
 
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
@@ -116,4 +114,13 @@ public class WovnServletFilter implements Filter {
             out.close();
         }
     }
+
+    private String getWovnHandlerHeaderValue() {
+        if (this.settings.showVersion) {
+            return "wovnjava_" + Settings.VERSION;
+        } else {
+            return "wovnjava";
+        }
+    }
+
 }

--- a/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
@@ -83,6 +83,28 @@ public class FilterConfigReaderTest extends TestCase {
         assertEquals(false, reader.getBoolParameterDefaultFalse("0"));
     }
 
+    public void testGetBoolParameterDefaultTrue() {
+        FilterConfig config = TestUtil.makeConfig(new HashMap<String, String>() {
+            {
+                put("off", "off");
+                put("false", "false");
+                put("1", "1");
+                put("0", "0");
+                put("empty-string", "");
+            }
+        });
+        FilterConfigReader reader = new FilterConfigReader(config);
+
+        assertEquals(false, reader.getBoolParameterDefaultTrue("off"));
+        assertEquals(false, reader.getBoolParameterDefaultTrue("false"));
+        assertEquals(false, reader.getBoolParameterDefaultTrue("0"));
+
+        assertEquals(true, reader.getBoolParameterDefaultTrue(null));
+        assertEquals(true, reader.getBoolParameterDefaultTrue("not-set"));
+        assertEquals(true, reader.getBoolParameterDefaultTrue("empty-string"));
+        assertEquals(true, reader.getBoolParameterDefaultTrue("1"));
+    }
+
     public void testGetArrayParameter() {
         FilterConfig config = TestUtil.makeConfig(new HashMap<String, String>() {{
             put("empty-string", "");

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -38,6 +38,7 @@ public class SettingsTest extends TestCase {
         assertEquals(false, s.debugMode);
         assertEquals(false, s.useProxy);
         assertEquals(false, s.enableFlushBuffer);
+        assertEquals(true, s.showVersion);
 
         assertEquals("", s.sitePrefixPath);
         assertEquals("", s.originalUrlHeader);
@@ -214,12 +215,14 @@ public class SettingsTest extends TestCase {
             put("debugMode", "on");
             put("useProxy", "1");
             put("enableFlushBuffer", "false");
+            put("showVersion", "false");
         }});
         Settings s = new Settings(config);
         assertEquals(true, s.devMode);
         assertEquals(true, s.debugMode);
         assertEquals(true, s.useProxy);
         assertEquals(false, s.enableFlushBuffer);
+        assertEquals(false, s.showVersion);
     }
 
     public void testSitePrefixPath__DeclareEmptyString__UseEmptyString() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -13,57 +13,57 @@ import junit.framework.TestCase;
 
 import org.easymock.EasyMock;
 
-
 public class WovnServletFilterTest extends TestCase {
-    public void testHtml() throws ServletException, IOException {
+    public void testHtml() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", pathOption);
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("/", mock.req.getRequestURI());
     }
 
-    public void testHtmlWithLang() throws ServletException, IOException {
+    public void testHtmlWithLang() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/", pathOption);
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("https://example.com/", mock.req.getRequestURL().toString());
     }
 
-    public void testHtmlWithQueryLang() throws ServletException, IOException {
+    public void testHtmlWithQueryLang() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/?wovn=ja", queryOption);
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("/", mock.req.getRequestURI());
     }
 
-    public void testHtmlWithSubdomain() throws ServletException, IOException {
+    public void testHtmlWithSubdomain() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", subdomainOption("ja.wovn.io"));
         assertEquals("text/html; charset=utf-8", mock.res.getContentType());
         assertEquals("/", mock.req.getRequestURI());
     }
 
-    public void testCss() throws ServletException, IOException {
+    public void testCss() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/css", "/dir/style.css", pathOption);
         assertEquals("text/css", mock.res.getContentType());
         assertEquals("/dir/style.css", mock.req.getRequestURI());
     }
 
-    public void testCssWithLang() throws ServletException, IOException {
+    public void testCssWithLang() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css", pathOption);
         assertEquals("text/css", mock.res.getContentType());
         assertEquals("https://example.com/style.css", mock.req.getRequestURL().toString());
     }
 
-    public void testImage() throws ServletException, IOException {
+    public void testImage() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("image/png", "/image.png", pathOption);
         assertEquals("image/png", mock.res.getContentType());
         assertEquals("/image.png", mock.req.getRequestURI());
     }
 
-    public void testImageWithLang() throws ServletException, IOException {
+    public void testImageWithLang() throws ServletException, IOException, ConfigurationError {
         FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png", pathOption);
         assertEquals("image/png", mock.res.getContentType());
         assertEquals("https://example.com/image.png", mock.req.getRequestURL().toString());
     }
 
-    public void testProcessRequestOnce__RequestNotProcessed__ProcessRequest() throws ServletException, IOException {
+    public void testProcessRequestOnce__RequestNotProcessed__ProcessRequest() throws ServletException, IOException,
+            ConfigurationError {
         HashMap<String, String> config = new HashMap<String, String>() {{
             put("urlPattern", "path");
             put("defaultLang", "ja");
@@ -78,7 +78,8 @@ public class WovnServletFilterTest extends TestCase {
         assertEquals(true, responseObjectPassedToFilterChain instanceof WovnHttpServletResponse);
     }
 
-    public void testProcessRequestOnce__RequestAlreadyProcessed__DoNotProcessRequestAgain() throws ServletException, IOException {
+    public void testProcessRequestOnce__RequestAlreadyProcessed__DoNotProcessRequestAgain() throws ServletException, IOException,
+            ConfigurationError {
         HashMap<String, String> config = new HashMap<String, String>() {{
             put("urlPattern", "path");
             put("defaultLang", "ja");
@@ -91,6 +92,10 @@ public class WovnServletFilterTest extends TestCase {
         // If wovnjava is ignoring the request, the response object should NOT be wrapped in a WovnHttpServletResponse
         assertEquals(true, responseObjectPassedToFilterChain instanceof HttpServletResponse);
         assertEquals(false, responseObjectPassedToFilterChain instanceof WovnHttpServletResponse);
+    }
+
+    public void testConfigShowVersion() throws ServletException, IOException, ConfigurationError {
+        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/", showVersionOption);
     }
 
     private final HashMap<String, String> pathOption = new HashMap<String, String>() {{
@@ -107,4 +112,8 @@ public class WovnServletFilterTest extends TestCase {
             put("host", host);
         }};
     }
+
+    private final HashMap<String, String> showVersionOption = new HashMap<String, String>() {{
+        put("showVersion", "false");
+    }};
 }


### PR DESCRIPTION
- Added a new `showVersion` setting.

Set showVersion to false, you can hide the version number of the X-Wovn-Handler header.

Note: Since there was a request for java7_support, java7_support will be merged with master and java6_support in the same way.