### PR TITLE
Fixed the problem of converting everything to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.1.1-java7</version>
+    <version>1.1.2-java7</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -25,11 +25,13 @@ class HtmlChecker {
     }
 
     public boolean isTextContentType(String type) {
+        String contentType = type.toLowerCase();
+
         return type == null
-            || type.toLowerCase().contains("text")
-            || type.toLowerCase().contains("html")
-            || type.toLowerCase().contains("application/json")
-            || type.toLowerCase().contains("application/javascript");
+            || contentType.contains("text")
+            || contentType.contains("html")
+            || contentType.contains("application/json")
+            || contentType.contains("application/javascript");
     }
 
     private boolean isAmp(String head) {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -25,10 +25,12 @@ class HtmlChecker {
     }
 
     public boolean isTextContentType(String type) {
+        if (type == null)
+            return true;
+
         String contentType = type.toLowerCase();
 
-        return type == null
-            || contentType.contains("text")
+        return contentType.contains("text")
             || contentType.contains("html")
             || contentType.contains("application/json")
             || contentType.contains("application/javascript");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -24,6 +24,14 @@ class HtmlChecker {
         return isHtml(head) && !isAmp(head);
     }
 
+    public boolean isTextContentType(String type) {
+        return type == null
+            || type.toLowerCase().contains("text")
+            || type.toLowerCase().contains("html")
+            || type.toLowerCase().contains("application/json")
+            || type.toLowerCase().contains("application/javascript");
+    }
+
     private boolean isAmp(String head) {
         Element element = Jsoup.parse(head).getElementsByTag("html").first();
         return element != null && (element.hasAttr("amp") || element.hasAttr("⚡"));

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -89,8 +89,9 @@ public class WovnServletFilter implements Filter {
             wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
         }
 
-        String originalBody = wovnResponse.toString();
-        if (originalBody != null) {
+        if (htmlChecker.isTextContentType(response.getContentType())) {
+            String originalBody = wovnResponse.toString();
+
             // text
             String body = null;
             if (htmlChecker.canTranslate(response.getContentType(), originalBody)) {
@@ -98,13 +99,12 @@ public class WovnServletFilter implements Filter {
                 Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
                 body = interceptor.translate(originalBody);
-
-                wovnResponse.setCharacterEncoding("utf-8");
             } else {
                 // css, javascript or others
                 body = originalBody;
             }
             wovnResponse.setContentLength(body.getBytes().length);
+            wovnResponse.setCharacterEncoding("utf-8");
             PrintWriter out = response.getWriter();
             out.write(body);
             out.close();

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -59,4 +59,19 @@ public class HtmlCheckerTest extends TestCase {
         assertEquals(expect, htmlChecker.canTranslateContent("<!-- comment -->" + prefix + template));
         assertEquals(expect, htmlChecker.canTranslateContent("<!-- comment -->\n " + prefix + template));
     }
+
+    public void testIsTextContentType() {
+        assertEquals(true, htmlChecker.isTextContentType(null));
+        assertEquals(true, htmlChecker.isTextContentType("html"));
+        assertEquals(true, htmlChecker.isTextContentType("text/html"));
+        assertEquals(true, htmlChecker.isTextContentType("text/xhtml"));
+        assertEquals(true, htmlChecker.isTextContentType("text/plain"));
+        assertEquals(true, htmlChecker.isTextContentType("text/javascript"));
+        assertEquals(true, htmlChecker.isTextContentType("application/json"));
+        assertEquals(true, htmlChecker.isTextContentType("application/javascript"));
+        assertEquals(false, htmlChecker.isTextContentType("image/png"));
+        assertEquals(false, htmlChecker.isTextContentType("image/jpeg"));
+        assertEquals(false, htmlChecker.isTextContentType("image/gif"));
+    }
+
 }


### PR DESCRIPTION
If it is possible to convert to utf-8, all things such as images will be converted to utf-8, so confirm the Content-Type to convert only text or json.

Note: In the future, may need the option to exclude some URLs or Content-Types.

The test implementation to verify the HTTP header has not yet been implemented, so I will attach the local verification results for the time being.

It is noteworthy that no unnecessary character codes have been added to the Content-Type.

BEFORE: 
![スクリーンショット 2020-03-31 22 25 13](https://user-images.githubusercontent.com/59548717/78031470-8fa1e400-739e-11ea-96c7-4fea40c9e615.png)
AFTER: 
![スクリーンショット 2020-03-31 22 25 23](https://user-images.githubusercontent.com/59548717/78031462-8dd82080-739e-11ea-8476-0f11b43baa73.png)