### PR TITLE
Added Support for Universal Routes in Docker Env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.3
+WOVN_VERSION := 1.9.2
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml
@@ -38,7 +38,7 @@ build_wovn_java:
 	mkdir -p ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
 	rm ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib/*.jar
 	cp ./target/wovnjava-$(WOVN_VERSION)*.jar ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
-	
+
 build_wovn_java_and_website:
 	make build_wovn_java
 	make build_website

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.2
+WOVN_VERSION := 1.9.3
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml
@@ -29,7 +29,7 @@ stop:
 
 build_website:
 	$(eval TARGET_DIR := ${PWD}/docker/java$(VERSION)/hello)
-	rm -r ${TARGET_DIR}/target
+	rm -rf ${TARGET_DIR}/target
 	$(MAVEN) clean package -f $(WEBSITE_CONFIG_FILE)
 
 build_wovn_java:
@@ -38,7 +38,7 @@ build_wovn_java:
 	mkdir -p ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
 	rm ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib/*.jar
 	cp ./target/wovnjava-$(WOVN_VERSION)*.jar ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
-
+	
 build_wovn_java_and_website:
 	make build_wovn_java
 	make build_website

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.2</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.3-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.2-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example.wovnjava.hello</groupId>
   <artifactId>hello</artifactId>
@@ -16,15 +15,92 @@
 
   <dependencies>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.9.2</version>
+      <version>1.9.3</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.2-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.3-jar-with-dependencies.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20210307</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 
   <build>
     <finalName>ROOT</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+
+      <!--
+            Set useSystemClassLoader to false as workaround for the issue discussed here
+            https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class
+            -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <useBaseVersion>false</useBaseVersion>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/docker/java8/hello/src/main/java/com/example/wovnjava/hello/UniversalFilter.java
+++ b/docker/java8/hello/src/main/java/com/example/wovnjava/hello/UniversalFilter.java
@@ -1,0 +1,52 @@
+package com.example.wovnjava.hello;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.stream.Collectors;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.JSONObject;
+
+public class UniversalFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
+        BufferedReader requestReader = request.getReader();
+        String requestBody = requestReader.lines().collect(Collectors.joining());
+        JSONObject requestJson = new JSONObject(requestBody).getJSONObject("response");
+        int status = requestJson.getInt("status");
+        String responseBody = requestJson.getString("body");
+        JSONObject headers = requestJson.getJSONObject("headers");
+        String contentType = requestJson.getString("content-type");
+
+        ((HttpServletResponse)response).setHeader("Content-Type", contentType);
+
+        Iterator<String> headersIterator = headers.keys();
+        while (headersIterator.hasNext()) {
+            String headerName = headersIterator.next();
+            ((HttpServletResponse)response).setHeader(headerName, headers.getString(headerName));
+        }
+
+        ((HttpServletResponse)response).setStatus(status);
+        PrintWriter out = ((HttpServletResponse)response).getWriter();
+        out.write(responseBody);
+        out.close();
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/docker/java8/hello/src/main/webapp/WEB-INF/web.xml
+++ b/docker/java8/hello/src/main/webapp/WEB-INF/web.xml
@@ -35,9 +35,19 @@
       </init-param> -->
   </filter>
 
+  <filter>
+      <filter-name>universalfilter</filter-name>
+      <filter-class>com.example.wovnjava.hello.UniversalFilter</filter-class>
+  </filter>
+
   <filter-mapping>
       <filter-name>wovn</filter-name>
       <url-pattern>/*</url-pattern>
   </filter-mapping>
+
+  <filter-mapping>
+   <filter-name>universalfilter</filter-name>
+   <url-pattern>/custom_response/*</url-pattern>
+</filter-mapping>
 
 </web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.3</version>
+    <version>1.9.2</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.2</version>
+    <version>1.9.3</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>


### PR DESCRIPTION
This PR is a quality of life PR that improves debugging using the docker environment. A new filter is provided in the java8 docker example website.

Most notably, this PR adds the ability to send a request to any route prefixed by `/custom_response`, and dictate what the response should be.

You can decide:

- Response headers
- Response HTTP status code
- Response body
- You need to include a JSON body with such requests:
```
{
    "response": {
        "body": "foo2",
        "content-type": "text/html",
        "status": 200,
        "headers": { "X-WovnTest": "Foo" }
    }
}
```

Theoretically speaking, content-type is also a header, but it is included in its separate field.

