### PR TITLE
Fix openjdk7 circle CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,145 +4,21 @@ workflows:
   version: 2
   test:
     jobs:
-      - oraclejdk7
-      - oraclejdk8
       - openjdk7
       - openjdk8
 
 jobs:
-  oraclejdk7:
-    docker:
-      - image: circleci/circleci-cli:latest
-    steps:
-      - checkout
-
-      - run:
-         name: install oracle jdk
-         command: |
-           sudo cp /etc/apt/sources.list /etc/apt/org_sources.list
-           sudo sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
-           sudo apt-get clean
-           sudo apt-get update
-           sudo apt install -y maven
-           cd ~/
-           curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py
-           python get-pip.py --user
-           export PATH=~/.local/bin/:$PATH
-           pip install awscli --upgrade --user
-           aws s3 cp s3://$JDK7_FILE_PATH ./jdk7-oracle.tar.gz > /dev/null 2>&1
-           mkdir jdk7-oracle && tar zxf jdk7-oracle.tar.gz -C jdk7-oracle --strip-components 1
-           sudo cp -a ~/jdk7-oracle /usr/lib/jvm
-           cd /usr/lib/jvm
-           sed -e "s/\(java-8-openjdk-amd64\|java-1.8.0-openjdk-amd64\)/jdk7-oracle/g" .java-1.8.0-openjdk-amd64.jinfo | sudo tee .jdk7-oracle.jinfo
-           cat .jdk7-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install || true
-           export JAVA_HOME=/usr/lib/jvm/jdk7-oracle
-           export PATH=${JAVA_HOME}/bin:$PATH
-           export M2_HOME=~/.m2
-           export MAVEN_HOME=~/.m2
-
-      - restore_cache:
-          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
-
-      - run: mvn dependency:go-offline
-
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
-
-      - run: mvn -Dhttps.protocols=TLSv1.2 package
-
-      - store_test_results:
-          path: target/surefire-reports
-
-      - run:
-          name: Collect artifacts
-          command: |
-            mkdir target/artifacts
-            version=`grep '^    <version>' pom.xml | sed -e 's/    <version>//' | sed -e 's!</version>!!'`
-            zip target/wovnjava-jar-${version}.zip -jr target/wovnjava-*.jar licenses/*
-            mv target/wovnjava-* target/artifacts
-
-      - store_artifacts:
-          path: target/artifacts/
-
-
-  oraclejdk8:
-    docker:
-      - image: circleci/circleci-cli:latest
-    steps:
-      - checkout
-
-      - run:
-         name: install oracle jdk
-         command: |
-           sudo cp /etc/apt/sources.list /etc/apt/org_sources.list
-           sudo sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
-           sudo apt-get clean
-           sudo apt-get update
-           sudo apt install -y maven
-           cd ~/
-           curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py
-           python get-pip.py --user
-           export PATH=~/.local/bin/:$PATH
-           pip install awscli --upgrade --user
-           aws s3 cp s3://$JDK8_FILE_PATH ./jdk8-oracle.tar.gz > /dev/null 2>&1
-           mkdir jdk8-oracle && tar zxf jdk8-oracle.tar.gz -C jdk8-oracle --strip-components 1
-           sudo cp -a ~/jdk8-oracle /usr/lib/jvm
-           cd /usr/lib/jvm
-           sed -e "s/\(java-8-openjdk-amd64\|java-1.8.0-openjdk-amd64\)/jdk8-oracle/g" .java-1.8.0-openjdk-amd64.jinfo | sudo tee .jdk8-oracle.jinfo
-           cat .jdk8-oracle.jinfo | awk -F'[ =]' '/^priority/ { priority=$2 } /^(hl|jre|jdk)/ { print "/usr/bin/" $2 " " $2 " " $3 " " priority; "\n" }' | xargs -t -n4 sudo update-alternatives --verbose --install || true
-           export JAVA_HOME=/usr/lib/jvm/jdk8-oracle
-           export PATH=${JAVA_HOME}/bin:$PATH
-           export M2_HOME=~/.m2
-           export MAVEN_HOME=~/.m2
-           export MAVEN_OPTS=-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
-
-      - restore_cache:
-          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
-
-      - run: mvn dependency:go-offline
-
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: circleci-wovnjava-oraclejdk-pom-{{ checksum "pom.xml" }}
-
-      - run: mvn package
-
-      - store_test_results:
-          path: target/surefire-reports
-
-      - run:
-          name: Collect artifacts
-          command: |
-            mkdir target/artifacts
-            version=`grep '^    <version>' pom.xml | sed -e 's/    <version>//' | sed -e 's!</version>!!'`
-            zip target/wovnjava-jar-${version}.zip -jr target/wovnjava-*.jar licenses/*
-            mv target/wovnjava-* target/artifacts
-
-      - store_artifacts:
-          path: target/artifacts/
-
-
   openjdk7:
     docker:
-      - image: circleci/circleci-cli:latest
+      - image: azul/zulu-openjdk-alpine:7
     steps:
       - checkout
 
       - run:
          name: install openjdk 7
          command: |
-           sudo cp /etc/apt/sources.list /etc/apt/org_sources.list
-           sudo sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
-           sudo apt-get clean
-           sudo apt-get update
-           sudo apt install -y maven
-           sudo apt update; sudo apt install -y software-properties-common gnupg
-           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
-           sudo apt-add-repository 'deb http://repos.azulsystems.com/debian stable main'
-           sudo apt update; sudo apt install -y zulu-7
+           apk add maven
+           apk add zip
            export M2_HOME=~/.m2
            export MAVEN_HOME=~/.m2
            export MAVEN_OPTS=-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
Use https://hub.docker.com/r/azul/zulu-openjdk image rather than manually crafting one from ubuntu. Delete oracle jobs because they aren't supported anymore anyway.