### PR TITLE
fix: detect CSV as a file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
+++ b/src/main/java/com/github/wovnio/wovnjava/FileExtensionMatcher.java
@@ -12,7 +12,7 @@ class FileExtensionMatcher {
 
     FileExtensionMatcher() {
         this.WEB_FILE_PATTERN = Pattern.compile("\\.(eot|woff)$");
-        this.TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt))$");
+        this.TEXT_FILE_PATTERN = Pattern.compile("\\.(?:(?:css)|(?:js)|(?:txt)|(?:csv))$");
         this.IMAGE_FILE_PATTERN = Pattern.compile("(\\.(jpe|jpe?g|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))$");
         this.AUDIO_FILE_PATTERN = Pattern.compile("(\\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))$");
         this.VIDEO_FILE_PATTERN = Pattern.compile("(\\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))$");

--- a/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/FileExtensionMatcherTest.java
@@ -29,6 +29,7 @@ public class FileExtensionMatcherTest extends TestCase {
         assertIsFile(true, "pdf");
         assertIsFile(true, "js");
         assertIsFile(true, "css");
+        assertIsFile(true, "csv");
         assertIsFile(true, "doc");
         assertIsFile(true, "docx");
         assertIsFile(true, "xls");


### PR DESCRIPTION
Not being detected as a file means it get encoded incorrectly