### PR TITLE
fix: [SUP-1501] stop setting content-length explicitly to avoid truncating responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - oraclejdk8
+      # - oraclejdk8 TODO: Repos have been deprecated, commands no longer work
       - openjdk8
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.14.0
+WOVN_VERSION := 1.14.2
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -i --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.14.0</version>
+      <version>1.14.2</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.14.0-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.14.2-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.14.0</version>
+    <version>1.14.2</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -96,12 +96,10 @@ class Api {
                 ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
                 con.setRequestProperty("Content-Type", "application/json");
                 con.setRequestProperty("Content-Encoding", "gzip");
-                con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()));
                 out = con.getOutputStream();
                 compressedBody.writeTo(out);
             } else {
                 con.setRequestProperty("Content-Type", "application/json");
-                con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length));
                 out = con.getOutputStream();
                 out.write(apiBodyBytes);
             }

--- a/src/main/java/com/github/wovnio/wovnjava/Diagnostics.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Diagnostics.java
@@ -1,0 +1,23 @@
+package com.github.wovnio.wovnjava;
+
+import java.nio.charset.Charset;
+import java.util.Locale;
+
+public class Diagnostics {
+    public static String getDiagnosticInfo() {
+        Locale locale = Locale.getDefault();
+        Charset charset = Charset.defaultCharset();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("**** Diagnostic info ****\n");
+        if (locale != null) {
+            sb.append("Locale: " + locale.toString() + "\n");
+        }
+        if (charset != null) {
+            sb.append("Default charset: " + charset.displayName() + "\n");
+        }
+        sb.append("**** End diagnostic info ****\n");
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -1,5 +1,8 @@
 package com.github.wovnio.wovnjava;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
@@ -24,10 +27,13 @@ class RequestOptions {
      */
     private boolean debugMode;
 
+    private String overrideEncoding;
+
     RequestOptions(Settings settings, ServletRequest request) {
         this.disableMode = false;
         this.cacheDisableMode = false;
         this.debugMode = false;
+        this.overrideEncoding = null;
 
         String query = ((HttpServletRequest)request).getQueryString();
         if (query != null) {
@@ -35,6 +41,13 @@ class RequestOptions {
             if (settings.debugMode) {
                 this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
                 this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
+
+                Pattern pattern = Pattern.compile("(.*)wovnOverrideEncoding=([^&]*)");
+                Matcher m = pattern.matcher(query);
+                if (m.matches()) {
+                    String encoding = m.group(2);
+                    this.overrideEncoding = encoding;
+                }
             }
         }
     }
@@ -49,5 +62,9 @@ class RequestOptions {
 
     public boolean getDebugMode() {
         return this.debugMode;
+    }
+
+    public String getOverrideEncoding() {
+        return this.overrideEncoding;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -42,7 +42,7 @@ class RequestOptions {
                 this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
                 this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
 
-                Pattern pattern = Pattern.compile("(.*)wovnOverrideEncoding=([^&]*)");
+                Pattern pattern = Pattern.compile("(.*)wovnEncodingOverride=([^&]*)");
                 Matcher m = pattern.matcher(query);
                 if (m.matches()) {
                     String encoding = m.group(2);

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -27,13 +27,13 @@ class RequestOptions {
      */
     private boolean debugMode;
 
-    private String overrideEncoding;
+    private String encodingOverride;
 
     RequestOptions(Settings settings, ServletRequest request) {
         this.disableMode = false;
         this.cacheDisableMode = false;
         this.debugMode = false;
-        this.overrideEncoding = null;
+        this.encodingOverride = null;
 
         String query = ((HttpServletRequest)request).getQueryString();
         if (query != null) {
@@ -46,7 +46,7 @@ class RequestOptions {
                 Matcher m = pattern.matcher(query);
                 if (m.matches()) {
                     String encoding = m.group(2);
-                    this.overrideEncoding = encoding;
+                    this.encodingOverride = encoding;
                 }
             }
         }
@@ -64,7 +64,7 @@ class RequestOptions {
         return this.debugMode;
     }
 
-    public String getOverrideEncoding() {
-        return this.overrideEncoding;
+    public String getEncodingOverride() {
+        return this.encodingOverride;
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -81,6 +81,7 @@ class Settings {
 
         if (this.enableLogging) {
             WovnLogger.enable();
+            WovnLogger.setDebugMode(this.debugMode);
         }
 
         this.widgetUrl = this.devMode ? stringOrDefault(reader.getStringParameter("widgetUrl"), DefaultWidgetUrlDevelopment) : stringOrDefault(reader.getStringParameter("widgetUrl"), DefaultWidgetUrlProduction);

--- a/src/main/java/com/github/wovnio/wovnjava/WovnLogger.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnLogger.java
@@ -29,7 +29,7 @@ class WovnLogger {
     public static void setUUID(String uuid) {
         WovnLogger.uuid = uuid;
     }
-    public static void resetLogs() {
+    public static void clear() {
         WovnLogger.requestLogs = new ArrayList<>();
     }
     

--- a/src/main/java/com/github/wovnio/wovnjava/WovnLogger.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnLogger.java
@@ -1,14 +1,18 @@
 package com.github.wovnio.wovnjava;
 
 
+import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class WovnLogger {
     private static Logger logger = Logger.getLogger("wovnLogger");
     private static boolean enabled = false;
+    private static boolean isDebugMode = false;
     private static String uuid = "NO_UUID";
     private final static String prefix = "WOVN";
+
+    private static ArrayList<String> requestLogs;
 
     public static void enable() {
         WovnLogger.enabled = true;
@@ -18,8 +22,27 @@ class WovnLogger {
         WovnLogger.enabled = false;
     }
 
+    public static void setDebugMode(boolean isDebugMode) {
+        WovnLogger.isDebugMode = isDebugMode;
+    }
+
     public static void setUUID(String uuid) {
         WovnLogger.uuid = uuid;
+    }
+    public static void resetLogs() {
+        WovnLogger.requestLogs = new ArrayList<>();
+    }
+    
+    public static String getRequestLogsHtmlComment() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!--");
+        sb.append("\n");
+        for (int i = 0; i < WovnLogger.requestLogs.size(); i++) {
+            sb.append(WovnLogger.requestLogs.get(i));
+            sb.append("\n");
+        }
+        sb.append("-->");
+        return sb.toString();
     }
 
     public static String getUUID() {
@@ -30,13 +53,21 @@ class WovnLogger {
         if (!WovnLogger.enabled) {
             return;
         }
-        WovnLogger.logger.log(Level.INFO, String.format("[%s][%s] %s", WovnLogger.prefix, WovnLogger.uuid, message), e);
+        String formattedMessage = String.format("[%s][%s] %s", WovnLogger.prefix, WovnLogger.uuid, message);
+        if (WovnLogger.isDebugMode) {
+            WovnLogger.requestLogs.add(formattedMessage);
+        }
+        WovnLogger.logger.log(Level.INFO, formattedMessage, e);
     }
 
     public static void log(String message) {
         if (!WovnLogger.enabled) {
             return;
         }
-        WovnLogger.logger.log(Level.INFO, String.format("[%s][%s] %s", WovnLogger.prefix, WovnLogger.uuid, message));
+        String formattedMessage = String.format("[%s][%s] %s", WovnLogger.prefix, WovnLogger.uuid, message);
+        if (WovnLogger.isDebugMode) {
+            WovnLogger.requestLogs.add(formattedMessage);
+        }
+        WovnLogger.logger.log(Level.INFO, formattedMessage);
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -37,14 +37,18 @@ public class WovnServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
         WovnLogger.setUUID(UUID.randomUUID().toString());
         boolean isRequestAlreadyProcessed = false;
+        RequestOptions requestOptions = new RequestOptions(this.settings, request);
+
         if (((HttpServletResponse)response).containsHeader("X-Wovn-Handler")) {
             isRequestAlreadyProcessed = true;
             WovnLogger.log("Request is already processed by WOVN.");
         } else {
             WovnLogger.clear();
+            if (requestOptions.getDebugMode()) {
+                WovnLogger.log(Diagnostics.getDiagnosticInfo());
+            }
             ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         }
-        RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
         boolean canTranslateRequest = !requestOptions.getDisableMode() &&

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -81,7 +81,7 @@ public class WovnServletFilter implements Filter {
     private void tryTranslate(Headers headers, RequestOptions requestOptions, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
 
-        String overrideEncoding = requestOptions.getOverrideEncoding();
+        String overrideEncoding = requestOptions.getEncodingOverride();
         String responseEncoding = overrideEncoding != null ? overrideEncoding : this.settings.encoding;
         WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, new Utf8(responseEncoding));
 

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -41,9 +41,9 @@ public class WovnServletFilter implements Filter {
             isRequestAlreadyProcessed = true;
             WovnLogger.log("Request is already processed by WOVN.");
         } else {
+            WovnLogger.clear();
             ((HttpServletResponse)response).setHeader("X-Wovn-Handler", "wovnjava_" + Settings.VERSION);
         }
-
         RequestOptions requestOptions = new RequestOptions(this.settings, request);
         Headers headers = new Headers((HttpServletRequest)request, this.settings, this.urlLanguagePatternHandler);
 
@@ -67,7 +67,9 @@ public class WovnServletFilter implements Filter {
             if (headers.getIsPathInDefaultLanguage()) {
                 chain.doFilter(wovnRequest, response);
             } else {
-                wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, response);
+                String newPath = headers.getCurrentContextUrlInDefaultLanguage().getPath();
+                WovnLogger.log("Forwarding to " + newPath);
+                wovnRequest.getRequestDispatcher(newPath).forward(wovnRequest, response);
             }
         }
     }
@@ -78,7 +80,10 @@ public class WovnServletFilter implements Filter {
 
     private void tryTranslate(Headers headers, RequestOptions requestOptions, HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         WovnHttpServletRequest wovnRequest = new WovnHttpServletRequest(request, headers);
-        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, new Utf8(this.settings.encoding));
+
+        String overrideEncoding = requestOptions.getOverrideEncoding();
+        String responseEncoding = overrideEncoding != null ? overrideEncoding : this.settings.encoding;
+        WovnHttpServletResponse wovnResponse = new WovnHttpServletResponse(response, headers, new Utf8(responseEncoding));
 
         ResponseHeaders responseHeaders = new ResponseHeaders(response);
         responseHeaders.setApiStatus("Unused");
@@ -86,7 +91,9 @@ public class WovnServletFilter implements Filter {
         if (headers.getIsPathInDefaultLanguage()) {
             chain.doFilter(wovnRequest, wovnResponse);
         } else {
-            wovnRequest.getRequestDispatcher(headers.getCurrentContextUrlInDefaultLanguage().getPath()).forward(wovnRequest, wovnResponse);
+            String newPath = headers.getCurrentContextUrlInDefaultLanguage().getPath();
+            WovnLogger.log("Forwarding to" + newPath);
+            wovnRequest.getRequestDispatcher(newPath).forward(wovnRequest, wovnResponse);
         }
 
         if (htmlChecker.isTextFileContentType(response.getContentType())) {
@@ -98,12 +105,17 @@ public class WovnServletFilter implements Filter {
                 Api api = new Api(settings, headers, requestOptions, responseHeaders);
                 Interceptor interceptor = new Interceptor(headers, settings, api, responseHeaders);
                 body = interceptor.translate(originalBody);
+
+
+                if (requestOptions.getDebugMode()) {
+                    body += WovnLogger.getRequestLogsHtmlComment();
+                }
             } else {
                 // css, javascript or others
                 body = originalBody;
             }
-            wovnResponse.setContentLength(body.getBytes().length);
-            wovnResponse.setCharacterEncoding("utf-8");
+
+            wovnResponse.setCharacterEncoding("UTF-8");
             PrintWriter out = response.getWriter();
             out.write(body);
             out.close();

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -63,7 +63,6 @@ public class TestUtil {
 
     public static HttpServletResponse mockResponse(String contentType, String encoding, boolean isPreviouslyProcessed, int statusCode) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
-        mock.setContentLength(EasyMock.anyInt());
         EasyMock.expectLastCall();
         mock.setCharacterEncoding("utf-8");
         EasyMock.expectLastCall();

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -63,7 +63,7 @@ public class TestUtil {
 
     public static HttpServletResponse mockResponse(String contentType, String encoding, boolean isPreviouslyProcessed, int statusCode) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
-        mock.setCharacterEncoding("utf-8");
+        mock.setCharacterEncoding("UTF-8");
         EasyMock.expectLastCall();
         EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));
         EasyMock.expect(mock.getContentType()).andReturn(contentType).atLeastOnce();

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -63,7 +63,6 @@ public class TestUtil {
 
     public static HttpServletResponse mockResponse(String contentType, String encoding, boolean isPreviouslyProcessed, int statusCode) throws IOException {
         HttpServletResponse mock = EasyMock.createMock(HttpServletResponse.class);
-        EasyMock.expectLastCall();
         mock.setCharacterEncoding("utf-8");
         EasyMock.expectLastCall();
         EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(new StringWriter()));


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/SUP-1501?focusedCommentId=49877

Setting Content-Length header isn't mandatory but can lead to truncation if not set correctly.

Also added some convenience debugging utilities while investigating this issue:
- Add `wovnEncodingOverride` debug query parameter to force the response encoding when wovnjava receives the original HTML. Only available in debug mode. There is an `encoding` setting in the wovnjava configuration file, but this allows us to change the encoding for a single request.
- `wovnDebugMode` now shows the request logs as a HTML comment for debugging purposes (when debug mode is enabled in settings)