### PR TITLE
feat: [ST-2746] Migrate `javax` dependencies to `jakarta`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL        := /bin/bash
 .SHELLFLAGS  := -eu -o pipefail -c
 
 VERSION := 8
-WOVN_VERSION := 1.16.1
+WOVN_VERSION := 2.0.0
 TARGET_DIR = ${PWD}
 MAVEN    = docker run -i --rm -v ${TARGET_DIR}:/project -v wovnjava-maven_repo:/root/.m2 -w /project maven:3-jdk-$(VERSION) mvn
 WEBSITE_CONFIG_FILE = pom.xml

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,7 +34,7 @@ The big difference is version for `source` and `target`.
 
 # Start using your local environment
 To build local docker environemnt, this repository is using the following three docker images.
-1. andreptb/tomcat: Tomcat is software to run Java Servlet
+1. tomcat: Tomcat is software to run Java Servlet
 2. maven: Maven is software to manage and build Java Servlet
 3. ngrok: This is utility tool to make your local website accessible from the outside
 

--- a/docker/README_ja.md
+++ b/docker/README_ja.md
@@ -34,7 +34,7 @@ Java6とJava7用のブランチが存在します。
 
 # ローカル環境の使用
 ローカルDocker環境を構築するために、このリポジトリでは以下の３つのDockerイメージを使用しています。
-1. andreptb/tomcat: TomcatはJava Servletを実行するソフトウェアです
+1. tomcat: TomcatはJava Servletを実行するソフトウェアです
 2. maven: MavenはJavaServletを管理・ビルドするためのソフトウェアです
 3. ngrok: ローカルウェブサイトを外部からアクセス可能にする便利ツールです
 

--- a/docker/java8/docker-compose.yml
+++ b/docker/java8/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   tomcat-jdk8:
     container_name: wovnjava-tomcat-jdk8
-    image: "andreptb/tomcat:9-jdk8"
+    image: "tomcat:10.0-jdk8"
     ports:
       - 8080:8080
     volumes:

--- a/docker/java8/hello/pom.xml
+++ b/docker/java8/hello/pom.xml
@@ -15,17 +15,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.wovnio</groupId>
       <artifactId>wovnjava</artifactId>
-      <version>1.16.1</version>
+      <version>2.0.0</version>
       <scope>system</scope>
-      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-1.16.1-jar-with-dependencies.jar</systemPath>
+      <systemPath>${basedir}/src/main/webapp/WEB-INF/lib/wovnjava-2.0.0-jar-with-dependencies.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/docker/java8/hello/pom_jitpack.xml
+++ b/docker/java8/hello/pom_jitpack.xml
@@ -30,9 +30,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/docker/java8/hello/src/main/java/com/example/wovnjava/hello/UniversalFilter.java
+++ b/docker/java8/hello/src/main/java/com/example/wovnjava/hello/UniversalFilter.java
@@ -7,13 +7,13 @@ import java.io.PrintWriter;
 import java.util.Iterator;
 import java.util.stream.Collectors;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.json.JSONObject;
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -81,9 +81,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>1.16.2</version>
+    <version>2.0.0</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/Api.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Api.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import com.github.cliftonlabs.json_simple.Jsoner;
 
 import net.arnx.jsonic.JSON;

--- a/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FilterConfigReader.java
@@ -2,7 +2,7 @@ package com.github.wovnio.wovnjava;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import javax.servlet.FilterConfig;
+import jakarta.servlet.FilterConfig;
 
 class FilterConfigReader {
     private final FilterConfig config;

--- a/src/main/java/com/github/wovnio/wovnjava/FilterServletOutputStream.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FilterServletOutputStream.java
@@ -3,7 +3,8 @@ package com.github.wovnio.wovnjava;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.servlet.ServletOutputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 
 class FilterServletOutputStream extends ServletOutputStream {
     private OutputStream stream;
@@ -35,5 +36,14 @@ class FilterServletOutputStream extends ServletOutputStream {
     @Override
     public void flush() throws IOException {
         stream.flush();
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
     }
 }

--- a/src/main/java/com/github/wovnio/wovnjava/Headers.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Headers.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.net.URL;
 import java.net.MalformedURLException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 class Headers {
     Settings settings;
@@ -30,7 +30,7 @@ class Headers {
     Headers(HttpServletRequest request, Settings settings, UrlLanguagePatternHandler urlLanguagePatternHandler) {
         this.settings = settings;
         this.request = request;
-        this.urlLanguagePatternHandler = urlLanguagePatternHandler;            
+        this.urlLanguagePatternHandler = urlLanguagePatternHandler;
         String clientRequestUrl = UrlResolver.computeClientRequestUrl(request, settings);
         this.requestLang = this.urlLanguagePatternHandler.getLang(clientRequestUrl);
         this.clientRequestUrlInDefaultLanguage = this.urlLanguagePatternHandler.convertToDefaultLanguage(clientRequestUrl);

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlChecker.java
@@ -1,12 +1,12 @@
 package com.github.wovnio.wovnjava;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
 class HtmlChecker {
     public boolean isTextFileContentType(String contentType) {
-        return contentType == null 
+        return contentType == null
             || contentType.toLowerCase().contains("text/")
             || contentType.toLowerCase().contains("html");
     }
@@ -41,9 +41,9 @@ class HtmlChecker {
     private boolean isHtml(String head) {
         // TODO: implement better HTML check, keyword might appear
         // after the sample.
-        return head.contains("<?xml") 
-            || head.contains("<!doctype") 
-            || head.contains("<html") 
+        return head.contains("<?xml")
+            || head.contains("<!doctype")
+            || head.contains("<html")
             || head.contains("<xhtml");
     }
 

--- a/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
+++ b/src/main/java/com/github/wovnio/wovnjava/RequestOptions.java
@@ -3,8 +3,8 @@ package com.github.wovnio.wovnjava;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 class RequestOptions {
     /*

--- a/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
+++ b/src/main/java/com/github/wovnio/wovnjava/ResponseHeaders.java
@@ -4,7 +4,7 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Collections;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 
 class ResponseHeaders {

--- a/src/main/java/com/github/wovnio/wovnjava/Settings.java
+++ b/src/main/java/com/github/wovnio/wovnjava/Settings.java
@@ -5,8 +5,8 @@ import java.util.Map;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import javax.servlet.FilterConfig;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.servlet.FilterConfig;
+import jakarta.xml.bind.DatatypeConverter;
 
 class Settings {
     public static final String VERSION = Version.readProjectVersion();
@@ -59,7 +59,7 @@ class Settings {
     public final String fixedScheme;
     public final int fixedPort;
     public final boolean hasUrlOverride;
-    
+
     public final boolean translateCanonicalTag;
     public final boolean overrideContentLength;
 

--- a/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
+++ b/src/main/java/com/github/wovnio/wovnjava/UrlResolver.java
@@ -1,6 +1,6 @@
 package com.github.wovnio.wovnjava;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 final class UrlResolver {
     private UrlResolver() {}
@@ -8,7 +8,7 @@ final class UrlResolver {
     static String computeClientRequestUrl(HttpServletRequest request, Settings settings) {
         String path = clientRequestPath(request, settings.originalUrlHeader);
         String query = clientRequestQuery(request, settings.originalQueryStringHeader);
-        
+
         if (settings.hasUrlOverride) {
             return getUrlOverride(settings, path, query);
         }
@@ -65,7 +65,7 @@ final class UrlResolver {
         }
         if (path == null) {
             // request.getAttribute returns Object or null
-            Object forwardedPath = request.getAttribute("javax.servlet.forward.request_uri");
+            Object forwardedPath = request.getAttribute("jakarta.servlet.forward.request_uri");
             if (forwardedPath != null) {
                 path = forwardedPath.toString();
             }
@@ -89,7 +89,7 @@ final class UrlResolver {
         }
         if (query == null) {
             // request.getAttribute returns Object or null
-            Object forwardedQuery = request.getAttribute("javax.servlet.forward.query_string");
+            Object forwardedQuery = request.getAttribute("jakarta.servlet.forward.query_string");
             if (forwardedQuery != null) {
                 query = forwardedQuery.toString();
             }

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletRequest.java
@@ -1,7 +1,7 @@
 package com.github.wovnio.wovnjava;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.HashMap;

--- a/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnHttpServletResponse.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 
 class WovnHttpServletResponse extends HttpServletResponseWrapper {
     int status;

--- a/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/WovnServletFilter.java
@@ -4,15 +4,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.UUID;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class WovnServletFilter implements Filter {
     private Settings settings;

--- a/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ApiTest.java
@@ -11,7 +11,7 @@ import java.util.zip.GZIPOutputStream;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URLDecoder;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 
@@ -64,9 +64,9 @@ public class ApiTest extends TestCase {
 
         String encodedApiRequestBody = decompress(requestStream.toByteArray());
         String apiRequestBody = new String(encodedApiRequestBody);
-        String expectedRequestBody = "{\"url\":\"https:\\/\\/example.com\\/somepage\\/\"," + 
-                                     "\"token\":\"token0\"," + 
-                                     "\"lang_code\":\"ja\"," + 
+        String expectedRequestBody = "{\"url\":\"https:\\/\\/example.com\\/somepage\\/\"," +
+                                     "\"token\":\"token0\"," +
+                                     "\"lang_code\":\"ja\"," +
                                      "\"url_pattern\":\"path\"," +
                                      "\"site_prefix_path\":\"\"," +
                                      "\"lang_param_name\":\"wovn\"," +

--- a/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterChainMock.java
@@ -2,10 +2,10 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class FilterChainMock implements FilterChain {
     public HttpServletRequest req;

--- a/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FilterConfigReaderTest.java
@@ -3,7 +3,7 @@ package com.github.wovnio.wovnjava;
 import junit.framework.TestCase;
 import java.util.HashMap;
 import java.util.ArrayList;
-import javax.servlet.FilterConfig;
+import jakarta.servlet.FilterConfig;
 
 public class FilterConfigReaderTest extends TestCase {
     public void testGetStringParameter() {

--- a/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HeadersTest.java
@@ -1,8 +1,8 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.HashMap;
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.easymock.EasyMock;
 

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlCheckerTest.java
@@ -1,6 +1,6 @@
 package com.github.wovnio.wovnjava;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.easymock.EasyMock;
 

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -1,7 +1,7 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.HashMap;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/InterceptorTest.java
@@ -2,8 +2,8 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 import java.util.HashMap;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 
@@ -94,7 +94,7 @@ public class InterceptorTest extends TestCase {
             throw new RuntimeException("Fail create mock");
         } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
-        } 
+        }
         EasyMock.replay(mock);
         return mock;
     }
@@ -107,7 +107,7 @@ public class InterceptorTest extends TestCase {
             throw new RuntimeException("Fail create mock");
         } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
-        } 
+        }
         EasyMock.replay(mock);
         return mock;
     }
@@ -120,7 +120,7 @@ public class InterceptorTest extends TestCase {
             throw new RuntimeException("Fail create mock");
         } catch (ApiNoPageDataException e) {
             throw new RuntimeException("Fail create mock");
-        } 
+        }
         EasyMock.replay(mock);
         return mock;
     }

--- a/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/MockHttpServletRequest.java
@@ -4,8 +4,8 @@ import java.util.Vector;
 import java.net.URL;
 import java.net.MalformedURLException;
 import java.lang.IllegalArgumentException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.RequestDispatcher;
 
 import org.easymock.EasyMock;
 
@@ -63,8 +63,8 @@ public class MockHttpServletRequest {
         EasyMock.expect(mock.getServerName()).andReturn(url.getHost()).anyTimes();
         EasyMock.expect(mock.getQueryString()).andReturn(url.getQuery()).anyTimes();
         EasyMock.expect(mock.getServerPort()).andReturn(port).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).anyTimes();
-        EasyMock.expect(mock.getAttribute("javax.servlet.forward.query_string")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("jakarta.servlet.forward.request_uri")).andReturn(null).anyTimes();
+        EasyMock.expect(mock.getAttribute("jakarta.servlet.forward.query_string")).andReturn(null).anyTimes();
     }
 
     private static void stubHeaders(HttpServletRequest mock) {

--- a/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestDispatcherMock.java
@@ -2,10 +2,10 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class RequestDispatcherMock implements RequestDispatcher {
     public HttpServletRequest req;

--- a/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/RequestOptionsTest.java
@@ -1,7 +1,7 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.HashMap;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/ResponseHeadersTest.java
@@ -1,7 +1,7 @@
 package com.github.wovnio.wovnjava;
 
 import java.net.HttpURLConnection;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/SettingsTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import javax.servlet.FilterConfig;
+import jakarta.servlet.FilterConfig;
 
 public class SettingsTest extends TestCase {
     private Lang english;

--- a/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
+++ b/src/test/java/com/github/wovnio/wovnjava/TestUtil.java
@@ -5,12 +5,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletResponse;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;

--- a/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/UrlResolverTest.java
@@ -1,7 +1,7 @@
 package com.github.wovnio.wovnjava;
 
 import java.util.HashMap;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.TestCase;
 
@@ -15,8 +15,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(443).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/page/index.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -31,8 +31,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(8080).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -47,8 +47,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/internal/find.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("user=Elvis").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/search").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/search").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("user=Elvis&q=korean+food").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings();
@@ -63,8 +63,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn(null).times(0,1);
         EasyMock.replay(r);
@@ -83,8 +83,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn(null).times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn(null).times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Host")).andReturn("global.co.jp").times(0,1);
         EasyMock.expect(r.getHeader("X-Forwarded-Port")).andReturn("777").times(0,1);
         EasyMock.replay(r);
@@ -103,8 +103,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/internal/forward/index.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=internal").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/global/").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/en/global/").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.expect(r.getHeader("X-My-Url")).andReturn(null).times(0,1);
         EasyMock.expect(r.getHeader("X-My-Query")).andReturn(null).times(0,1);
         EasyMock.replay(r);
@@ -124,8 +124,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/internal/forward/index.html").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=internal").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.expect(r.getHeader("X-My-Url")).andReturn("/global/").times(0,1);
         EasyMock.expect(r.getHeader("X-My-Query")).andReturn("wovn=vi").times(0,1);
         EasyMock.replay(r);
@@ -145,8 +145,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=original").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.replay(r);
 
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
@@ -165,8 +165,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=original").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.replay(r);
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("fixedHost", "example.com");
@@ -184,8 +184,8 @@ public class UrlResolverTest extends TestCase {
         EasyMock.expect(r.getServerPort()).andReturn(80).times(0,1);
         EasyMock.expect(r.getRequestURI()).andReturn("/en/tokyo").times(0,1);
         EasyMock.expect(r.getQueryString()).andReturn("q=original").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
-        EasyMock.expect(r.getAttribute("javax.servlet.forward.query_string")).andReturn("q=original").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.request_uri")).andReturn("/en/tokyo").times(0,1);
+        EasyMock.expect(r.getAttribute("jakarta.servlet.forward.query_string")).andReturn("q=original").times(0,1);
         EasyMock.replay(r);
         Settings s = TestUtil.makeSettings(new HashMap<String, String>() {{
             put("fixedScheme", "http");

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletRequestTest.java
@@ -5,8 +5,8 @@ import junit.framework.TestCase;
 import java.util.HashMap;
 import java.util.Enumeration;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class WovnHttpServletRequestTest extends TestCase {
 

--- a/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletResponseTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnHttpServletResponseTest.java
@@ -1,6 +1,6 @@
 package com.github.wovnio.wovnjava;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 import org.easymock.EasyMock;

--- a/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/WovnServletFilterTest.java
@@ -2,9 +2,9 @@ package com.github.wovnio.wovnjava;
 
 import java.io.IOException;
 import java.util.HashMap;
-import javax.servlet.ServletException;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 
@@ -40,7 +40,7 @@ public class WovnServletFilterTest extends TestCase {
         String expectedResponseBody = String.format("<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=path&amp;version=%s\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/ja/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>", Settings.VERSION);
 
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/ja/", "/", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("text/html; charset=utf-8", mock.response.getContentType());
         assertEquals("https://example.com/", mock.request.getRequestURL().toString());
@@ -52,7 +52,7 @@ public class WovnServletFilterTest extends TestCase {
         String expectedResponseBody = String.format("<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=ja&amp;defaultLang=en&amp;urlPattern=query&amp;version=%s\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://example.com/?wovn=ja\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>", Settings.VERSION);
 
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/?wovn=ja", "/", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("text/html; charset=utf-8", mock.response.getContentType());
         assertEquals("/", mock.request.getRequestURI());
@@ -64,7 +64,7 @@ public class WovnServletFilterTest extends TestCase {
         String expectedResponseBody = String.format("<html lang=\"en\"><head><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=subdomain&amp;version=%s\" data-wovnio-type=\"fallback\" async></script><link rel=\"alternate\" hreflang=\"en\" href=\"https://example.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://ja.example.com/\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body>Original</body></html>", Settings.VERSION);
 
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html; charset=utf-8", "/", "/", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("text/html; charset=utf-8", mock.response.getContentType());
         assertEquals("/", mock.request.getRequestURI());
@@ -76,7 +76,7 @@ public class WovnServletFilterTest extends TestCase {
         String expectedResponseBody = originalResponseBody;
 
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/css", "/dir/style.css", "/dir/style.css", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("text/css", mock.response.getContentType());
         assertEquals("/dir/style.css", mock.request.getRequestURI());
@@ -86,9 +86,9 @@ public class WovnServletFilterTest extends TestCase {
         HashMap<String, String> settings = createSettings("path");
         String originalResponseBody = "body { color: red; }";
         String expectedResponseBody = originalResponseBody;
-        
+
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/css", "/ja/style.css", "/style.css", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("text/css", mock.response.getContentType());
         assertEquals("https://example.com/style.css", mock.request.getRequestURL().toString());
@@ -100,7 +100,7 @@ public class WovnServletFilterTest extends TestCase {
         String expectedResponseBody = originalResponseBody;
 
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("image/png", "/image.png", "/image.png", settings, originalResponseBody);;
-        
+
         assertEquals(expectedResponseBody, mock.responseBuffer.toString());
         assertEquals("image/png", mock.response.getContentType());
         assertEquals("/image.png", mock.request.getRequestURI());
@@ -136,7 +136,7 @@ public class WovnServletFilterTest extends TestCase {
         HashMap<String, String> settings = createSettings("path");
         String originalResponseBody = "<html>Original</html>";
         String expectedResponseBody = originalResponseBody;
-        
+
         boolean requestIsAlreadyProcessed = true;
         TestUtil.TestFilterResult mock = TestUtil.doServletFilter("text/html", "/search/", "/search/", settings, requestIsAlreadyProcessed, 200, originalResponseBody);
 

--- a/wovn-servlet-filter.iml
+++ b/wovn-servlet-filter.iml
@@ -19,7 +19,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jakarta.servlet:servlet-api:2.5" level="project" />
     <orderEntry type="library" name="Maven: net.arnx:jsonic:1.3.10" level="project" />
     <orderEntry type="library" name="Maven: nu.validator:htmlparser:1.4.1" level="project" />
     <orderEntry type="library" name="Maven: xerces:xercesImpl:2.11.0" level="project" />


### PR DESCRIPTION
https://wovnio.atlassian.net/browse/ST-2746

This PR introduces a new major version that uses `jakarta` (Jakarta EE 9) namespace, replacing `javax` (Java EE 8).

**Jakarta EE 9 specifications**
https://jakarta.ee/specifications/platform/9/

**Jakarta Servlet 5.0 specifications**
https://jakarta.ee/specifications/servlet/5.0/

**Jakarta XML Binding 3.0 specifications**
https://jakarta.ee/specifications/xml-binding/3.0/