### PR TITLE
[ST-983] Allow explicit encoding setting

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -40,6 +40,20 @@ wovnjava-mvn test -f pom.xml
 
 ## How to use it in docker
 
+### Using a development branch
+
+This is the recommended way of evaluating a development copy of wovnjava. You need to have your development branch pushed to Github. Then, specify the branch you want to use in the `pom.xml` file by using the following format:
+
+```
+<version>branchname-SNAPSHOT</version>
+```
+
+Replace `branchname` with the actual branch name (`/` in branch names should be replaced with `~`.)
+
+Then build the docker envrionment as usual.
+
+### Using a locally compiled version
+
 If you want to use a locally compiled version of wovnjava, please use the following method.
 
 Remove or comment out the repository configuration in jitpack.io and enable the dependency systemPath instead.

--- a/README.en.md
+++ b/README.en.md
@@ -116,6 +116,7 @@ sitePrefixPath            |          |
 langCodeAliases           |          |
 customDomainLangs         |          |
 debugMode                 |          | false
+encoding | | 
 
 ### 2.1. projectToken (required)
 
@@ -422,6 +423,10 @@ Using `wovnDebugMode` as a query parameter will activate embedded debug informat
 This is intended to better understand what the problem is if something is not working correctly with wovnjava on your server.
 
 _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMode is turned on in your wovnjava configuration._
+
+### 2.15. encoding
+
+You can choose to optionally explicitly specify the encoding used by your HTML. If `encoding` is not set, wovnjava will attempt to automatically detect the encoding. 
 
 ## Supported Langauges
 

--- a/README.en.md
+++ b/README.en.md
@@ -427,7 +427,8 @@ _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMo
 ### 2.15. encoding
 
 You can choose to optionally explicitly specify the encoding used by your HTML. If `encoding` is not set, wovnjava will attempt to automatically detect the encoding.
-Commonly used encodings are `utf-8`, `Shift_JIS` and `EUC-JP`.
+
+Commonly used encodings are `utf-8`, `Shift_JIS` and `EUC-JP`. For a complete list of supported encodings, please refer to Java's official documentation [here](https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html).
 
 ## Supported Langauges
 

--- a/README.en.md
+++ b/README.en.md
@@ -426,7 +426,8 @@ _Note that `wovnCacheDisable` and `wovnDebugMode` is only available when debugMo
 
 ### 2.15. encoding
 
-You can choose to optionally explicitly specify the encoding used by your HTML. If `encoding` is not set, wovnjava will attempt to automatically detect the encoding. 
+You can choose to optionally explicitly specify the encoding used by your HTML. If `encoding` is not set, wovnjava will attempt to automatically detect the encoding.
+Commonly used encodings are `utf-8`, `Shift_JIS` and `EUC-JP`.
 
 ## Supported Langauges
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,7 +37,7 @@ Change your project token in `hello/src/main/webapp/WEB-INF/web.xml`.
 ## 5. Re-Compile
 
 ```
-mave-clean-package.sh
+maven-clean-package.sh
 ```
 
 ## 6. Restart Tomcat

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.7.1</version>
+    <version>1.7.3</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.7.3</version>
+    <version>1.8.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -50,6 +50,8 @@ class Settings {
     public final String outboundProxyHost;
     public final int outboundProxyPort;
 
+    public final String encoding;
+
     Settings(FilterConfig config) throws ConfigurationError {
         FilterConfigReader reader = new FilterConfigReader(config);
 
@@ -84,6 +86,8 @@ class Settings {
 
         this.outboundProxyHost = nonEmptyString(reader, "outboundProxyHost");
         this.outboundProxyPort = reader.getIntParameter("outboundProxyPort");
+
+        this.encoding = stringOrDefault(reader.getStringParameter("encoding"), "");
     }
 
     private String verifyToken(String declaredUserToken, String declaredProjectToken) throws ConfigurationError {

--- a/src/main/java/com/github/wovnio/wovnjava/Utf8.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Utf8.java
@@ -4,9 +4,14 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
 public class Utf8 {
+    private String encoding;
+
+    Utf8(String encoding) {
+        this.encoding = encoding;
+    }
 
     // https://docs.oracle.com/javase/jp/6/technotes/guides/intl/encoding.doc.html
-    static final String[] ENCODINGS = new String[] {
+    static final String[] DEFAULT_CANDIDATE_ENCODINGS = new String[] {
             "UTF-8",
             "Shift_JIS",
             "windows-31j",
@@ -16,7 +21,7 @@ public class Utf8 {
     };
 
     static String detectEncoding(byte[] data) {
-        for (String encoding : ENCODINGS) {
+        for (String encoding : DEFAULT_CANDIDATE_ENCODINGS) {
             byte[] converted;
             try {
                 converted = (new String(data, encoding)).getBytes(encoding);
@@ -31,16 +36,19 @@ public class Utf8 {
         return "UTF-8";
     }
 
-    static String toStringUtf8(byte[] data) {
-        String encoding = detectEncoding(data);
+    public String toStringUtf8(byte[] data) {
+        String encoding;
 
+        if (this.encoding == "") {
+            encoding = detectEncoding(data);
+        } else {
+            encoding = this.encoding;
+        }
+        
         if (Logger.isDebug()) {
             Logger.log.info("encoding: " + encoding);
         }
 
-        if (encoding.equals("UTF-8")) {
-            return new String(data);
-        }
         try {
             return new String(data, encoding);
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -16,11 +16,13 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
     private PrintWriter writer;
     private ServletOutputStream output;
     private Headers headers;
+    private Utf8 unicodeConverter;
 
-    WovnHttpServletResponse(HttpServletResponse response, Headers headers) {
+    WovnHttpServletResponse(HttpServletResponse response, Headers headers, String encoding) {
         super(response);
         this.buff = new ByteArrayOutputStream();
         this.headers = headers;
+        this.unicodeConverter = new Utf8(encoding);
     }
 
     byte[] getData() {
@@ -46,7 +48,7 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
 
     @Override
     public String toString() {
-        return Utf8.toStringUtf8(this.getData());
+        return this.unicodeConverter.toStringUtf8(this.getData());
     }
 
     @Override

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -18,11 +18,11 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
     private Headers headers;
     private Utf8 unicodeConverter;
 
-    WovnHttpServletResponse(HttpServletResponse response, Headers headers, String encoding) {
+    WovnHttpServletResponse(HttpServletResponse response, Headers headers, Utf8 unicodeConverter) {
         super(response);
         this.buff = new ByteArrayOutputStream();
         this.headers = headers;
-        this.unicodeConverter = new Utf8(encoding);
+        this.unicodeConverter = unicodeConverter;
     }
 
     byte[] getData() {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -76,7 +76,7 @@ public class WovnServletFilter implements Filter {
 
     private void tryTranslate(Headers headers, RequestOptions requestOptions, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
-        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, this.settings.encoding);
+        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, new Utf8(this.settings.encoding));
 
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -76,7 +76,7 @@ public class WovnServletFilter implements Filter {
 
     private void tryTranslate(Headers headers, RequestOptions requestOptions, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
-        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers);
+        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, this.settings.encoding);
 
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");

--- a/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
+++ b/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
@@ -1,0 +1,45 @@
+package com.github.wovnio.wovnjava;
+
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.UnsupportedEncodingException;
+
+import junit.framework.TestCase;
+
+public class Utf8Test extends TestCase {
+    public void testDefaultEncodingUTF8() {
+        Utf8 unicodeConverter = new Utf8("");
+        String data = new String("Unicøde Sentence　東京");
+        byte[] rawData = null;
+        try {
+            rawData = data.getBytes("utf-8");
+        } catch (UnsupportedEncodingException e) {
+            System.exit(1);
+        } 
+        assertEquals(data, unicodeConverter.toStringUtf8(rawData));
+    }
+
+    public void testWrongEncodingProvidedShouldNotDecode() {
+        Utf8 unicodeConverter = new Utf8("Shift_JIS");
+        String data = new String("Unicøde Sentence　東京");
+        byte[] rawData = null;
+        try {
+            rawData = data.getBytes("utf-8");
+        } catch (UnsupportedEncodingException e) {
+            System.exit(1);
+        } 
+        assertNotEquals(data, unicodeConverter.toStringUtf8(rawData));
+    }
+
+    public void testSpecifyEncoding() {
+        Utf8 unicodeConverter = new Utf8("EUC-JP");
+        String data = new String("Unicøde Sentence　東京");
+        byte[] rawData = null;
+        try {
+            rawData = data.getBytes("EUC-JP");
+        } catch (UnsupportedEncodingException e) {
+            System.exit(1);
+        } 
+        assertEquals(data, unicodeConverter.toStringUtf8(rawData));
+    }
+}

--- a/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
+++ b/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.UnsupportedEncodingException;
 
+import org.junit.Ignore;
+
 import junit.framework.TestCase;
 
 public class Utf8Test extends TestCase {
     public void testDefaultEncodingUTF8() {
         Utf8 unicodeConverter = new Utf8("");
-        String data = new String("Unicøde Sentence　東京");
+        String data = new String("Unicøde Sentence　東京 الخط العربي في يونيكود");
         byte[] rawData = null;
         try {
             rawData = data.getBytes("utf-8");
@@ -17,6 +19,31 @@ public class Utf8Test extends TestCase {
             System.exit(1);
         } 
         assertEquals(data, unicodeConverter.toStringUtf8(rawData));
+    }
+
+    public void testDefaultEncodingShiftJIS() {
+        Utf8 unicodeConverter = new Utf8("");
+        String data = new String("新字体 関	鉄 気 １２３");
+        byte[] rawData = null;
+        try {
+            rawData = data.getBytes("Shift_JIS");
+        } catch (UnsupportedEncodingException e) {
+            System.exit(1);
+        } 
+        assertEquals(data, unicodeConverter.toStringUtf8(rawData));
+    }
+
+
+    public void testDefaultEncodingEUCJP__expected_to_fail() {
+        Utf8 unicodeConverter = new Utf8("");
+        String data = new String("新字体 関	鉄 気１２３");
+        byte[] rawData = null;
+        try {
+            rawData = data.getBytes("EUC-JP");
+        } catch (UnsupportedEncodingException e) {
+            System.exit(1);
+        } 
+        assertNotEquals(data, unicodeConverter.toStringUtf8(rawData));
     }
 
     public void testWrongEncodingProvidedShouldNotDecode() {

--- a/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
+++ b/src/test/java/com/github/wovnio/wovnjava/Utf8Test.java
@@ -4,20 +4,13 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.UnsupportedEncodingException;
 
-import org.junit.Ignore;
-
 import junit.framework.TestCase;
 
 public class Utf8Test extends TestCase {
-    public void testDefaultEncodingUTF8() {
+    public void testDefaultEncodingUTF8() throws UnsupportedEncodingException {
         Utf8 unicodeConverter = new Utf8("");
         String data = new String("Unicøde Sentence　東京 الخط العربي في يونيكود");
-        byte[] rawData = null;
-        try {
-            rawData = data.getBytes("utf-8");
-        } catch (UnsupportedEncodingException e) {
-            System.exit(1);
-        } 
+        byte[] rawData = data.getBytes("utf-8");
         assertEquals(data, unicodeConverter.toStringUtf8(rawData));
     }
 


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/ST-983

Added a new setting item called `encoding`, when set, wovnjava will use that encoding to handle all strings. If not set, wovnjava will attempt to determine the encoding from a predetermined list of encodings.