### PR TITLE
feature: [ST-1100] Add compressApiRequests setting, defaulted to true.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build_wovn_java:
 	make clean
 	make build
 	mkdir -p ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
-	rm ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib/*.jar
+	rm -rf ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib/*.jar
 	cp ./target/wovnjava-$(WOVN_VERSION)*.jar ./docker/java$(VERSION)/hello/src/main/webapp/WEB-INF/lib
 
 build_wovn_java_and_website:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.9.3
+WOVN_VERSION := 1.10.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/README.en.md
+++ b/README.en.md
@@ -439,7 +439,7 @@ The logs make use of `java.util.logging` and it is most likely to appear in the 
 
 ### 2.17. compressApiRequests
 
-By default, translation API requests will be sent with gzip compression. Set to false to disable compression.
+By default, requests to the translation API will be sent with gzip compression. Set to false to disable compression.
 ## Supported Langauges
 
 Language code | Language name | Name in English

--- a/README.en.md
+++ b/README.en.md
@@ -117,6 +117,8 @@ langCodeAliases           |          |
 customDomainLangs         |          |
 debugMode                 |          | false
 encoding                  |          | 
+enableLogging             |          | false
+compressApiRequests       |          | true
 
 ### 2.1. projectToken (required)
 
@@ -435,6 +437,9 @@ Commonly used encodings are `utf-8`, `Shift_JIS` and `EUC-JP`. For a complete li
 You can choose to enable WOVN's logging feature that will log some useful debug information by setting `enableLogging` to "true".
 The logs make use of `java.util.logging` and it is most likely to appear in the catalina logs.
 
+### 2.17. compressApiRequests
+
+By default, translation API requests will be sent with gzip compression. Set to false to disable compression.
 ## Supported Langauges
 
 Language code | Language name | Name in English

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.9.3-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.10.0-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.9.3</version>
+    <version>1.10.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -14,7 +14,6 @@ import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.security.MessageDigest;
@@ -84,6 +83,7 @@ class Api {
                 ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
                 compressedBody.writeTo(out);
                 con.setRequestProperty("Content-Type", "application/octet-stream");
+                con.setRequestProperty("Content-Encoding", "gzip");
                 con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()));
             } else {
                 out.write(apiBodyBytes);

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -14,7 +14,9 @@ import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -72,15 +74,27 @@ class Api {
     String translate(String lang, String html, HttpURLConnection con) throws ApiException, ApiNoPageDataException {
         OutputStream out = null;
         try {
-            ByteArrayOutputStream body = gzipStream(getApiBody(lang, html).getBytes());
+            out = con.getOutputStream();
+
+            Map<String, String> apiParams = getApiParameters(lang, html);
+            String urlEncodedBody =  FormUrlEncoding.encode(apiParams);
+            byte[] apiBodyBytes = urlEncodedBody.getBytes();
+
+            if (this.settings.compressApiRequests) {
+                ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
+                compressedBody.writeTo(out);
+                con.setRequestProperty("Content-Type", "application/octet-stream");
+                con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()));
+            } else {
+                out.write(apiBodyBytes);
+                con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length));  
+            }
             con.setDoOutput(true);
             con.setRequestProperty("X-Request-Id", WovnLogger.getUUID());
             con.setRequestProperty("Accept-Encoding", "gzip");
-            con.setRequestProperty("Content-Type", "application/octet-stream");
-            con.setRequestProperty("Content-Length", String.valueOf(body.size()));
+
             con.setRequestMethod("POST");
-            out = con.getOutputStream();
-            body.writeTo(out);
             out.close();
             out = null;
             this.responseHeaders.forwardFastlyHeaders(con);
@@ -98,8 +112,8 @@ class Api {
             else {
                 throw new ApiException("Failure", "Status code " + String.valueOf(status));
             }
-        } catch (UnsupportedEncodingException e) {
-            throw new ApiException("UnsupportedEncodingException", e.getMessage());
+        } catch (UnsupportedOperationException e) {
+            throw new ApiException("UnsupportedOperationException", e.getMessage());
         } catch (SocketTimeoutException e) {
             throw new ApiException("SocketTimeoutException", e.getMessage());
         } catch (IOException e) {
@@ -144,20 +158,20 @@ class Api {
         return html;
     }
 
-    private String getApiBody(String lang, String body) throws UnsupportedEncodingException {
-        StringBuilder sb = new StringBuilder();
-        appendKeyValue(sb, "url=", headers.getClientRequestUrlInDefaultLanguage());
-        appendKeyValue(sb, "&token=", settings.projectToken);
-        appendKeyValue(sb, "&lang_code=", lang);
-        appendKeyValue(sb, "&url_pattern=", settings.urlPattern);
-        appendKeyValue(sb, "&site_prefix_path=", settings.sitePrefixPath);
-        appendKeyValue(sb, "&custom_lang_aliases=", LanguageAliasSerializer.serializeToJson(settings.langCodeAliases));
-        appendKeyValue(sb, "&custom_domain_langs=", CustomDomainLanguageSerializer.serializeToJson(settings.customDomainLanguages));
-        appendKeyValue(sb, "&product=", "wovnjava");
-        appendKeyValue(sb, "&version=", Settings.VERSION);
-        appendKeyValue(sb, "&debug_mode=", String.valueOf(this.requestOptions.getDebugMode()));
-        appendKeyValue(sb, "&body=", body);
-        return sb.toString();
+    private Map<String, String> getApiParameters(String lang, String body) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        result.put("url", headers.getClientRequestUrlInDefaultLanguage());
+        result.put("token", settings.projectToken);
+        result.put("lang_code", lang);
+        result.put("url_pattern", settings.urlPattern);
+        result.put("site_prefix_path", settings.sitePrefixPath);
+        result.put("custom_lang_aliases", LanguageAliasSerializer.serializeToJson(settings.langCodeAliases));
+        result.put("custom_domain_langs", CustomDomainLanguageSerializer.serializeToJson(settings.customDomainLanguages));
+        result.put("product", "wovnjava");
+        result.put("version", Settings.VERSION);
+        result.put("debug_mode", String.valueOf(this.requestOptions.getDebugMode()));
+        result.put("body", body);
+        return result;
     }
 
     private URL getApiUrl(String lang, String body) throws UnsupportedEncodingException, NoSuchAlgorithmException, MalformedURLException {
@@ -191,12 +205,7 @@ class Api {
         return DatatypeConverter.printHexBinary(digest).toUpperCase();
     }
 
-    private void appendKeyValue(StringBuilder sb, String key, String value) throws UnsupportedEncodingException {
-        sb.append(key);
-        appendValue(sb, value);
-    }
-
-    private void appendValue(StringBuilder sb, String value) throws UnsupportedEncodingException {
-        sb.append(URLEncoder.encode(value, "UTF-8"));
+    private void appendValue(StringBuilder sb, String value) throws UnsupportedOperationException {
+        sb.append(FormUrlEncoding.encodeValue(value));
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
@@ -34,10 +34,10 @@ class FilterConfigReader {
         return n;
     }
 
-    boolean getBoolParameterDefaultFalse(String paramName) {
+    boolean getBoolParameterOrDefault(String paramName, boolean defaultValue) {
         String param = this.config.getInitParameter(paramName);
         if (param == null) {
-            return false;
+            return defaultValue;
         }
         param = param.trim().toLowerCase();
         return param.equals("on") || param.equals("true") || param.equals("1");

--- a/src/main/java/com/github/wovnio/wovnjava/FormUrlEncoding.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FormUrlEncoding.java
@@ -1,0 +1,22 @@
+package com.github.wovnio.wovnjava;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+final class FormUrlEncoding {
+    public static String encode(Map<String, String> params) throws UnsupportedOperationException {
+        return params.entrySet().stream()
+            .map(p -> encodeValue(p.getKey()) + "=" + encodeValue(p.getValue()))
+            .reduce((p1, p2) -> p1 + "&" + p2)
+            .orElse("");
+    }
+
+    public static String encodeValue(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -32,6 +32,7 @@ class Settings {
     public final boolean useProxy;
     public final boolean enableFlushBuffer;
     public final boolean enableLogging;
+    public final boolean compressApiRequests;
 
     public final String sitePrefixPath;
     public final Map<Lang, String> langCodeAliases;
@@ -63,11 +64,12 @@ class Settings {
         this.supportedLangs = verifySupportedLangs(reader.getArrayParameter("supportedLangs"), this.defaultLang);
 
         // Optional settings
-        this.devMode = reader.getBoolParameterDefaultFalse("devMode");
-        this.debugMode = reader.getBoolParameterDefaultFalse("debugMode");
-        this.useProxy = reader.getBoolParameterDefaultFalse("useProxy");
-        this.enableFlushBuffer = reader.getBoolParameterDefaultFalse("enableFlushBuffer");
-        this.enableLogging = reader.getBoolParameterDefaultFalse("enableLogging");
+        this.devMode = reader.getBoolParameterOrDefault("devMode", false);
+        this.debugMode = reader.getBoolParameterOrDefault("debugMode", false);
+        this.useProxy = reader.getBoolParameterOrDefault("useProxy", false);
+        this.enableFlushBuffer = reader.getBoolParameterOrDefault("enableFlushBuffer", false);
+        this.enableLogging = reader.getBoolParameterOrDefault("enableLogging", false);
+        this.compressApiRequests = reader.getBoolParameterOrDefault("compressApiRequests", true);
 
         if (this.enableLogging) {
             WovnLogger.enable();

--- a/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
@@ -63,7 +63,7 @@ public class FilterConfigReaderTest extends TestCase {
         assertEquals(true, errorOnText);
     }
 
-    public void testGetBoolParameterDefaultFalse() {
+    public void testGetBoolParameterOrDefault() {
         FilterConfig config = TestUtil.makeConfig(new HashMap<String, String>() {{
             put("on", "on");
             put("true", "true");
@@ -73,14 +73,18 @@ public class FilterConfigReaderTest extends TestCase {
         }});
         FilterConfigReader reader = new FilterConfigReader(config);
 
-        assertEquals(true, reader.getBoolParameterDefaultFalse("on"));
-        assertEquals(true, reader.getBoolParameterDefaultFalse("true"));
-        assertEquals(true, reader.getBoolParameterDefaultFalse("1"));
+        assertEquals(true, reader.getBoolParameterOrDefault("on", false));
+        assertEquals(true, reader.getBoolParameterOrDefault("true", false));
+        assertEquals(true, reader.getBoolParameterOrDefault("1", false));
 
-        assertEquals(false, reader.getBoolParameterDefaultFalse(null));
-        assertEquals(false, reader.getBoolParameterDefaultFalse("not-set"));
-        assertEquals(false, reader.getBoolParameterDefaultFalse("empty-string"));
-        assertEquals(false, reader.getBoolParameterDefaultFalse("0"));
+        assertEquals(false, reader.getBoolParameterOrDefault(null, false));
+        assertEquals(true, reader.getBoolParameterOrDefault(null, true));
+        assertEquals(false, reader.getBoolParameterOrDefault("not-in-config", false));
+        assertEquals(true, reader.getBoolParameterOrDefault("not-in-config", true));
+        assertEquals(false, reader.getBoolParameterOrDefault("empty-string", false));
+        assertEquals(false, reader.getBoolParameterOrDefault("empty-string", true));
+        assertEquals(false, reader.getBoolParameterOrDefault("0", false));
+        assertEquals(false, reader.getBoolParameterOrDefault("0", true));
     }
 
     public void testGetArrayParameter() {

--- a/src/test/java/com/github/wovnio/wovnjava/FormUrlEncodingTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FormUrlEncodingTest.java
@@ -1,0 +1,33 @@
+package com.github.wovnio.wovnjava;
+
+import junit.framework.TestCase;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FormUrlEncodingTest extends TestCase {
+
+    public void testEncode__EmptyMap__ReturnsEmpty() throws UnsupportedOperationException {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+
+        String result = FormUrlEncoding.encode(map);
+
+        assertEquals("", result);
+    }
+
+    public void testEncode__NonEmptyMap__ReturnsUrlEncodedKeysAndValues() throws UnsupportedOperationException {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        map.put("key one", "value one");
+        map.put("key two", "value two");
+
+        String result = FormUrlEncoding.encode(map);
+
+        assertEquals("key+one=value+one&key+two=value+two", result);
+    }
+
+    public void testEncodeValue__ReturnsUrlEncodedValue() throws UnsupportedOperationException {
+        assertEquals("", FormUrlEncoding.encodeValue(""));
+        assertEquals("one", FormUrlEncoding.encodeValue("one"));
+        assertEquals("has+spaces", FormUrlEncoding.encodeValue("has spaces"));
+    }
+}


### PR DESCRIPTION
wovnio.atlassian.net/browse/ST-1100

We currently gzip the request to html swapper. There is now a compress_api_request setting that can be set to false to disable this.

This is only to make it easier to use MockServer to assert the incoming request as JSON in integration tests.

Small refactor to stop constructing a url encoded string manually and generate it from a Map instead.