### PR TITLE
feature: [ST-1269] translate canonical url + search engine api timeout settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.13.1
+WOVN_VERSION := 1.14.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -it --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/README.en.md
+++ b/README.en.md
@@ -119,6 +119,11 @@ debugMode                 |          | false
 encoding                  |          | 
 enableLogging             |          | false
 compressApiRequests       |          | true
+fixedScheme               |          | 
+fixedHost                 |          | 
+fixedPort                 |          | 
+apiTimeoutSearchEngineBots|          | 5000
+translateCanonicalTag     |          | true
 
 ### 2.1. projectToken (required)
 
@@ -445,6 +450,26 @@ By default, requests to the translation API will be sent with gzip compression. 
 These settings can be used if your web server is behind a load balancer where the request URL is different to what the user sees. They should be set to match the URL used in your WOVN.io project. These settings have higher presedence than `useProxy` if both are enabled at the same time.
 
 You must set all three of these settings at the same time or none at all, failing to do so will result in `ConfigurationError` exceptions being thrown.
+
+### 2.19. apiTimeoutSearchEngineBots
+Maximum time (in milliseconds) to call the WOVN.io translation API.
+This will be used if the current request is detected to be from a search engine bot. Currently, bots from Google, Yahoo, Bing, Yandex, DuckDuckGo and Baidu are supported.
+By default the timeout is 5000ms.
+
+### 2.20. translateCanonicalTag
+Configures if wovnjava should automatically translate existing canonical tag in the HTML. When set to `true`, wovnjava
+will translate the canonical URL with the current language code according to your `urlPattern` setting. 
+This setting defaults to `true`.
+
+Example:
+ `<link rel="canonical" href="http://site.com/page.html">` may be translated to
+ `<link rel="canonical" href="http://site.com/en/page.html">` if you are using `path` URL pattern.
+```XML
+<init-param>
+  <param-name>translateCanonicalTag</param-name>
+  <param-value>true</param-value>
+</init-param>
+```
 ## Supported Langauges
 
 Language code | Language name | Name in English

--- a/README.en.md
+++ b/README.en.md
@@ -464,12 +464,7 @@ This setting defaults to `true`.
 Example:
  `<link rel="canonical" href="http://site.com/page.html">` may be translated to
  `<link rel="canonical" href="http://site.com/en/page.html">` if you are using `path` URL pattern.
-```XML
-<init-param>
-  <param-name>translateCanonicalTag</param-name>
-  <param-value>true</param-value>
-</init-param>
-```
+ 
 ## Supported Langauges
 
 Language code | Language name | Name in English

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.13.1</version>
+      <version>1.14.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.13.1-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.14.0-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.13.1</version>
+    <version>1.14.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -51,8 +51,15 @@ class Api {
               Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.settings.outboundProxyHost, this.settings.outboundProxyPort));
               con = (HttpURLConnection) url.openConnection(proxy);
             }
-            con.setConnectTimeout(settings.connectTimeout);
-            con.setReadTimeout(settings.readTimeout);
+            int connectTimeout = settings.connectTimeout;
+            int readTimeout = settings.readTimeout;
+            if (this.headers.getIsValidRequest()) {
+                connectTimeout = this.settings.apiTimeoutSearchEngineBots;
+                readTimeout = this.settings.apiTimeoutSearchEngineBots;
+            }
+
+            con.setConnectTimeout(connectTimeout);
+            con.setReadTimeout(readTimeout);
             return translate(lang, html, con);
         } catch (UnsupportedEncodingException e) {
             WovnLogger.log("API error: unsupported encoding.");
@@ -176,6 +183,7 @@ class Api {
         result.put("product", "wovnjava");
         result.put("version", Settings.VERSION);
         result.put("debug_mode", String.valueOf(this.requestOptions.getDebugMode()));
+        result.put("translate_canonical_tag", String.valueOf(settings.translateCanonicalTag));
         result.put("body", body);
         return result;
     }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -53,7 +53,7 @@ class Api {
             }
             int connectTimeout = settings.connectTimeout;
             int readTimeout = settings.readTimeout;
-            if (this.headers.getIsValidRequest()) {
+            if (this.headers.isSearchEngineBot()) {
                 connectTimeout = this.settings.apiTimeoutSearchEngineBots;
                 readTimeout = this.settings.apiTimeoutSearchEngineBots;
             }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -3,7 +3,6 @@ package com.github.wovnio.wovnjava;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.net.URL;
 import java.net.MalformedURLException;
 

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -1,7 +1,9 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.net.URL;
 import java.net.MalformedURLException;
 
@@ -117,6 +119,26 @@ class Headers {
 
     public boolean getIsValidRequest() {
         return this.isValidRequest;
+    }
+
+
+    private static final String[] searchEngineUserAgents = new String[] {
+        "Googlebot/",
+        "bingbot/",
+        "YandexBot/",
+        "YandexWebmaster/",
+        "DuckDuckBot-Https/",
+        "Baiduspider/",
+        "Slurp",
+        "Yahoo"
+    };
+
+    public boolean isSearchEngineBot() {
+        String userAgent = this.request.getHeader("User-Agent");
+        if (userAgent != null) {
+            return Arrays.stream(searchEngineUserAgents).anyMatch(userAgent::contains);
+        }
+        return false;
     }
 
     public LinkedHashMap<String, String> getHreflangUrlMap() {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -185,15 +185,12 @@ class HtmlConverter {
     }
 
     private void translateCanonicalTag(String lang) {
-        Elements elements = doc.head().getElementsByTag("link");
+        Elements elements = doc.select("link[rel=\"canonical\"]");
         for (Element element : elements) {
-            String rel = element.attr("rel");
-            if (rel != null && rel.equalsIgnoreCase("canonical")) {
-                String href = element.attr("href");
-                if (href != null) {
-                    String translatedCanonicalUrl = this.headers.locationWithLangCode(href);
-                    element.attr("href", translatedCanonicalUrl);
-                }
+            String href = element.attr("href");
+            if (href != null) {
+                String translatedCanonicalUrl = this.headers.locationWithLangCode(href);
+                element.attr("href", translatedCanonicalUrl);
             }
         }
     }

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -14,6 +14,7 @@ import org.jsoup.parser.Tag;
 class HtmlConverter {
     private final Document doc;
     private final Settings settings;
+    private final Headers headers;
     private final HashMap<String, String> hreflangMap;
     private final HtmlReplaceMarker htmlReplaceMarker;
 
@@ -21,6 +22,7 @@ class HtmlConverter {
 
     HtmlConverter(Settings settings, Headers headers, String original) {
         this.settings = settings;
+        this.headers = headers;
         this.htmlReplaceMarker = new HtmlReplaceMarker();
         this.hreflangMap = headers.getHreflangUrlMap();
         doc = Jsoup.parse(original);
@@ -51,6 +53,9 @@ class HtmlConverter {
         appendHrefLang();
         replaceContentType();
         insertHtmlLangAttribute();
+        if (this.settings.translateCanonicalTag) {
+            translateCanonicalTag(lang);
+        }
         return doc.html();
     }
 
@@ -176,6 +181,20 @@ class HtmlConverter {
             link.attr("hreflang", hreflang.getKey());
             link.attr("href", hreflang.getValue());
             doc.head().appendChild(link);
+        }
+    }
+
+    private void translateCanonicalTag(String lang) {
+        Elements elements = doc.head().getElementsByTag("link");
+        for (Element element : elements) {
+            String rel = element.attr("rel");
+            if (rel != null && rel.equalsIgnoreCase("canonical")) {
+                String href = element.attr("href");
+                if (href != null) {
+                    String translatedCanonicalUrl = this.headers.locationWithLangCode(href);
+                    element.attr("href", translatedCanonicalUrl);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -13,6 +13,7 @@ class Settings {
 
     // Default configuration values
     public static final int DefaultTimeout = 1000;
+    public static final int DefaultApiSearchEngineBotsTimeout = 5000;
     public static final String DefaultApiUrlBase  = "https://wovn.global.ssl.fastly.net";
     public static final String DefaultApiUrlProduction  = DefaultApiUrlBase + "/v0/";
     public static final String DefaultApiUrlDevelopment = "http://localhost:3001/v0/";
@@ -47,6 +48,7 @@ class Settings {
 
     public final int connectTimeout;
     public final int readTimeout;
+    public final int apiTimeoutSearchEngineBots;
 
     public final String outboundProxyHost;
     public final int outboundProxyPort;
@@ -57,6 +59,8 @@ class Settings {
     public final String fixedScheme;
     public final int fixedPort;
     public final boolean hasUrlOverride;
+    
+    public final boolean translateCanonicalTag;
 
     Settings(FilterConfig config) throws ConfigurationError {
         FilterConfigReader reader = new FilterConfigReader(config);
@@ -97,6 +101,8 @@ class Settings {
         this.connectTimeout = positiveIntOrDefault(reader.getIntParameter("connectTimeout"), DefaultTimeout);
         this.readTimeout = positiveIntOrDefault(reader.getIntParameter("readTimeout"), DefaultTimeout);
 
+        this.apiTimeoutSearchEngineBots = positiveIntOrDefault(reader.getIntParameter("apiTimeoutSearchEngineBots"), DefaultApiSearchEngineBotsTimeout);
+
         this.outboundProxyHost = nonEmptyString(reader, "outboundProxyHost");
         this.outboundProxyPort = reader.getIntParameter("outboundProxyPort");
 
@@ -107,6 +113,8 @@ class Settings {
         this.fixedPort = positiveIntOrDefault(reader.getIntParameter("fixedPort"), -1);
         this.verifyFixedURLConfigs(this.fixedHost, this.fixedScheme, this.fixedPort);
         this.hasUrlOverride = this.fixedPort != -1;
+
+        this.translateCanonicalTag = reader.getBoolParameterOrDefault("translateCanonicalTag", true);
     }
 
     private void verifyFixedURLConfigs(String fixedHost, String fixedScheme, int fixedPort) throws ConfigurationError {

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -75,6 +75,7 @@ public class ApiTest extends TestCase {
                                      "\"product\":\"wovnjava\"," +
                                      "\"version\":\"" + Settings.VERSION + "\"," +
                                      "\"debug_mode\":\"false\"," +
+                                     "\"translate_canonical_tag\":\"true\"," +
                                      "\"body\":\"\u003Chtml\u003Emuch content\u003C\\/html\u003E\"}";
 
         assertEquals(expectedRequestBody, apiRequestBody);

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -3,6 +3,9 @@ package com.github.wovnio.wovnjava;
 import java.util.HashMap;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
+
+import org.easymock.EasyMock;
+
 import java.net.URL;
 import java.net.MalformedURLException;
 
@@ -351,5 +354,41 @@ public class HeadersTest extends TestCase {
 		assertEquals("https://th.example.com/home?user=123", hreflangs.get("th"));
 		assertEquals("https://zh-CHT.example.com/home?user=123", hreflangs.get("zh-Hant"));
 		assertEquals("https://zh-CHS.example.com/home?user=123", hreflangs.get("zh-Hans"));
+    }
+
+    public void testIsSearchEngineBot_NoUserAgent_False() throws ConfigurationError {
+        String userAgent = null;
+
+        Settings settings = TestUtil.makeSettings();
+        UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123", userAgent);
+
+        Headers sut = new Headers(request, settings, patternHandler);
+
+        assertEquals(false, sut.isSearchEngineBot());
+    }
+
+    public void testIsSearchEngineBot_OrdinaryUserAgent_False() throws ConfigurationError {
+        String userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36";
+
+        Settings settings = TestUtil.makeSettings();
+        UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123");
+
+        Headers sut = new Headers(request, settings, patternHandler);
+
+        assertEquals(false, sut.isSearchEngineBot());
+    }
+
+    public void testIsSearchEngineBot_SearchEngineBotUserAgent_True() throws ConfigurationError {
+        String userAgent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+        Settings settings = TestUtil.makeSettings();
+        UrlLanguagePatternHandler patternHandler = UrlLanguagePatternHandlerFactory.create(settings);
+        HttpServletRequest request = MockHttpServletRequest.create("https://example.com/home?user=123", userAgent);
+
+        Headers sut = new Headers(request, settings, patternHandler);
+
+        assertEquals(true, sut.isSearchEngineBot());
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -240,6 +240,169 @@ public class HtmlConverterTest extends TestCase {
         assertTrue("lang attribute exists - keep existing lang", stripExtraSpaces(html).indexOf(expected) != -1);
     }
 
+    public void testConvert__TranslateCanonicalTagEnabled__CanonicalUrlIsExternal__DoesNotModifyCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/en/has-canonical.html";
+        String expectedJaUrl = "http://site.com/has-canonical.html";
+        String expectedEnUrl = requestUrl;
+
+        String html = "<html><head><link rel=\"canonical\" href=\"http://google.com\"></head></html>";
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "true");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"http://google.com\">%s%s%s</head><body></body></html>", expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
+    public void testConvert__TranslateCanonicalTagEnabled__CanonicalUrlIsInternal__AbsoluteUrl__DefaultLang__DoesNotModifyCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedJaUrl = requestUrl;
+        String expectedEnUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String canonicalUrl = requestUrl;
+
+        String html = String.format("<html><head><link rel=\"canonical\" href=\"%s\"></head></html>", canonicalUrl);
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "true");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"%s\">%s%s%s</head><body></body></html>", canonicalUrl, expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
+    public void testConvert__TranslateCanonicalTagEnabled__CanonicalUrlIsInternal__AbsoluteUrl__TargetLang__TranslatesCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String expectedJaUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedEnUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String canonicalUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedCanonicalUrl = expectedEnUrl;
+
+        String html = String.format("<html><head><link rel=\"canonical\" href=\"%s\"></head></html>", canonicalUrl);
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "true");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"%s\">%s%s%s</head><body></body></html>", expectedCanonicalUrl, expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
+    public void testConvert__TranslateCanonicalTagEnabled__CanonicalUrlIsInternal__AbsolutePath__DefaultLang__DoesNotModifyCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedJaUrl = requestUrl;
+        String expectedEnUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String canonicalUrl = "/has-canonical.html?foo=bar";
+
+        String html = String.format("<html><head><link rel=\"canonical\" href=\"%s\"></head></html>", canonicalUrl);
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "true");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"%s\">%s%s%s</head><body></body></html>", canonicalUrl, expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
+    public void testConvert__TranslateCanonicalTagEnabled__CanonicalUrlIsInternal__AbsolutePath__TargetLang__TranslatesCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String expectedJaUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedEnUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String canonicalUrl = "/has-canonical.html?foo=bar";
+        String expectedCanonicalUrl = "http://site.com/en/has-canonical.html?foo=bar";;
+
+        String html = String.format("<html><head><link rel=\"canonical\" href=\"%s\"></head></html>", canonicalUrl);
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "true");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"%s\">%s%s%s</head><body></body></html>", expectedCanonicalUrl, expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
+    public void testConvert__TranslateCanonicalTagDisabled__CanonicalUrlIsInternal__TargetLang__DoesNotModifyCanonicalUrl() throws ConfigurationError {
+        String requestUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String expectedJaUrl = "http://site.com/has-canonical.html?foo=bar";
+        String expectedEnUrl = "http://site.com/en/has-canonical.html?foo=bar";
+        String canonicalUrl = "/has-canonical.html?foo=bar";
+
+        String html = String.format("<html><head><link rel=\"canonical\" href=\"%s\"></head></html>", canonicalUrl);
+
+        HashMap<String, String> option = new HashMap<String, String>() {{
+            put("defaultLang", "ja");
+            put("supportedLangs", "ja,en");
+            put("urlPattern", "path");
+            put("translateCanonicalTag", "false");
+        }};
+        Settings settings = TestUtil.makeSettings(option);
+        HtmlConverter converter = this.createHtmlConverter(settings, requestUrl, html);
+        String result = converter.convert("en");
+
+        String expectedSnippet = String.format("<script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=ja&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script>", Settings.VERSION);
+        String expectedHrefLangs = String.format("<link rel=\"alternate\" hreflang=\"ja\" href=\"%s\">", expectedJaUrl) +
+                                   String.format("<link rel=\"alternate\" hreflang=\"en\" href=\"%s\">", expectedEnUrl);
+        String expectedContentType = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
+        String expectedHtml = String.format("<html lang=\"ja\"><head><link rel=\"canonical\" href=\"%s\">%s%s%s</head><body></body></html>", canonicalUrl, expectedSnippet, expectedHrefLangs, expectedContentType);
+
+        assertEquals(expectedHtml, result);
+    }
+
     private String stripExtraSpaces(String html) {
         return html.replaceAll("\\s +", "").replaceAll(">\\s+<", "><");
     }

--- a/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
@@ -13,9 +13,13 @@ public class MockHttpServletRequest {
     private static int DefaultTestPort = 443;
 
     public static HttpServletRequest create(String urlString) {
+        return create(urlString, null);
+    }
+
+    public static HttpServletRequest create(String urlString, String userAgent) {
         HttpServletRequest mock = EasyMock.createMock(HttpServletRequest.class);
         stubLocation(mock, parseURL(urlString));
-        stubHeaders(mock);
+        stubHeaders(mock, userAgent);
         EasyMock.replay(mock);
         return mock;
     }
@@ -64,8 +68,14 @@ public class MockHttpServletRequest {
     }
 
     private static void stubHeaders(HttpServletRequest mock) {
+        stubHeaders(mock, null);
+    }
+
+    private static void stubHeaders(HttpServletRequest mock, String userAgent) {
         /* `X-Wovn-Lang` is a Header value that we mock with our HttpServletRequestWrapper (unless the Header value already exists) */
         EasyMock.expect(mock.getHeader("X-Wovn-Lang")).andReturn(null).anyTimes();
+
+        EasyMock.expect(mock.getHeader("User-Agent")).andReturn(userAgent).anyTimes();
 
         /* Stub `X-Header-Test` for testing behavior of an existing Header value */
         EasyMock.expect(mock.getHeader("X-Header-Test")).andReturn("x-header-test-value").anyTimes();


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/ST-1269
1. Add `api_timeout_search_engine_bots` setting. Having a longer timeout for search engines makes it more likely they will receive a translated version of the page.
2. Add `translate_canonical_tag` setting. This setting adds lang codes to `<link rel="canonical" href="">` tags in the fallback snippet HTML. In the event our API request does time out,  it should not negatively impact SEO. This can be set to `false` to disable translating this tag completely (including in html swapper)
