### PR TITLE
[SUP-969] Add Handling of 422 API Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.2
+WOVN_VERSION := 1.9.3
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.9.2</version>
+      <version>1.9.3</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.2-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.3-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.2</version>
+    <version>1.9.3</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -37,7 +37,7 @@ class Api {
         this.responseHeaders = responseHeaders;
     }
 
-    String translate(String lang, String html) throws ApiException {
+    String translate(String lang, String html) throws ApiException, ApiNoPageDataException {
         this.responseHeaders.setApiStatus("Requested");
         HttpURLConnection con = null;
         try {
@@ -69,7 +69,7 @@ class Api {
         }
     }
 
-    String translate(String lang, String html, HttpURLConnection con) throws ApiException {
+    String translate(String lang, String html, HttpURLConnection con) throws ApiException, ApiNoPageDataException {
         OutputStream out = null;
         try {
             ByteArrayOutputStream body = gzipStream(getApiBody(lang, html).getBytes());
@@ -92,7 +92,10 @@ class Api {
                     input = new GZIPInputStream(input);
                 }
                 return extractHtml(input);
-            } else {
+            } else if (status == 422) {
+                throw new ApiNoPageDataException();
+            }
+            else {
                 throw new ApiException("Failure", "Status code " + String.valueOf(status));
             }
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -93,7 +93,7 @@ class Api {
                 }
                 return extractHtml(input);
             } else if (status == 422) {
-                throw new ApiNoPageDataException();
+                throw new ApiNoPageDataException("ApiDataNotAvailable");
             }
             else {
                 throw new ApiException("Failure", "Status code " + String.valueOf(status));

--- a/src/main/java/com/github/wovnio/wovnjava/ApiNoPageDataException.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ApiNoPageDataException.java
@@ -1,7 +1,14 @@
 package com.github.wovnio.wovnjava;
 
 public class ApiNoPageDataException extends Exception {
-    ApiNoPageDataException() {
-        super();
+    private String details;
+
+    ApiNoPageDataException(String details) {
+        super(details);
+        this.details = details;
+    }
+
+    public String getDetails() {
+        return this.details;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/ApiNoPageDataException.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ApiNoPageDataException.java
@@ -1,0 +1,7 @@
+package com.github.wovnio.wovnjava;
+
+public class ApiNoPageDataException extends Exception {
+    ApiNoPageDataException() {
+        super();
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -1,8 +1,6 @@
 package com.github.wovnio.wovnjava;
 
 class Interceptor {
-    public static final String NO_API_DATA_STATUS = "ApiDataNotAvailable";
-
     private final Settings settings;
     private final Headers headers;
     private final Api api;
@@ -32,7 +30,7 @@ class Interceptor {
             responseHeaders.setApiStatus("Success");
             return converter.restore(translatedBody);
         } catch (ApiNoPageDataException e) {
-            responseHeaders.setApiStatus(Interceptor.NO_API_DATA_STATUS);
+            responseHeaders.setApiStatus(e.getDetails());
             return apiTranslateFail(body, lang);
         } catch (ApiException e) {
             responseHeaders.setApiStatus(e.getType());

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -7,7 +7,7 @@ class Interceptor {
     private final Headers headers;
     private final Api api;
     private final ResponseHeaders responseHeaders;
-     
+
     Interceptor(Headers headers, Settings settings, Api api, ResponseHeaders responseHeaders) {
         this.headers = headers;
         this.settings = settings;

--- a/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Interceptor.java
@@ -1,11 +1,13 @@
 package com.github.wovnio.wovnjava;
 
 class Interceptor {
+    public static final String NO_API_DATA_STATUS = "ApiDataNotAvailable";
+
     private final Settings settings;
     private final Headers headers;
     private final Api api;
     private final ResponseHeaders responseHeaders;
-
+     
     Interceptor(Headers headers, Settings settings, Api api, ResponseHeaders responseHeaders) {
         this.headers = headers;
         this.settings = settings;
@@ -29,6 +31,9 @@ class Interceptor {
             String translatedBody = api.translate(lang, convertedBody);
             responseHeaders.setApiStatus("Success");
             return converter.restore(translatedBody);
+        } catch (ApiNoPageDataException e) {
+            responseHeaders.setApiStatus(Interceptor.NO_API_DATA_STATUS);
+            return apiTranslateFail(body, lang);
         } catch (ApiException e) {
             responseHeaders.setApiStatus(e.getType());
             WovnLogger.log("ApiException", e);

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -36,14 +36,6 @@ public class HeadersTest extends TestCase {
         return TestUtil.makeConfigWithValidDefaults(parameters);
     }
 
-    private static FilterConfig mockConfigOriginalHeaders() {
-        HashMap<String, String> parameters = new HashMap<String, String>() {{
-            put("originalUrlHeader", "REDIRECT_URL");
-            put("originalQueryStringHeader", "REDIRECT_QUERY_STRING");
-        }};
-        return TestUtil.makeConfigWithValidDefaults(parameters);
-    }
-
     public void testHeaders() throws ConfigurationError {
         HttpServletRequest mockRequest = MockHttpServletRequest.create("https://example.com/ja/test");
         FilterConfig mockConfig = mockConfigPath();

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -90,9 +90,9 @@ public class InterceptorTest extends TestCase {
         Api mock = EasyMock.createMock(Api.class);
         try {
             EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andReturn("replaced html").atLeastOnce();
-        } catch (ApiException _) {
+        } catch (ApiException e) {
             throw new RuntimeException("Fail create mock");
-        } catch (ApiNoPageDataException _) {
+        } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
         } 
         EasyMock.replay(mock);
@@ -103,9 +103,9 @@ public class InterceptorTest extends TestCase {
         Api mock = EasyMock.createMock(Api.class);
         try {
             EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiException("SocketTimeoutException", "")).atLeastOnce();
-        } catch (ApiException _) {
+        } catch (ApiException e) {
             throw new RuntimeException("Fail create mock");
-        } catch (ApiNoPageDataException _) {
+        } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
         } 
         EasyMock.replay(mock);
@@ -116,9 +116,9 @@ public class InterceptorTest extends TestCase {
         Api mock = EasyMock.createMock(Api.class);
         try {
             EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiNoPageDataException("ApiDataNotAvailable")).atLeastOnce();
-        } catch (ApiException _) {
+        } catch (ApiException eApiException) {
             throw new RuntimeException("Fail create mock");
-        } catch (ApiNoPageDataException _) {
+        } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
         } 
         EasyMock.replay(mock);

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -43,6 +43,24 @@ public class InterceptorTest extends TestCase {
         assertEquals(expect, stripExtraSpaces(html));
     }
 
+    public void testApi422() throws NoSuchMethodException, IllegalAccessException, IOException, ServletException, ConfigurationError {
+        String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body>test</body></html>";
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
+            put("projectToken", "token0");
+            put("defaultLang", "en");
+            put("supportedLangs", "en,ja,fr");
+        }});
+        String html = translate("https://example.com/ja/", originalHtml, settings, mockApi422Error(), mockResponseHeaders422Error());
+        String expect = "<!doctype html><html lang=\"en\"><head><title>test</title>" +
+                        "<script src=\"//j.wovn.io/1\" data-wovnio=\"key=token0&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;version=" + version + "\" data-wovnio-type=\"fallback\" async></script>" +
+                        "<link ref=\"alternate\" hreflang=\"en\" href=\"https://example.com/\">" +
+                        "<link ref=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\">" +
+                        "<link ref=\"alternate\" hreflang=\"fr\" href=\"https://example.com/fr/\">" +
+                        "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">" +
+                        "</head><body>test</body></html>";
+        assertEquals(expect, stripExtraSpaces(html));
+    }
+
     public void testNoApi() throws NoSuchMethodException, IllegalAccessException, IOException, ServletException, ConfigurationError {
         String originalHtml = "<!doctype html><html><head><meta http-equiv=\"CONTENT-TYPE\"><title>test</title></head><body>test</body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{
@@ -74,7 +92,9 @@ public class InterceptorTest extends TestCase {
             EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andReturn("replaced html").atLeastOnce();
         } catch (ApiException _) {
             throw new RuntimeException("Fail create mock");
-        }
+        } catch (ApiNoPageDataException _) {
+            throw new RuntimeException("Fail create mock");
+        } 
         EasyMock.replay(mock);
         return mock;
     }
@@ -85,7 +105,22 @@ public class InterceptorTest extends TestCase {
             EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiException("SocketTimeoutException", "")).atLeastOnce();
         } catch (ApiException _) {
             throw new RuntimeException("Fail create mock");
-        }
+        } catch (ApiNoPageDataException _) {
+            throw new RuntimeException("Fail create mock");
+        } 
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private Api mockApi422Error() {
+        Api mock = EasyMock.createMock(Api.class);
+        try {
+            EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiNoPageDataException()).atLeastOnce();
+        } catch (ApiException _) {
+            throw new RuntimeException("Fail create mock");
+        } catch (ApiNoPageDataException _) {
+            throw new RuntimeException("Fail create mock");
+        } 
         EasyMock.replay(mock);
         return mock;
     }
@@ -105,6 +140,14 @@ public class InterceptorTest extends TestCase {
     private ResponseHeaders mockResponseHeadersTimeout() {
         ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
         mock.setApiStatus("SocketTimeoutException");
+        EasyMock.expectLastCall().times(1);
+        EasyMock.replay(mock);
+        return mock;
+    }
+
+    private ResponseHeaders mockResponseHeaders422Error() {
+        ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
+        mock.setApiStatus(Interceptor.NO_API_DATA_STATUS);
         EasyMock.expectLastCall().times(1);
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -115,7 +115,7 @@ public class InterceptorTest extends TestCase {
     private Api mockApi422Error() {
         Api mock = EasyMock.createMock(Api.class);
         try {
-            EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiNoPageDataException()).atLeastOnce();
+            EasyMock.expect(mock.translate(EasyMock.anyString(), EasyMock.anyString())).andThrow(new ApiNoPageDataException("ApiDataNotAvailable")).atLeastOnce();
         } catch (ApiException _) {
             throw new RuntimeException("Fail create mock");
         } catch (ApiNoPageDataException _) {
@@ -147,7 +147,7 @@ public class InterceptorTest extends TestCase {
 
     private ResponseHeaders mockResponseHeaders422Error() {
         ResponseHeaders mock = EasyMock.createMock(ResponseHeaders.class);
-        mock.setApiStatus(Interceptor.NO_API_DATA_STATUS);
+        mock.setApiStatus("ApiDataNotAvailable");
         EasyMock.expectLastCall().times(1);
         EasyMock.replay(mock);
         return mock;

--- a/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
@@ -69,7 +69,7 @@ public class MockHttpServletRequest {
 
         /* Stub `X-Header-Test` for testing behavior of an existing Header value */
         EasyMock.expect(mock.getHeader("X-Header-Test")).andReturn("x-header-test-value").anyTimes();
-        Vector headersVector = new Vector<String>();
+        Vector<String> headersVector = new Vector<String>();
         headersVector.add("X-Header-Test");
         EasyMock.expect(mock.getHeaderNames()).andReturn(headersVector.elements()).anyTimes();
     }

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -126,7 +126,7 @@ public class SettingsTest extends TestCase {
         }});
         boolean errorThrown = false;
         try {
-            Settings s = new Settings(config);
+            new Settings(config);
         } catch (ConfigurationError e) {
             errorThrown = true;
         }
@@ -176,7 +176,7 @@ public class SettingsTest extends TestCase {
     public void testSettings__ConfigWithValidBase__DoesNotRaiseError() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
         }});
-        Settings s = new Settings(config);
+        new Settings(config);
         assertEquals(true, true); // no error
     }
 
@@ -480,7 +480,7 @@ public class SettingsTest extends TestCase {
     private void assertErrorThrown(FilterConfig config) {
         boolean errorThrown = false;
         try {
-            Settings s = new Settings(config);
+            new Settings(config);
         } catch (ConfigurationError e) {
             errorThrown = true;
         }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -58,11 +58,6 @@ public class WovnServletFilterTest extends TestCase {
     }
 
     public void testProcessRequestOnce__RequestNotProcessed__ProcessRequest() throws ServletException, IOException {
-        HashMap<String, String> config = new HashMap<String, String>() {{
-            put("urlPattern", "path");
-            put("defaultLang", "ja");
-            put("location", "https://example.com/ja/search/");
-        }};
         boolean requestIsAlreadyProcessed = false;
         FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", TestUtil.emptyOption, requestIsAlreadyProcessed);
 
@@ -73,11 +68,6 @@ public class WovnServletFilterTest extends TestCase {
     }
 
     public void testProcessRequestOnce__RequestAlreadyProcessed__DoNotProcessRequestAgain() throws ServletException, IOException {
-        HashMap<String, String> config = new HashMap<String, String>() {{
-            put("urlPattern", "path");
-            put("defaultLang", "ja");
-            put("location", "https://example.com/ja/search/");
-        }};
         boolean requestIsAlreadyProcessed = true;
         FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", TestUtil.emptyOption, requestIsAlreadyProcessed);
 


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/SUP-969

With this PR, an HTTP 422 status code returned from html-swapper no longer results in an unhandled exception being thrown.

- Added new exception `ApiNoPageDataException`, thrown when the html-swapper response code is 422
- The `ApiNoPageDataException` is caught and the request is processed the same way as other failed swaps
- `X-Wovn-Api-Status: ApiDataNotAvailable` header is added to all responses where `ApiNoPageDataException` is caught
- Fixed misc. code warnings (unused variables etc)