### PR TITLE
bump to 1.11.1 to refresh jitpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.11.0
+WOVN_VERSION := 1.11.1
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.11.0</version>
+      <version>1.11.1</version>
       <scope>system</scope>
       <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.10.0-jar-with-dependencies.jar</systemPath>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.11.0</version>
+    <version>1.11.1</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>


### PR DESCRIPTION
No actual code changes. Some build artifacts on 1.11.0 have been lost somehow like https://jitpack.io/com/github/wovnio/wovnjava/1.11.0/wovnjava-1.11.0.pom