### PR TITLE
[ST-1104] Added support for widget versioning url.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.3
+WOVN_VERSION := 1.10.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.3</version>
+    <version>1.10.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -17,11 +17,7 @@ class HtmlConverter {
     private final HashMap<String, String> hreflangMap;
     private final HtmlReplaceMarker htmlReplaceMarker;
 
-    private static final String[] WOVN_WIDGET_URLS = new String[] {
-        "j.wovn.io",
-        "j.dev-wovn.io:3000",
-        Settings.DefaultVersionedWidgetUrlProduction
-    };
+    private final String[] WOVN_WIDGET_URLS;
 
     HtmlConverter(Settings settings, Headers headers, String original) {
         this.settings = settings;
@@ -29,6 +25,12 @@ class HtmlConverter {
         this.hreflangMap = headers.getHreflangUrlMap();
         doc = Jsoup.parse(original);
         doc.outputSettings().prettyPrint(false);
+        
+        this.WOVN_WIDGET_URLS = new String[] {
+            "j.wovn.io",
+            "j.dev-wovn.io:3000",
+            this.settings.defaultVersionedWidgetUrlProduction
+        };
     }
 
     String strip() {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -29,7 +29,7 @@ class HtmlConverter {
         this.WOVN_WIDGET_URLS = new String[] {
             "j.wovn.io",
             "j.dev-wovn.io:3000",
-            this.settings.snippetUrl
+            this.settings.widgetUrl
         };
     }
 
@@ -162,7 +162,7 @@ class HtmlConverter {
             sb.append(CustomDomainLanguageSerializer.serializeToJson(settings.customDomainLanguages));
         }
         String key = sb.toString();
-        js.attr("src", settings.snippetUrl);
+        js.attr("src", settings.widgetUrl);
         js.attr("data-wovnio", key);
         js.attr("data-wovnio-type", "fallback");
         js.attr("async", "async");

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -29,7 +29,7 @@ class HtmlConverter {
         this.WOVN_WIDGET_URLS = new String[] {
             "j.wovn.io",
             "j.dev-wovn.io:3000",
-            this.settings.defaultVersionedWidgetUrlProduction
+            this.settings.snippetUrl
         };
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -16,6 +16,7 @@ class Settings {
     public static final String DefaultApiUrlBase  = "https://wovn.global.ssl.fastly.net";
     public static final String DefaultApiUrlProduction  = DefaultApiUrlBase + "/v0/";
     public static final String DefaultApiUrlDevelopment = "http://localhost:3001/v0/";
+    public static final String DefaultSnippetUrlDevelopment = "//j.dev-wovn.io:3000/1";
     public static final String DefaultSnippetUrlProduction  = "https://j.wovn.io/1";
 
     // Required settings
@@ -59,7 +60,6 @@ class Settings {
         this.urlPattern = verifyUrlPattern(reader.getStringParameter("urlPattern"));
         this.defaultLang = verifyDefaultLang(reader.getStringParameter("defaultLang"));
         this.supportedLangs = verifySupportedLangs(reader.getArrayParameter("supportedLangs"), this.defaultLang);
-        this.snippetUrl = stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlProduction);
 
         // Optional settings
         this.devMode = reader.getBoolParameterDefaultFalse("devMode");
@@ -71,6 +71,8 @@ class Settings {
         if (this.enableLogging) {
             WovnLogger.enable();
         }
+
+        this.snippetUrl = this.devMode ? stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlDevelopment) : stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlProduction);
 
         this.sitePrefixPath = normalizeSitePrefixPath(reader.getStringParameter("sitePrefixPath"));
         this.langCodeAliases = parseLangCodeAliases(reader.getStringParameter("langCodeAliases"));

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -2,7 +2,6 @@ package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.net.MalformedURLException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -16,8 +16,7 @@ class Settings {
     public static final String DefaultApiUrlBase  = "https://wovn.global.ssl.fastly.net";
     public static final String DefaultApiUrlProduction  = DefaultApiUrlBase + "/v0/";
     public static final String DefaultApiUrlDevelopment = "http://localhost:3001/v0/";
-    public static final String DefaultSnippetUrlProduction  = "//j.wovn.io/1";
-    public static final String DefaultSnippetUrlDevelopment = "//j.dev-wovn.io:3000/1";
+    public static final String DefaultSnippetUrlProduction  = "https://j.wovn.io/1";
 
     // Required settings
     public final String projectToken;
@@ -130,7 +129,7 @@ class Settings {
 
     private String verifySnippetUrl(String value) throws ConfigurationError {
         if (value == null || value.isEmpty()) {
-            throw new ConfigurationError("Missing required configuration for \"snippetUrl\".");
+            return DefaultSnippetUrlProduction;
         }
         return value;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -59,7 +59,7 @@ class Settings {
         this.urlPattern = verifyUrlPattern(reader.getStringParameter("urlPattern"));
         this.defaultLang = verifyDefaultLang(reader.getStringParameter("defaultLang"));
         this.supportedLangs = verifySupportedLangs(reader.getArrayParameter("supportedLangs"), this.defaultLang);
-        this.snippetUrl = verifySnippetUrl(reader.getStringParameter("snippetUrl"));
+        this.snippetUrl = stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlProduction);
 
         // Optional settings
         this.devMode = reader.getBoolParameterDefaultFalse("devMode");
@@ -125,13 +125,6 @@ class Settings {
             throw new ConfigurationError("Invalid configuration for \"defaultLang\", must match a supported language code.");
         }
         return lang;
-    }
-
-    private String verifySnippetUrl(String value) throws ConfigurationError {
-        if (value == null || value.isEmpty()) {
-            return DefaultSnippetUrlProduction;
-        }
-        return value;
     }
 
     private ArrayList<Lang> verifySupportedLangs(ArrayList<String> values, Lang defaultLang) throws ConfigurationError {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -16,15 +16,15 @@ class Settings {
     public static final String DefaultApiUrlBase  = "https://wovn.global.ssl.fastly.net";
     public static final String DefaultApiUrlProduction  = DefaultApiUrlBase + "/v0/";
     public static final String DefaultApiUrlDevelopment = "http://localhost:3001/v0/";
-    public static final String DefaultSnippetUrlDevelopment = "//j.dev-wovn.io:3000/1";
-    public static final String DefaultSnippetUrlProduction  = "https://j.wovn.io/1";
+    public static final String DefaultWidgetUrlDevelopment = "//j.dev-wovn.io:3000/1";
+    public static final String DefaultWidgetUrlProduction  = "https://j.wovn.io/1";
 
     // Required settings
     public final String projectToken;
     public final String urlPattern;
     public final Lang defaultLang;
     public final ArrayList<Lang> supportedLangs;
-    public final String snippetUrl;
+    public final String widgetUrl;
 
     // Optional settings
     public final boolean devMode;
@@ -72,7 +72,7 @@ class Settings {
             WovnLogger.enable();
         }
 
-        this.snippetUrl = this.devMode ? stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlDevelopment) : stringOrDefault(reader.getStringParameter("snippetUrl"), DefaultSnippetUrlProduction);
+        this.widgetUrl = this.devMode ? stringOrDefault(reader.getStringParameter("widgetUrl"), DefaultWidgetUrlDevelopment) : stringOrDefault(reader.getStringParameter("widgetUrl"), DefaultWidgetUrlProduction);
 
         this.sitePrefixPath = normalizeSitePrefixPath(reader.getStringParameter("sitePrefixPath"));
         this.langCodeAliases = parseLangCodeAliases(reader.getStringParameter("langCodeAliases"));

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -14,7 +14,6 @@ class Settings {
     // Default configuration values
     public static final int DefaultTimeout = 1000;
     public static final String DefaultApiUrlBase  = "https://wovn.global.ssl.fastly.net";
-    public static final String DefaultWidgetVersionUrlPrefix = "https://cdn.wovn.io/widget/";
     public static final String DefaultApiUrlProduction  = DefaultApiUrlBase + "/v0/";
     public static final String DefaultApiUrlDevelopment = "http://localhost:3001/v0/";
     public static final String DefaultSnippetUrlProduction  = "//j.wovn.io/1";

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -25,7 +25,7 @@ public class HtmlConverterTest extends TestCase {
     }
 
     public void testRemoveWovnSnippet() throws ConfigurationError {
-        String original = "<html><head><script src=\"https://wovn.global.ssl.fastly.net/widget/abcdef\"></script><script src=\"https://j.dev-wovn.io:3000\"></script><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
+        String original = "<html><head><script src=\"https://cdn.wovn.io/widget/123456\"></script><script src=\"https://j.dev-wovn.io:3000\"></script><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
         String removedHtml = "<html lang=\"en\"><head><link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link ref=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = this.createHtmlConverter(settings, location, original);

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -25,7 +25,7 @@ public class HtmlConverterTest extends TestCase {
     }
 
     public void testRemoveWovnSnippet() throws ConfigurationError {
-        String original = "<html><head><script src=\"https://cdn.wovn.io/widget/123456\"></script><script src=\"https://j.dev-wovn.io:3000\"></script><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
+        String original = "<html><head><script src=\"https://j.wovn.io/1\"></script><script src=\"https://j.dev-wovn.io:3000\"></script><script src=\"//j.wovn.io/1\" data-wovnio=\"key=NCmbvk&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=0.0.0\" data-wovnio-type=\"backend_without_api\" async></script></head><body></body></html>";
         String removedHtml = "<html lang=\"en\"><head><link ref=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link ref=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link ref=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = this.createHtmlConverter(settings, location, original);

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -26,7 +26,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -52,7 +52,7 @@ public class SettingsTest extends TestCase {
         assertEquals(emptyArrayList, s.ignoreClasses);
         assertEquals(emptyArrayList, s.ignorePaths);
 
-        assertEquals("//j.wovn.io/1", s.snippetUrl);
+        assertEquals("//j.wovn.io/1", s.widgetUrl);
         assertEquals(Settings.DefaultApiUrlProduction, s.apiUrl);
 
         assertEquals(Settings.DefaultTimeout, s.connectTimeout);
@@ -64,7 +64,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -75,7 +75,7 @@ public class SettingsTest extends TestCase {
             put("projectToken", "123456");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -97,7 +97,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "English");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -108,7 +108,7 @@ public class SettingsTest extends TestCase {
             put("projectToken", "123456");
             put("urlPattern", "path");
             put("defaultLang", "en");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -120,7 +120,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,Japanese");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -132,7 +132,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
         boolean errorThrown = false;
         try {
@@ -149,7 +149,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -163,7 +163,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -176,7 +176,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -297,21 +297,21 @@ public class SettingsTest extends TestCase {
         assertEquals("http://test.test", s.apiUrl);
     }
 
-    public void testSnippetUrl__Empty__ProductionMode__UseDefaultInstead() throws ConfigurationError {
+    public void testwidgetUrl__Empty__ProductionMode__UseDefaultInstead() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("snippetUrl", null);
+            put("widgetUrl", null);
         }});
         Settings s = new Settings(config);
-        assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);
+        assertEquals(Settings.DefaultWidgetUrlProduction, s.widgetUrl);
     }
 
-    public void testSnippetUrl__EmptyUrl__DevMode__UseDefaultInstead() throws ConfigurationError {
+    public void testwidgetUrl__EmptyUrl__DevMode__UseDefaultInstead() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
             put("devMode", "true");
-            put("snippetUrl", null);
+            put("widgetUrl", null);
         }});
         Settings s = new Settings(config);
-        assertEquals(Settings.DefaultSnippetUrlDevelopment, s.snippetUrl);
+        assertEquals(Settings.DefaultWidgetUrlDevelopment, s.widgetUrl);
     }
 
     public void testIgnorePaths__DeclareEmptyString__UseDefaultEmptyArray() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -477,6 +477,16 @@ public class SettingsTest extends TestCase {
         assertEquals(4000, settings.outboundProxyPort);
     }
 
+    public void testEnableWidgetVersioning__SnippetURLShouldBeVersionedWhenEnabled() throws ConfigurationError {
+        FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
+            put("enableWidgetVersioning", "true");
+        }});
+
+        Settings settings = new Settings(config);
+
+        assertEquals("https://cdn.wovn.io/widget/123456", settings.snippetUrl);
+    }
+
     private void assertErrorThrown(FilterConfig config) {
         boolean errorThrown = false;
         try {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -52,7 +52,7 @@ public class SettingsTest extends TestCase {
         assertEquals(emptyArrayList, s.ignoreClasses);
         assertEquals(emptyArrayList, s.ignorePaths);
 
-        assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);
+        assertEquals("//j.wovn.io/1", s.snippetUrl);
         assertEquals(Settings.DefaultApiUrlProduction, s.apiUrl);
 
         assertEquals(Settings.DefaultTimeout, s.connectTimeout);
@@ -297,13 +297,12 @@ public class SettingsTest extends TestCase {
         assertEquals("http://test.test", s.apiUrl);
     }
 
-    public void testSnippetUrl__EmptyUrl__ThrowsException() throws ConfigurationError {
+    public void testSnippetUrl__EmptyUrl__UseDefaultInstead() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
             put("snippetUrl", "");
         }});
-        assertThrows("Missing required configuration for \"snippetUrl\".", ConfigurationError.class, () -> {
-            new Settings(config);
-        });
+        Settings s = new Settings(config);
+        assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);
     }
 
     public void testIgnorePaths__DeclareEmptyString__UseDefaultEmptyArray() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -3,6 +3,9 @@ package com.github.wovnio.wovnjava;
 import junit.framework.TestCase;
 
 import java.util.HashMap;
+
+import static org.junit.Assert.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -23,6 +26,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -60,6 +64,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -70,6 +75,7 @@ public class SettingsTest extends TestCase {
             put("projectToken", "123456");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -91,6 +97,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "English");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -101,6 +108,7 @@ public class SettingsTest extends TestCase {
             put("projectToken", "123456");
             put("urlPattern", "path");
             put("defaultLang", "en");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -112,6 +120,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,Japanese");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
 
         assertErrorThrown(config);
@@ -123,6 +132,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
         boolean errorThrown = false;
         try {
@@ -139,6 +149,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -152,6 +163,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -164,6 +176,7 @@ public class SettingsTest extends TestCase {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }});
         Settings s = new Settings(config);
 
@@ -284,20 +297,13 @@ public class SettingsTest extends TestCase {
         assertEquals("http://test.test", s.apiUrl);
     }
 
-    public void testSnippetUrl__ProductionMode__DefaultValue() throws ConfigurationError {
+    public void testSnippetUrl__EmptyUrl__ThrowsException() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("devMode", "false");
+            put("snippetUrl", "");
         }});
-        Settings s = new Settings(config);
-        assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);
-    }
-
-    public void testSnippetUrl__DevelopmentMode__DefaultValue() throws ConfigurationError {
-        FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("devMode", "true");
-        }});
-        Settings s = new Settings(config);
-        assertEquals(Settings.DefaultSnippetUrlDevelopment, s.snippetUrl);
+        assertThrows("Missing required configuration for \"snippetUrl\".", ConfigurationError.class, () -> {
+            new Settings(config);
+        });
     }
 
     public void testIgnorePaths__DeclareEmptyString__UseDefaultEmptyArray() throws ConfigurationError {
@@ -475,16 +481,6 @@ public class SettingsTest extends TestCase {
         Settings settings = new Settings(config);
 
         assertEquals(4000, settings.outboundProxyPort);
-    }
-
-    public void testEnableWidgetVersioning__SnippetURLShouldBeVersionedWhenEnabled() throws ConfigurationError {
-        FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("enableWidgetVersioning", "true");
-        }});
-
-        Settings settings = new Settings(config);
-
-        assertEquals("https://cdn.wovn.io/widget/123456", settings.snippetUrl);
     }
 
     private void assertErrorThrown(FilterConfig config) {

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -299,7 +299,7 @@ public class SettingsTest extends TestCase {
 
     public void testSnippetUrl__EmptyUrl__UseDefaultInstead() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
-            put("snippetUrl", "");
+            put("snippetUrl", null);
         }});
         Settings s = new Settings(config);
         assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -297,12 +297,21 @@ public class SettingsTest extends TestCase {
         assertEquals("http://test.test", s.apiUrl);
     }
 
-    public void testSnippetUrl__EmptyUrl__UseDefaultInstead() throws ConfigurationError {
+    public void testSnippetUrl__Empty__ProductionMode__UseDefaultInstead() throws ConfigurationError {
         FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
             put("snippetUrl", null);
         }});
         Settings s = new Settings(config);
         assertEquals(Settings.DefaultSnippetUrlProduction, s.snippetUrl);
+    }
+
+    public void testSnippetUrl__EmptyUrl__DevMode__UseDefaultInstead() throws ConfigurationError {
+        FilterConfig config = TestUtil.makeConfigWithValidDefaults(new HashMap<String, String>() {{
+            put("devMode", "true");
+            put("snippetUrl", null);
+        }});
+        Settings s = new Settings(config);
+        assertEquals(Settings.DefaultSnippetUrlDevelopment, s.snippetUrl);
     }
 
     public void testIgnorePaths__DeclareEmptyString__UseDefaultEmptyArray() throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -43,6 +43,7 @@ public class TestUtil {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
+            put("snippetUrl", "//j.wovn.io/1");
         }};
         settings.putAll(options);
         return TestUtil.makeConfig(settings);

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -43,7 +43,7 @@ public class TestUtil {
             put("urlPattern", "path");
             put("defaultLang", "en");
             put("supportedLangs", "en,ja");
-            put("snippetUrl", "//j.wovn.io/1");
+            put("widgetUrl", "//j.wovn.io/1");
         }};
         settings.putAll(options);
         return TestUtil.makeConfig(settings);


### PR DESCRIPTION
Added support for widget versioning.
- added a required option `snippetUrl` that should be set to the URL of the snippet.
  -  if not set, `https://j.wovn.io/1` will be used