### PR TITLE
Revert: Add TLS 1.2 support for java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.0.3-jdk6</version>
+    <version>1.0.4-jdk6</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>
@@ -73,20 +73,6 @@
             <artifactId>easymock</artifactId>
             <version>3.4</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.66</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bctls-jdk15on -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
-            <version>1.66</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -1,37 +1,26 @@
 package com.github.wovnio.wovnjava;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.Security;
-import java.util.LinkedHashMap;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.LinkedHashMap;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
-import javax.net.ssl.HttpsURLConnection;
 import javax.xml.bind.DatatypeConverter;
-
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.jsse.provider.SSLSocketFactoryImpl;
 
 import net.arnx.jsonic.JSON;
 
 class Api {
-    static {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-    }
-
     private final int READ_BUFFER_SIZE = 8196;
     private final Settings settings;
     private final Headers headers;
@@ -48,13 +37,11 @@ class Api {
 
     String translate(String lang, String html) throws ApiException {
         this.responseHeaders.setApiStatus("Requested");
-
-        HttpsURLConnection con = null;
+        HttpURLConnection con = null;
         try {
             URL url = getApiUrl(lang, html);
-            con = (HttpsURLConnection) url.openConnection();
+            con = (HttpURLConnection) url.openConnection();
             con.setConnectTimeout(settings.connectTimeout);
-            con.setSSLSocketFactory(new SSLSocketFactoryImpl());
             con.setReadTimeout(settings.readTimeout);
             return translate(lang, html, con);
         } catch (UnsupportedEncodingException e) {
@@ -67,8 +54,7 @@ class Api {
             throw new ApiException("NoSuchAlgorithmException", e.getMessage());
         } catch(Exception e) {
             throw new ApiException("Exception", e.getMessage());
-        }
-        finally {
+        } finally {
             if (con != null) {
                 con.disconnect();
             }


### PR DESCRIPTION
Revert https://github.com/WOVNio/wovnjava/pull/159

The code is basically correct in how we are installing BouncyCastle, but there are several environment problems we weren't aware of.

```
Caused by: java.security.NoSuchAlgorithmException: Algorithm ECDH not available
        at javax.crypto.KeyAgreement.getInstance(DashoA13*..)
```

```
                                 com.github.wovnio.wovnjava.ApiException: Exception : unable to create JcaTlsCrypto: SecureRandom DEFAULT implementation not found: java.lang.ClassNotFoundException: org.bouncycastle.jcajce.provider.drbg.DRBG$Default
        at com.github.wovnio.wovnjava.Api.translate(Api.java:69)
```

For now I am reverting this change until we understand these issues more. I suspect there is a problem with the fat jar packaging we are doing.

https://stackoverflow.com/questions/46175454/exclude-bouncycastle-jar-but-include-everything-else-in-a-fat-jar
https://github.com/bcgit/bc-java/issues/514