### PR TITLE
Update ignore file extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,14 @@ stop:
 
 build_website:
 	$(eval TARGET_DIR := ${PWD}/docker/java$(VERSION)/hello)
+	rm -r ${TARGET_DIR}/target
 	$(MAVEN) clean package -f $(WEBSITE_CONFIG_FILE)
 
 build_wovn_java:
 	make clean
 	make build
 	mkdir -p ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
+	rm ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib/*.jar
 	cp ./target/wovnjava-$(WOVN_VERSION)*.jar ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
 
 build_wovn_java_and_website:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.1
+WOVN_VERSION := 1.9.2
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -18,9 +18,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.9.1</version>
+      <version>1.9.2</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.1-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.2-jar-with-dependencies.jar</systemPath>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.1</version>
+    <version>1.9.2</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
@@ -8,8 +8,10 @@ class FileExtensionMatcher {
     private final Pattern AUDIO_FILE_PATTERN;
     private final Pattern VIDEO_FILE_PATTERN;
     private final Pattern DOC_FILE_PATTERN;
+    private final Pattern WEB_FILE_PATTERN;
 
     FileExtensionMatcher() {
+        this.WEB_FILE_PATTERN = Pattern.compile("\\.(eot|woff)$");
         this.TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
         this.IMAGE_FILE_PATTERN = Pattern.compile("(\\.(jpe|jpe?g|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
         this.AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
@@ -27,6 +29,7 @@ class FileExtensionMatcher {
             || IMAGE_FILE_PATTERN.matcher(path).find()
             || AUDIO_FILE_PATTERN.matcher(path).find()
             || VIDEO_FILE_PATTERN.matcher(path).find()
-            || DOC_FILE_PATTERN.matcher(path).find();
+            || DOC_FILE_PATTERN.matcher(path).find()
+            || WEB_FILE_PATTERN.matcher(path).find();
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -4,6 +4,10 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
 class HtmlChecker {
+    public boolean isTextFileContentType(String contentType) {
+        return contentType == null || contentType.toLowerCase().contains("text/") || contentType.toLowerCase().contains("html");
+    }
+
     public boolean canTranslate(String contentType, String html) {
         return canTranslateContentType(contentType) &&
             canTranslateContent(html);
@@ -28,6 +32,8 @@ class HtmlChecker {
     }
 
     private boolean isHtml(String head) {
+        // TODO: implement better HTML check, keyword might appear 
+        // after the sample.
         return head.contains("<?xml")
             || head.contains("<!doctype")
             || head.contains("<html")

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -48,6 +48,7 @@ class WovnHttpServletResponse extends HttpServletResponseWrapper {
 
     @Override
     public String toString() {
+        // TODO: thrown an exception when this is called twice
         return this.unicodeConverter.toStringUtf8(this.getData());
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -89,15 +89,15 @@ public class WovnServletFilter implements Filter {
             wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
         }
 
-        String originalBody = wovnResponse.toString();
-        if (originalBody != null) {
+        if (htmlChecker.isTextFileContentType(response.getContentType())) {
             // text
+            String originalBody = wovnResponse.toString();
             String body = null;
             if (htmlChecker.canTranslate(response.getContentType(), originalBody)) {
                 // html
                 Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
-                body = interceptor.translate(originalBody);
+                body = interceptor.translate(wovnResponse.toString());
             } else {
                 // css, javascript or others
                 body = originalBody;

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -97,7 +97,7 @@ public class WovnServletFilter implements Filter {
                 // html
                 Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
-                body = interceptor.translate(wovnResponse.toString());
+                body = interceptor.translate(originalBody);
             } else {
                 // css, javascript or others
                 body = originalBody;

--- a/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
@@ -34,6 +34,8 @@ public class FileExtensionMatcherTest extends TestCase {
         assertIsFile(true, "xls");
         assertIsFile(true, "xlsx");
         assertIsFile(true, "xlsm");
+        assertIsFile(true, "woff");
+        assertIsFile(true, "eot");
         assertIsFile(false, "unknown");
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -13,6 +13,16 @@ public class HtmlCheckerTest extends TestCase {
         assertEquals(false, htmlChecker.canTranslateContentType("text/plain"));
     }
 
+    public void testIsTextFileContentType() {
+        assertEquals(true, htmlChecker.isTextFileContentType(null));
+        assertEquals(true, htmlChecker.isTextFileContentType("html"));
+        assertEquals(true, htmlChecker.isTextFileContentType("text/html"));
+        assertEquals(true, htmlChecker.isTextFileContentType("text/xhtml"));
+        assertEquals(true, htmlChecker.isTextFileContentType("text/plain"));
+        assertEquals(true, htmlChecker.isTextFileContentType("text/css"));
+        assertEquals(true, htmlChecker.isTextFileContentType("text/javascript"));
+    }
+
     public void testCanTranslate() {
         assertEquals(false, htmlChecker.canTranslateContent(null));
         assertEquals(false, htmlChecker.canTranslateContent(""));


### PR DESCRIPTION
Changes:
- added two new file extensions into the list of "should not translate"
- changed how we detect if a file is binary/needs UTF-8 conversion treatment
  - before: we load the entire file and see if we can convert it to a string (this doesn't work, as you always get _some_ string back)
  - after: we look at the content-type, only those that have `text/` in them are not binary + needs UTF-8 conversion.

Other changes:
- updated make file to make stale build artifacts less likely to exist