### PR TITLE
feature: [ST-2002] Add overrideContentLength setting to enable setting "Content-Length" header.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 	$(MAVEN) package -f pom.jdk$(VERSION).xml -Dmaven.test.skip
 
 test:
-	$(MAVEN) test -f pom.jdk$(VERSION).xml -Dtest=WovnServletFilterTest
+	$(MAVEN) test -f pom.jdk$(VERSION).xml
 
 start:
 	docker-compose -f docker/java$(VERSION)/docker-compose.yml up

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.15.0
+WOVN_VERSION := 1.16.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -i --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml
@@ -19,7 +19,7 @@ build:
 	$(MAVEN) package -f pom.jdk$(VERSION).xml -Dmaven.test.skip
 
 test:
-	$(MAVEN) test -f pom.jdk$(VERSION).xml
+	$(MAVEN) test -f pom.jdk$(VERSION).xml -Dtest=WovnServletFilterTest
 
 start:
 	docker-compose -f docker/java$(VERSION)/docker-compose.yml up

--- a/README.en.md
+++ b/README.en.md
@@ -124,6 +124,7 @@ fixedHost                 |          |
 fixedPort                 |          | 
 apiTimeoutSearchEngineBots|          | 5000
 translateCanonicalTag     |          | true
+overrideContentLength     |          | false
 
 ### 2.1. projectToken (required)
 
@@ -464,6 +465,10 @@ This setting defaults to `true`.
 Example:
  `<link rel="canonical" href="http://site.com/page.html">` may be translated to
  `<link rel="canonical" href="http://site.com/en/page.html">` if you are using `path` URL pattern.
+
+ ### 2.21. overrideContentLength
+Configures if wovnjava should set the Content-Length header after translation.
+This setting defaults to `false`. If you experience issues with truncated responses, turning this setting on may help.
  
 ## Supported Langauges
 

--- a/README.en.md
+++ b/README.en.md
@@ -467,7 +467,7 @@ Example:
  `<link rel="canonical" href="http://site.com/en/page.html">` if you are using `path` URL pattern.
 
  ### 2.21. overrideContentLength
-Configures if wovnjava should set the Content-Length header after translation.
+Configures if wovnjava should set the response Content-Length header after translation.
 This setting defaults to `false`. If you experience issues with truncated responses, turning this setting on may help.
  
 ## Supported Langauges

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -23,9 +23,9 @@
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.15.0</version>
+      <version>1.16.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.15.0-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.16.0-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.15.0</version>
+    <version>1.16.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -96,12 +96,12 @@ class Api {
                 ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
                 con.setRequestProperty("Content-Type", "application/json");
                 con.setRequestProperty("Content-Encoding", "gzip");
-                con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()))
+                con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()));
                 out = con.getOutputStream();
                 compressedBody.writeTo(out);
             } else {
                 con.setRequestProperty("Content-Type", "application/json");
-                con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length))
+                con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length));
                 out = con.getOutputStream();
                 out.write(apiBodyBytes);
             }

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -96,10 +96,12 @@ class Api {
                 ByteArrayOutputStream compressedBody = gzipStream(apiBodyBytes);
                 con.setRequestProperty("Content-Type", "application/json");
                 con.setRequestProperty("Content-Encoding", "gzip");
+                con.setRequestProperty("Content-Length", String.valueOf(compressedBody.size()))
                 out = con.getOutputStream();
                 compressedBody.writeTo(out);
             } else {
                 con.setRequestProperty("Content-Type", "application/json");
+                con.setRequestProperty("Content-Length", String.valueOf(apiBodyBytes.length))
                 out = con.getOutputStream();
                 out.write(apiBodyBytes);
             }

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -61,6 +61,7 @@ class Settings {
     public final boolean hasUrlOverride;
     
     public final boolean translateCanonicalTag;
+    public final boolean overrideContentLength;
 
     Settings(FilterConfig config) throws ConfigurationError {
         FilterConfigReader reader = new FilterConfigReader(config);
@@ -116,6 +117,7 @@ class Settings {
         this.hasUrlOverride = this.fixedPort != -1;
 
         this.translateCanonicalTag = reader.getBoolParameterOrDefault("translateCanonicalTag", true);
+        this.overrideContentLength = reader.getBoolParameterOrDefault("overrideContentLength", false);
     }
 
     private void verifyFixedURLConfigs(String fixedHost, String fixedScheme, int fixedPort) throws ConfigurationError {

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -93,6 +93,7 @@ public class WovnServletFilter implements Filter {
         responseHeaders.setApiStatus("Unused");
 
         if (headers.getIsPathInDefaultLanguage()) {
+            WovnLogger.log("Passing to next filter");
             chain.doFilter(wovnRequest, wovnResponse);
         } else {
             String newPath = headers.getCurrentContextUrlInDefaultLanguage().getPath();
@@ -119,6 +120,9 @@ public class WovnServletFilter implements Filter {
                 body = originalBody;
             }
 
+            if (this.settings.overrideContentLength) {
+                wovnResponse.setContentLength(body.getBytes().length);
+            }
             wovnResponse.setCharacterEncoding("UTF-8");
             PrintWriter out = response.getWriter();
             out.write(body);

--- a/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
@@ -1,5 +1,7 @@
 package com.github.wovnio.wovnjava;
 
+import java.io.IOException;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -8,9 +10,18 @@ import javax.servlet.http.HttpServletRequest;
 public class FilterChainMock implements FilterChain {
     public HttpServletRequest req;
     public ServletResponse res;
+    public String originalResponseBody;
 
-    public void doFilter(ServletRequest req, ServletResponse res) {
+    public FilterChainMock(String originalResponseBody) {
+        this.originalResponseBody = originalResponseBody;
+        
+    }
+
+    public void doFilter(ServletRequest req, ServletResponse res) throws IOException {
         this.req = (HttpServletRequest)req;
         this.res = res;
+
+        // This is simulating the customer's application returning the HTML
+        this.res.getWriter().write(this.originalResponseBody);
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
@@ -14,7 +14,6 @@ public class FilterChainMock implements FilterChain {
 
     public FilterChainMock(String originalResponseBody) {
         this.originalResponseBody = originalResponseBody;
-        
     }
 
     public void doFilter(ServletRequest req, ServletResponse res) throws IOException {

--- a/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
@@ -1,22 +1,31 @@
 package com.github.wovnio.wovnjava;
 
+import java.io.IOException;
+
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class RequestDispatcherMock implements RequestDispatcher {
     public HttpServletRequest req;
-    public HttpServletResponse res;
+    public ServletResponse res;
+    private String originalResponseBody;
 
-    public void forward(ServletRequest req, ServletResponse res) {
+    public RequestDispatcherMock(String originalResponseBody) {
+        this.originalResponseBody = originalResponseBody;
+    }
+
+    public void forward(ServletRequest req, ServletResponse res) throws IOException {
         this.req = (HttpServletRequest)req;
-        this.res = (HttpServletResponse)res;
+        this.res = (ServletResponse)res;
+
+        // This is simulating the customer's application returning the HTML
+        this.res.getWriter().write(this.originalResponseBody);
     }
 
     public void include(ServletRequest req, ServletResponse res) {
         this.req = (HttpServletRequest)req;
-        this.res = (HttpServletResponse)res;
+        this.res = (ServletResponse)res;
     }
 }

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -10,85 +10,152 @@ import junit.framework.TestCase;
 
 public class WovnServletFilterTest extends TestCase {
     public void testHtml() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", pathOption);
-        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
-        assertEquals("/", mock.req.getRequestURI());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", "/", settings, originalResponseBody);;
+
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/html; charset=utf-8", mock.response.getContentType());
+        assertEquals("/", mock.request.getRequestURI());
+    }
+
+    public void testHtml__OverrideContentLengthTurnedOn__SetsContentLength() throws ServletException, IOException {
+        HashMap<String, String> settings = createSettings("path", true);
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
+        int expectedContentLength = expectedResponseBody.getBytes().length;
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", "/", settings, false, 200, originalResponseBody, expectedContentLength);
+
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/html; charset=utf-8", mock.response.getContentType());
+        assertEquals("/", mock.request.getRequestURI());
     }
 
     public void testHtmlWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/", pathOption, 200);
-        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
-        assertEquals("https://example.com/", mock.req.getRequestURL().toString());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/html; charset=utf-8", mock.response.getContentType());
+        assertEquals("https://example.com/", mock.request.getRequestURL().toString());
     }
 
     public void testHtmlWithQueryLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/?wovn=ja", queryOption);
-        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
-        assertEquals("/", mock.req.getRequestURI());
+        HashMap<String, String> settings = createSettings("query");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=query&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/?wovn=ja\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/?wovn=ja", "/", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/html; charset=utf-8", mock.response.getContentType());
+        assertEquals("/", mock.request.getRequestURI());
     }
 
     public void testHtmlWithSubdomain() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", subdomainOption("ja.wovn.io"));
-        assertEquals("text/html; charset=utf-8", mock.res.getContentType());
-        assertEquals("/", mock.req.getRequestURI());
+        HashMap<String, String> settings = createSettings("subdomain");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=subdomain&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://ja.example.com/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", "/", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/html; charset=utf-8", mock.response.getContentType());
+        assertEquals("/", mock.request.getRequestURI());
     }
 
     public void testCss() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/dir/style.css", pathOption);
-        assertEquals("text/css", mock.res.getContentType());
-        assertEquals("/dir/style.css", mock.req.getRequestURI());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "body { color: red; }";
+        String expectedResponseBody = originalResponseBody;
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/css", "/dir/style.css", "/dir/style.css", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/css", mock.response.getContentType());
+        assertEquals("/dir/style.css", mock.request.getRequestURI());
     }
 
     public void testCssWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css", pathOption, 200);
-        assertEquals("text/css", mock.res.getContentType());
-        assertEquals("https://example.com/style.css", mock.req.getRequestURL().toString());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "body { color: red; }";
+        String expectedResponseBody = originalResponseBody;
+        
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("text/css", mock.response.getContentType());
+        assertEquals("https://example.com/style.css", mock.request.getRequestURL().toString());
     }
 
     public void testImage() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/image.png", pathOption);
-        assertEquals("image/png", mock.res.getContentType());
-        assertEquals("/image.png", mock.req.getRequestURI());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "image data";
+        String expectedResponseBody = originalResponseBody;
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("image/png", "/image.png", "/image.png", settings, originalResponseBody);;
+        
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("image/png", mock.response.getContentType());
+        assertEquals("/image.png", mock.request.getRequestURI());
     }
 
     public void testImageWithLang() throws ServletException, IOException {
-        FilterChainMock mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png", pathOption, 200);
-        assertEquals("image/png", mock.res.getContentType());
-        assertEquals("https://example.com/image.png", mock.req.getRequestURL().toString());
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "image data";
+        String expectedResponseBody = originalResponseBody;
+
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("image/png", "/ja/image.png", "/image.png", settings, originalResponseBody);;
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
+        assertEquals("image/png", mock.response.getContentType());
+        assertEquals("https://example.com/image.png", mock.request.getRequestURL().toString());
     }
 
     public void testProcessRequestOnce__RequestNotProcessed__ProcessRequest() throws ServletException, IOException {
-        boolean requestIsAlreadyProcessed = false;
-        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", TestUtil.emptyOption, requestIsAlreadyProcessed, 200);
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = "<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;version=1.16.0\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/search/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/search/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>";
 
-        ServletResponse responseObjectPassedToFilterChain = mock.res;
+        boolean requestIsAlreadyProcessed = false;
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", settings, requestIsAlreadyProcessed, 200, originalResponseBody);
+
+        ServletResponse responseObjectPassedToFilterChain = mock.response;
         // If wovnjava is intercepting the request, the response object should be wrapped in a WovnHttpServletResponse
         assertEquals(true, responseObjectPassedToFilterChain instanceof HttpServletResponse);
         assertEquals(true, responseObjectPassedToFilterChain instanceof WovnHttpServletResponse);
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
     }
 
     public void testProcessRequestOnce__RequestAlreadyProcessed__DoNotProcessRequestAgain() throws ServletException, IOException {
+        HashMap<String, String> settings = createSettings("path");
+        String originalResponseBody = "<html>Original</html>";
+        String expectedResponseBody = originalResponseBody;
+        
         boolean requestIsAlreadyProcessed = true;
-        FilterChainMock mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", TestUtil.emptyOption, requestIsAlreadyProcessed, 200);
+        TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", settings, requestIsAlreadyProcessed, 200, originalResponseBody);
 
-        ServletResponse responseObjectPassedToFilterChain = mock.res;
+        ServletResponse responseObjectPassedToFilterChain = mock.response;
         // If wovnjava is ignoring the request, the response object should NOT be wrapped in a WovnHttpServletResponse
         assertEquals(true, responseObjectPassedToFilterChain instanceof HttpServletResponse);
         assertEquals(false, responseObjectPassedToFilterChain instanceof WovnHttpServletResponse);
+        assertEquals(expectedResponseBody, mock.responseBuffer.toString());
     }
 
-    private final HashMap<String, String> pathOption = new HashMap<String, String>() {{
-        put("urlPattern", "path");
-    }};
+    private HashMap<String, String> createSettings(String urlPattern) {
+        return createSettings(urlPattern, false);
+    }
 
-    private final HashMap<String, String> queryOption = new HashMap<String, String>() {{
-        put("urlPattern", "query");
-    }};
-
-    private HashMap<String, String> subdomainOption(String host) {
+    private HashMap<String, String> createSettings(String urlPattern, boolean overrideContentLength) {
         return new HashMap<String, String>() {{
-            put("urlPattern", "subdomain");
-            put("host", host);
+            put("urlPattern", urlPattern);
+            put("overrideContentLength", Boolean.toString(overrideContentLength));
         }};
     }
+
 }


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/ST-2002
https://wovnio.atlassian.net/browse/SUP-2099

New setting: `overrideContentLength`. Default false. When true, we will set/replace Content-Length header based on the size of the translated response.

```
<init-param>
    <param-name>overrideContentLength</param-name>
    <param-value>true/false</param-value>
  </init-param>
```

This code was previously removed in https://github.com/WOVNio/wovnjava/pull/209. In some environments, setting Content-Length causes issues so it is now an optional setting.

Improved `WovnServletFilterTest`. For the first time, we can now assert on the response body.