### PR TITLE
tests: Enable forwarding for UniversalFilter, so it can be forwarded from the wovn filter

### DIFF
--- a/docker/java8/hello/src/main/webapp/WEB-INF/web.xml
+++ b/docker/java8/hello/src/main/webapp/WEB-INF/web.xml
@@ -34,11 +34,15 @@
   <filter-mapping>
       <filter-name>wovn</filter-name>
       <url-pattern>/*</url-pattern>
+      <dispatcher>REQUEST</dispatcher>
+      <dispatcher>FORWARD</dispatcher>
   </filter-mapping>
 
   <filter-mapping>
    <filter-name>universalfilter</filter-name>
    <url-pattern>/custom_response/*</url-pattern>
+   <dispatcher>REQUEST</dispatcher>
+   <dispatcher>FORWARD</dispatcher>
 </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
By default, filters are only executed for browser requests. When browsing to `/ja/custom_response`, the wovn filter will execute first, remove `/ja/` and call `requestDispatcher.forward()` which starts a separate request pipeline. UniversalFilter won't be executed in this pipeline unless given `FORWARD` permission in the filter list.

Note that this UniversalFilter is only part of the test docker website so we can craft any kind of origin request for testing purposes.