### PR TITLE
fix(SUP-4254): use plain-key markers for title and textarea

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.wovnio</groupId>
     <artifactId>wovnjava</artifactId>
     <name>wovnjava</name>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <url>https://github.com/WOVNio/wovnjava</url>
 
     <licenses>

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -226,9 +226,20 @@ class HtmlConverter {
     }
 
     private void replaceNodeToMarkerComment(Element element) {
+        // RCDATA elements (textarea, title) treat inner content as plain text, not HTML.
+        // HTML comment markers would become literal text and leak into form submissions.
+        if (isRcdataElement(element)) {
+            return;
+        }
+
         String commentKey = htmlReplaceMarker.addCommentValue(htmlReplaceMarker.revert(element.html()));
         element.html("");
         element.appendChild(new Comment(commentKey));
+    }
+
+    private boolean isRcdataElement(Element element) {
+        String tagName = element.tagName();
+        return tagName.equals("textarea") || tagName.equals("title");
     }
 
     private void replaceContentType() {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -226,15 +226,25 @@ class HtmlConverter {
     }
 
     private void replaceNodeToMarkerComment(Element element) {
-        // RCDATA elements (textarea, title) treat inner content as plain text, not HTML.
-        // HTML comment markers would become literal text and leak into form submissions.
         if (isRcdataElement(element)) {
+            replaceRcdataToMarker(element);
             return;
         }
 
         String commentKey = htmlReplaceMarker.addCommentValue(htmlReplaceMarker.revert(element.html()));
         element.html("");
         element.appendChild(new Comment(commentKey));
+    }
+
+    private void replaceRcdataToMarker(Element element) {
+        String original = htmlReplaceMarker.revert(element.text());
+        if (original.contains("wovn-marker-")) {
+            return;
+        }
+
+        String key = htmlReplaceMarker.generateKey();
+        htmlReplaceMarker.addValue(key, original);
+        element.text(key);
     }
 
     private boolean isRcdataElement(Element element) {

--- a/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
+++ b/src/main/java/com/github/wovnio/wovnjava/HtmlConverter.java
@@ -226,30 +226,18 @@ class HtmlConverter {
     }
 
     private void replaceNodeToMarkerComment(Element element) {
-        if (isRcdataElement(element)) {
-            replaceRcdataToMarker(element);
-            return;
-        }
-
-        String commentKey = htmlReplaceMarker.addCommentValue(htmlReplaceMarker.revert(element.html()));
-        element.html("");
-        element.appendChild(new Comment(commentKey));
-    }
-
-    private void replaceRcdataToMarker(Element element) {
-        String original = htmlReplaceMarker.revert(element.text());
-        if (original.contains("wovn-marker-")) {
-            return;
-        }
-
-        String key = htmlReplaceMarker.generateKey();
-        htmlReplaceMarker.addValue(key, original);
-        element.text(key);
-    }
-
-    private boolean isRcdataElement(Element element) {
         String tagName = element.tagName();
-        return tagName.equals("textarea") || tagName.equals("title");
+        String elementHtml = htmlReplaceMarker.revert(element.html());
+
+        if (tagName.equals("textarea") || tagName.equals("title")) {
+            String key = htmlReplaceMarker.generateKey();
+            htmlReplaceMarker.addValue(key, elementHtml);
+            element.text(key);
+        } else {
+            String commentKey = htmlReplaceMarker.addCommentValue(elementHtml);
+            element.html("");
+            element.appendChild(new Comment(commentKey));
+        }
     }
 
     private void replaceContentType() {

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -54,24 +54,36 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(removedHtml, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveWovnIgnore__Textarea__LeavesContentUnchanged() throws ConfigurationError {
+    public void testRemoveWovnIgnore__Textarea__ReplacesContentWithMarker() throws ConfigurationError {
         String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><form><textarea data-wovn-ignore name=\"inquiry\"></textarea></form></body></html>";
+        String removedHtml = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><form><textarea data-wovn-ignore name=\"inquiry\">wovn-marker-0</textarea></form></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = this.createHtmlConverter(settings, location, original);
         String html = converter.strip();
 
-        assertEquals(original, stripExtraSpaces(html));
+        assertEquals(removedHtml, stripExtraSpaces(html));
         assertEquals(original, stripExtraSpaces(converter.restore(html)));
     }
 
-    public void testRemoveWovnIgnore__TextareaWithContent__LeavesContentUnchanged() throws ConfigurationError {
+    public void testRemoveWovnIgnore__TextareaWithContent__ReplacesContentWithMarker() throws ConfigurationError {
         String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><textarea wovn-ignore>default text</textarea></body></html>";
+        String removedHtml = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><textarea wovn-ignore>wovn-marker-0</textarea></body></html>";
         Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
         HtmlConverter converter = this.createHtmlConverter(settings, location, original);
         String html = converter.strip();
 
-        assertFalse(html.contains("wovn-marker"));
-        assertEquals(original, stripExtraSpaces(html));
+        assertEquals(removedHtml, stripExtraSpaces(html));
+        assertEquals(original, stripExtraSpaces(converter.restore(html)));
+    }
+
+    public void testRemoveWovnIgnore__Title__ReplacesContentWithMarker() throws ConfigurationError {
+        String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><title wovn-ignore>hello</title><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body></body></html>";
+        String removedHtml = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><title wovn-ignore>wovn-marker-0</title><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body></body></html>";
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
+        HtmlConverter converter = this.createHtmlConverter(settings, location, original);
+        String html = converter.strip();
+
+        assertEquals(removedHtml, stripExtraSpaces(html));
         assertEquals(original, stripExtraSpaces(converter.restore(html)));
     }
 

--- a/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
+++ b/src/test/java/com/github/wovnio/wovnjava/HtmlConverterTest.java
@@ -54,6 +54,27 @@ public class HtmlConverterTest extends TestCase {
         assertEquals(removedHtml, stripExtraSpaces(converter.restore(html)));
     }
 
+    public void testRemoveWovnIgnore__Textarea__LeavesContentUnchanged() throws ConfigurationError {
+        String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><form><textarea data-wovn-ignore name=\"inquiry\"></textarea></form></body></html>";
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
+        HtmlConverter converter = this.createHtmlConverter(settings, location, original);
+        String html = converter.strip();
+
+        assertEquals(original, stripExtraSpaces(html));
+        assertEquals(original, stripExtraSpaces(converter.restore(html)));
+    }
+
+    public void testRemoveWovnIgnore__TextareaWithContent__LeavesContentUnchanged() throws ConfigurationError {
+        String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><textarea wovn-ignore>default text</textarea></body></html>";
+        Settings settings = TestUtil.makeSettings(new HashMap<String, String>() {{ put("supportedLangs", "en,fr,ja"); }});
+        HtmlConverter converter = this.createHtmlConverter(settings, location, original);
+        String html = converter.strip();
+
+        assertFalse(html.contains("wovn-marker"));
+        assertEquals(original, stripExtraSpaces(html));
+        assertEquals(original, stripExtraSpaces(converter.restore(html)));
+    }
+
     public void testRemoveWovnIgnore() throws ConfigurationError {
         String original = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><div>Hello <span wovn-ignore>Duke</span><span data-wovn-ignore>Silver</span>.</div></body></html>";
         String removedHtml = "<html lang=\"en\"><head><link rel=\"alternate\" hreflang=\"x-default\" href=\"https://customer-existing.com\"><link rel=\"alternate\" hreflang=\"en\" href=\"https://site.com/global/tokyo/\"><link rel=\"alternate\" hreflang=\"fr\" href=\"https://site.com/fr/global/tokyo/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"https://site.com/ja/global/tokyo/\"></head><body><div>Hello <span wovn-ignore><!--wovn-marker-0--></span><span data-wovn-ignore><!--wovn-marker-1--></span>.</div></body></html>";


### PR DESCRIPTION
## Summary
- Use plain-key `addValue` markers for `<title>` and `<textarea>` instead of HTML comment markers when stripping `wovn-ignore` content
- RCDATA elements treat inner content as plain text, so `<!--wovn-marker-N-->` becomes a literal value (e.g. leaked into form submissions) instead of a hidden comment
- Matches the WOVN.php pattern for `<title>` and extends the same approach to `<textarea>` (same RCDATA behavior)
- Fixes inquiry form leaking marker strings into auto-reply emails for users
