### PR TITLE
Add JSON support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.11.0
+WOVN_VERSION := 1.12.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.10.0-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.12.0-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.11.0</version>
+    <version>1.12.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>
@@ -72,6 +72,12 @@
             <artifactId>easymock</artifactId>
             <version>3.4</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.cliftonlabs</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>4.0.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -20,6 +20,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import javax.xml.bind.DatatypeConverter;
+import com.github.cliftonlabs.json_simple.Jsoner;
 
 import net.arnx.jsonic.JSON;
 
@@ -79,18 +80,18 @@ class Api {
             con.setRequestMethod("POST");
 
             Map<String, String> apiParams = getApiParameters(lang, html);
-            String urlEncodedBody =  FormUrlEncoding.encode(apiParams);
-            byte[] apiBodyBytes = urlEncodedBody.getBytes();
+            String jsonEncodedBody = Jsoner.serialize(apiParams);
+            byte[] apiBodyBytes = jsonEncodedBody.getBytes();
 
             if (this.settings.compressApiRequests) {
                 ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
-                con.setRequestProperty("Content-Type", "application/octet-stream");
+                con.setRequestProperty("Content-Type", "application/json");
                 con.setRequestProperty("Content-Encoding", "gzip");
                 con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()));
                 out = con.getOutputStream();
                 compressedBody.writeTo(out);
             } else {
-                con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                con.setRequestProperty("Content-Type", "application/json");
                 con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length));
                 out = con.getOutputStream();
                 out.write(apiBodyBytes);

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -63,19 +63,20 @@ public class ApiTest extends TestCase {
         String result = api.translate("ja", html, con);
 
         String encodedApiRequestBody = decompress(requestStream.toByteArray());
-        String apiRequestBody = URLDecoder.decode(encodedApiRequestBody, "UTF-8");
-        String expectedRequestBody = "url=https://example.com/somepage/" +
-                                     "&token=token0" +
-                                     "&lang_code=ja" +
-                                     "&url_pattern=path" +
-                                     "&site_prefix_path=" +
-                                     "&lang_param_name=wovn" +
-                                     "&custom_lang_aliases={}" +
-                                     "&custom_domain_langs=" +
-                                     "&product=wovnjava" +
-                                     "&version=" + Settings.VERSION +
-                                     "&debug_mode=false" +
-                                     "&body=" + html;
+        String apiRequestBody = new String(encodedApiRequestBody);
+        String expectedRequestBody = "{\"url\":\"https:\\/\\/example.com\\/somepage\\/\"," + 
+                                     "\"token\":\"token0\"," + 
+                                     "\"lang_code\":\"ja\"," + 
+                                     "\"url_pattern\":\"path\"," +
+                                     "\"site_prefix_path\":\"\"," +
+                                     "\"lang_param_name\":\"wovn\"," +
+                                     "\"custom_lang_aliases\":\"{}\"," +
+                                     "\"custom_domain_langs\":\"\"," +
+                                     "\"product\":\"wovnjava\"," +
+                                     "\"version\":\"" + Settings.VERSION + "\"," +
+                                     "\"debug_mode\":\"false\"," +
+                                     "\"body\":\"\u003Chtml\u003Emuch content\u003C\\/html\u003E\"}";
+
         assertEquals(expectedRequestBody, apiRequestBody);
 
         return result;


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/ST-1216

`simple_json` was used to serialize the request body because it produces a more "sane" serialized string. (Only down side is that it also escapes `/` as `\/`)
When serializing with `jsonic` too many characters get unicode escaped and it's very unreadable.