### PR TITLE
[Fix] Changed character encoding only when converting HTML

### DIFF
--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -98,12 +98,13 @@ public class WovnServletFilter implements Filter {
                 Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
                 body = interceptor.translate(originalBody);
+
+                wovnResponse.setCharacterEncoding("utf-8");
             } else {
                 // css, javascript or others
                 body = originalBody;
             }
             wovnResponse.setContentLength(body.getBytes().length);
-            wovnResponse.setCharacterEncoding("utf-8");
             PrintWriter out = response.getWriter();
             out.write(body);
             out.close();


### PR DESCRIPTION
### Purpose/goal of PR

Don't need to set the character code the content-type is not HTML.
Fixed a bug that it is converted to image/png;charset=utf-8 when content-type is image/png.